### PR TITLE
feat(speech): add stt and wake runtime

### DIFF
--- a/pkg/gateway/transport/reply/dispatch_test.go
+++ b/pkg/gateway/transport/reply/dispatch_test.go
@@ -1,0 +1,127 @@
+package reply
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	llm "github.com/1024XEngineer/anyclaw/pkg/capability/models"
+	"github.com/1024XEngineer/anyclaw/pkg/capability/tools"
+)
+
+type stubHook struct {
+	messageCalls int
+	err          error
+}
+
+func (h *stubHook) OnMessage(ctx context.Context, msg *Message) error {
+	_, _ = ctx, msg
+	h.messageCalls++
+	return h.err
+}
+
+func (h *stubHook) OnResponse(ctx context.Context, resp *Response) error {
+	_, _ = ctx, resp
+	return nil
+}
+
+type stubLLMClient struct {
+	resp *llm.Response
+	err  error
+}
+
+func (c *stubLLMClient) Chat(ctx context.Context, messages []llm.Message, tools []llm.ToolDefinition) (*llm.Response, error) {
+	_, _, _ = ctx, messages, tools
+	return c.resp, c.err
+}
+
+func (c *stubLLMClient) StreamChat(ctx context.Context, messages []llm.Message, tools []llm.ToolDefinition, onChunk func(string)) error {
+	_, _, _, _ = ctx, messages, tools, onChunk
+	return nil
+}
+
+func (c *stubLLMClient) Name() string {
+	return "stub"
+}
+
+func TestDispatcherCommandAndParsing(t *testing.T) {
+	dispatcher := NewDispatcher(tools.NewRegistry())
+	hook := &stubHook{}
+	dispatcher.RegisterHook(hook)
+	dispatcher.RegisterCommand(CommandHandler{
+		Name: "echo",
+		Handler: func(ctx context.Context, args map[string]string) (string, error) {
+			_ = ctx
+			if _, ok := args["hello world"]; !ok {
+				t.Fatalf("expected parsed arg 'hello world', got %#v", args)
+			}
+			return "ok", nil
+		},
+	})
+
+	resp, err := dispatcher.Dispatch(context.Background(), &Message{
+		ID:   "msg-1",
+		Text: `/echo "hello world"`,
+	})
+	if err != nil {
+		t.Fatalf("Dispatch(command): %v", err)
+	}
+	if resp.Text != "ok" {
+		t.Fatalf("unexpected response text: %q", resp.Text)
+	}
+	if hook.messageCalls != 1 {
+		t.Fatalf("expected hook message calls = 1, got %d", hook.messageCalls)
+	}
+
+	args := splitArgs(`one "two words" three`)
+	if len(args) != 3 || args[1] != "two words" {
+		t.Fatalf("splitArgs() = %#v, want quoted token preserved", args)
+	}
+}
+
+func TestDispatcherAgentFallbacks(t *testing.T) {
+	dispatcher := NewDispatcher(nil)
+	dispatcher.RegisterAgent(&AgentHandler{
+		Name:     "assistant",
+		Provider: "provider-a",
+	})
+
+	resp, err := dispatcher.Dispatch(context.Background(), &Message{ID: "msg-2", Text: "hello"})
+	if err != nil {
+		t.Fatalf("Dispatch(no provider): %v", err)
+	}
+	if resp.Text != "Provider not available" {
+		t.Fatalf("unexpected missing-provider response: %q", resp.Text)
+	}
+
+	dispatcher.RegisterLLM("provider-a", &stubLLMClient{resp: &llm.Response{Content: "agent-reply"}})
+	resp, err = dispatcher.Dispatch(context.Background(), &Message{ID: "msg-3", Text: "hello"})
+	if err != nil {
+		t.Fatalf("Dispatch(agent): %v", err)
+	}
+	if resp.Text != "agent-reply" {
+		t.Fatalf("unexpected agent response: %q", resp.Text)
+	}
+
+	dispatcher.RegisterLLM("provider-a", &stubLLMClient{err: errors.New("llm-failed")})
+	if _, err := dispatcher.Dispatch(context.Background(), &Message{ID: "msg-4", Text: "hello"}); err == nil {
+		t.Fatal("expected llm error to be returned")
+	}
+}
+
+func TestDispatcherNoAgentAndHookError(t *testing.T) {
+	dispatcher := NewDispatcher(nil)
+
+	resp, err := dispatcher.Dispatch(context.Background(), &Message{ID: "msg-5", Text: "hello"})
+	if err != nil {
+		t.Fatalf("Dispatch(no agent): %v", err)
+	}
+	if resp.Text != "No agent available" {
+		t.Fatalf("unexpected no-agent response: %q", resp.Text)
+	}
+
+	dispatcher.RegisterHook(&stubHook{err: errors.New("hook-failed")})
+	if _, err := dispatcher.Dispatch(context.Background(), &Message{ID: "msg-6", Text: "hello"}); err == nil {
+		t.Fatal("expected hook error to abort dispatch")
+	}
+}

--- a/pkg/speech/audio_player_test.go
+++ b/pkg/speech/audio_player_test.go
@@ -1,0 +1,186 @@
+package speech
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+type testAudioPlayer struct {
+	playing bool
+	audio   []byte
+	format  AudioFormat
+}
+
+func (p *testAudioPlayer) Play(ctx context.Context, audio []byte, format AudioFormat) error {
+	_ = ctx
+	p.playing = true
+	p.audio = append([]byte(nil), audio...)
+	p.format = format
+	return nil
+}
+
+func (p *testAudioPlayer) Stop() error {
+	p.playing = false
+	return nil
+}
+
+func (p *testAudioPlayer) IsPlaying() bool {
+	return p.playing
+}
+
+func TestLocalAudioPlayerHelpers(t *testing.T) {
+	tempDir := t.TempDir()
+	defaultCfg := DefaultLocalAudioPlayerConfig()
+	if defaultCfg.Volume != 1.0 {
+		t.Fatalf("DefaultLocalAudioPlayerConfig() = %+v, want Volume=1.0", defaultCfg)
+	}
+
+	player := NewLocalAudioPlayer(LocalAudioPlayerConfig{
+		TempDir:   tempDir,
+		PlayerCmd: "custom-player",
+		Volume:    5,
+	})
+
+	if player.Player() != "custom-player" {
+		t.Fatalf("Player() = %q, want custom-player", player.Player())
+	}
+	if player.Volume() != 1.0 {
+		t.Fatalf("Volume() = %v, want 1.0", player.Volume())
+	}
+
+	tmpPath, err := player.writeTempFile([]byte("audio"), FormatWAV)
+	if err != nil {
+		t.Fatalf("writeTempFile: %v", err)
+	}
+	defer os.Remove(tmpPath)
+
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		t.Fatalf("ReadFile(temp): %v", err)
+	}
+	if string(data) != "audio" {
+		t.Fatalf("unexpected temp file contents: %q", data)
+	}
+
+	player.SetVolume(1.5)
+	player.SetVolume(9)
+	if player.Volume() != 1.5 {
+		t.Fatalf("Volume() after updates = %v, want 1.5", player.Volume())
+	}
+
+	player.SetPlayer("")
+	if err := player.Play(context.Background(), []byte("audio"), FormatMP3); err == nil {
+		t.Fatal("expected Play without player command to fail")
+	}
+
+	player.SetPlayer("unsupported")
+	if err := player.playFile(context.Background(), tmpPath, FormatMP3); err == nil {
+		t.Fatal("expected playFile with unsupported player to fail")
+	}
+	if player.IsPlaying() {
+		t.Fatal("expected unsupported playback to reset playing state")
+	}
+
+	player.isPlaying = true
+	if err := player.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if player.IsPlaying() {
+		t.Fatal("expected Stop to clear playing state")
+	}
+
+	_ = detectPlayer()
+
+	if players := player.AvailablePlayers(); players == nil {
+		t.Fatal("AvailablePlayers() should not return nil")
+	}
+}
+
+func TestBufferAndMultiAudioPlayers(t *testing.T) {
+	buffer := NewBufferAudioPlayer()
+
+	ctx, cancelRunning := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- buffer.Play(ctx, []byte("stream"), FormatWAV)
+	}()
+
+	select {
+	case <-buffer.playCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for buffer player to start")
+	}
+
+	if !buffer.IsPlaying() {
+		t.Fatal("expected buffer player to be playing")
+	}
+
+	cancelRunning()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Buffer Play returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for buffer player to return")
+	}
+
+	if buffer.IsPlaying() {
+		t.Fatal("expected buffer player to stop")
+	}
+	if string(buffer.Buffer()) != "stream" || buffer.Format() != FormatWAV {
+		t.Fatalf("unexpected buffer state: %q / %s", buffer.Buffer(), buffer.Format())
+	}
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := buffer.Play(cancelCtx, []byte("cancel"), FormatMP3); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+	if err := buffer.Stop(); err != nil {
+		t.Fatalf("Buffer Stop: %v", err)
+	}
+
+	multi := NewMultiAudioPlayer()
+	if err := multi.Play(context.Background(), []byte("x"), FormatPCM); err == nil {
+		t.Fatal("expected empty multi player to fail")
+	}
+
+	player := &testAudioPlayer{}
+	multi.AddPlayer(player)
+	if err := multi.SetPlayer(1); err == nil {
+		t.Fatal("expected invalid player index to fail")
+	}
+	if err := multi.SetPlayer(0); err != nil {
+		t.Fatalf("SetPlayer(0): %v", err)
+	}
+	if err := multi.Play(context.Background(), []byte("abc"), FormatPCM); err != nil {
+		t.Fatalf("Multi Play: %v", err)
+	}
+	if !multi.IsPlaying() {
+		t.Fatal("expected multi player to report playing")
+	}
+	if err := multi.Stop(); err != nil {
+		t.Fatalf("Multi Stop: %v", err)
+	}
+	if multi.IsPlaying() {
+		t.Fatal("expected multi player to stop")
+	}
+	if got := multi.Players(); len(got) != 1 {
+		t.Fatalf("Players() len = %d, want 1", len(got))
+	}
+
+	var nop NopAudioPlayer
+	if err := nop.Play(context.Background(), []byte("abc"), FormatMP3); err != nil {
+		t.Fatalf("Nop Play: %v", err)
+	}
+	if nop.IsPlaying() {
+		t.Fatal("expected nop player to never report playing")
+	}
+	if err := nop.Stop(); err != nil {
+		t.Fatalf("Nop Stop: %v", err)
+	}
+}

--- a/pkg/speech/implementations_test.go
+++ b/pkg/speech/implementations_test.go
@@ -1,0 +1,332 @@
+package speech
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOpenAIProviderHTTPAndHelpers(t *testing.T) {
+	var payloads []map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/audio/speech" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer openai-key" {
+			t.Fatalf("unexpected auth header: %s", got)
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll(request): %v", err)
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("Unmarshal(request): %v", err)
+		}
+		payloads = append(payloads, payload)
+
+		w.Header().Set("Content-Type", "audio/mpeg")
+		_, _ = w.Write([]byte("openai-audio"))
+	}))
+	defer server.Close()
+
+	provider, err := NewOpenAIProvider(
+		"openai-key",
+		WithOpenAIBaseURL(server.URL),
+		WithOpenAITimeout(time.Second),
+		WithOpenAIRetries(0),
+		WithOpenAIVoice("alloy"),
+		WithOpenAIModel(OpenAITTS1HD),
+	)
+	if err != nil {
+		t.Fatalf("NewOpenAIProvider: %v", err)
+	}
+
+	if provider.Name() != "openai" || provider.Type() != ProviderOpenAI {
+		t.Fatalf("unexpected provider identity: %s/%s", provider.Name(), provider.Type())
+	}
+
+	voices, err := provider.ListVoices(context.Background())
+	if err != nil {
+		t.Fatalf("ListVoices: %v", err)
+	}
+	if len(voices) == 0 {
+		t.Fatal("expected built-in openai voices")
+	}
+
+	voice, err := provider.GetVoice(context.Background(), "nova")
+	if err != nil {
+		t.Fatalf("GetVoice(nova): %v", err)
+	}
+	if voice.ID != "nova" {
+		t.Fatalf("unexpected voice lookup result: %+v", voice)
+	}
+	if err := provider.ValidateVoice("invalid"); err == nil {
+		t.Fatal("expected invalid voice validation to fail")
+	}
+
+	provider.SetModel(OpenAITTS1)
+	provider.SetVoice("echo")
+
+	result, err := provider.Synthesize(context.Background(), "hello", WithSpeed(1.25), WithFormat(FormatWAV))
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	if string(result.Data) != "openai-audio" || result.Format != FormatWAV {
+		t.Fatalf("unexpected synth result: %+v", result)
+	}
+
+	stream, err := provider.SynthesizeStream(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("SynthesizeStream: %v", err)
+	}
+
+	var streamed []byte
+	for chunk := range stream {
+		streamed = append(streamed, chunk...)
+	}
+	if string(streamed) != "openai-audio" {
+		t.Fatalf("unexpected streamed audio: %q", streamed)
+	}
+
+	if len(payloads) < 2 {
+		t.Fatalf("expected synth and stream requests, got %d", len(payloads))
+	}
+	if payloads[0]["model"] != string(OpenAITTS1) {
+		t.Fatalf("unexpected model payload: %#v", payloads[0]["model"])
+	}
+	if payloads[0]["voice"] != "echo" {
+		t.Fatalf("unexpected voice payload: %#v", payloads[0]["voice"])
+	}
+}
+
+func TestElevenLabsProviderHTTPAndHelpers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("xi-api-key"); got != "eleven-key" {
+			t.Fatalf("unexpected xi-api-key: %s", got)
+		}
+
+		switch {
+		case r.URL.Path == "/v1/user":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"subscription":{"character_count":12,"character_limit":1000}}`))
+		case strings.HasSuffix(r.URL.Path, "/stream"):
+			w.Header().Set("Content-Type", "audio/mpeg")
+			_, _ = w.Write([]byte("eleven-stream"))
+		case strings.HasPrefix(r.URL.Path, "/v1/text-to-speech/"):
+			w.Header().Set("Content-Type", "audio/ogg")
+			_, _ = w.Write([]byte("eleven-audio"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	settings := ElevenLabsVoiceSettings{
+		Stability:       0.8,
+		SimilarityBoost: 0.9,
+		Style:           0.2,
+		UseSpeakerBoost: false,
+	}
+
+	provider, err := NewElevenLabsProvider(
+		"eleven-key",
+		WithElevenLabsBaseURL(server.URL+"/v1"),
+		WithElevenLabsTimeout(time.Second),
+		WithElevenLabsRetries(0),
+		WithElevenLabsVoice("voice-a"),
+		WithElevenLabsModel(ElevenLabsTurboV2),
+		WithElevenLabsVoiceSettings(settings),
+	)
+	if err != nil {
+		t.Fatalf("NewElevenLabsProvider: %v", err)
+	}
+
+	if provider.Name() != "elevenlabs" || provider.Type() != ProviderElevenLabs {
+		t.Fatalf("unexpected provider identity: %s/%s", provider.Name(), provider.Type())
+	}
+
+	voices, err := provider.ListVoices(context.Background())
+	if err != nil {
+		t.Fatalf("ListVoices: %v", err)
+	}
+	if len(voices) == 0 {
+		t.Fatal("expected built-in elevenlabs voices")
+	}
+
+	voice, err := provider.GetVoice(context.Background(), "21m00Tcm4TlvDq8ikWAM")
+	if err != nil {
+		t.Fatalf("GetVoice: %v", err)
+	}
+	if voice.ID == "" {
+		t.Fatalf("unexpected voice lookup result: %+v", voice)
+	}
+
+	provider.SetModel(ElevenLabsTurboV25)
+	provider.SetVoice("voice-b")
+	provider.SetVoiceSettings(ElevenLabsVoiceSettings{Stability: 0.5})
+
+	result, err := provider.Synthesize(context.Background(), "hello", WithFormat(FormatOGG))
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	if string(result.Data) != "eleven-audio" || result.ContentType != "audio/ogg" {
+		t.Fatalf("unexpected synth result: %+v", result)
+	}
+
+	stream, err := provider.SynthesizeStream(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("SynthesizeStream: %v", err)
+	}
+	var streamed []byte
+	for chunk := range stream {
+		streamed = append(streamed, chunk...)
+	}
+	if string(streamed) != "eleven-stream" {
+		t.Fatalf("unexpected streamed audio: %q", streamed)
+	}
+
+	count, limit, err := provider.GetUsage(context.Background())
+	if err != nil {
+		t.Fatalf("GetUsage: %v", err)
+	}
+	if count != 12 || limit != 1000 {
+		t.Fatalf("GetUsage() = (%d, %d), want (12, 1000)", count, limit)
+	}
+}
+
+func TestEdgePiperAndCoquiProviders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/synthesize" {
+			t.Fatalf("unexpected edge path: %s", r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll(edge request): %v", err)
+		}
+		text := string(body)
+		if !strings.Contains(text, `xml:lang="ja-JP"`) || !strings.Contains(text, `voice name="ja-JP-NanamiNeural"`) {
+			t.Fatalf("unexpected edge SSML: %s", text)
+		}
+		_, _ = w.Write([]byte("edge-audio"))
+	}))
+	defer server.Close()
+
+	edge, err := NewEdgeProvider(
+		WithEdgeBaseURL(server.URL),
+		WithEdgeVoice("ja-JP-NanamiNeural"),
+		WithEdgeLanguage("ja-JP"),
+		WithEdgeTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewEdgeProvider: %v", err)
+	}
+	if edge.Name() != "edge" || edge.Type() != ProviderEdge {
+		t.Fatalf("unexpected edge identity: %s/%s", edge.Name(), edge.Type())
+	}
+
+	result, err := edge.Synthesize(context.Background(), "hello", WithFormat(FormatWAV))
+	if err != nil {
+		t.Fatalf("Edge Synthesize: %v", err)
+	}
+	if string(result.Data) != "edge-audio" || result.Format != FormatWAV {
+		t.Fatalf("unexpected edge synth result: %+v", result)
+	}
+
+	edgeVoices, err := edge.ListVoices(context.Background())
+	if err != nil {
+		t.Fatalf("Edge ListVoices: %v", err)
+	}
+	if len(edgeVoices) == 0 {
+		t.Fatal("expected edge voices")
+	}
+
+	tmpDir := t.TempDir()
+	modelA := filepath.Join(tmpDir, "en_US-lessac-high.onnx")
+	modelB := filepath.Join(tmpDir, "zh_CN-huayan-medium.onnx")
+	for _, path := range []string{modelA, modelB} {
+		if err := os.WriteFile(path, []byte("model"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+		configPath := strings.TrimSuffix(path, ".onnx") + ".onnx.json"
+		if err := os.WriteFile(configPath, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", configPath, err)
+		}
+	}
+
+	piper, err := NewPiperProvider(
+		WithPiperModelPath(modelA),
+		WithPiperVoiceDir(tmpDir),
+		WithPiperDefaultVoice("en_US-lessac-high"),
+		WithPiperDefaultLanguage("en-US"),
+		WithPiperUseGPU(true),
+		WithPiperVolume(1.4),
+		WithPiperSentenceSilence(0.3),
+		WithPiperPythonCmd("python-test"),
+	)
+	if err != nil {
+		t.Fatalf("NewPiperProvider: %v", err)
+	}
+	if piper.Name() != "piper" || piper.Type() != ProviderPiper {
+		t.Fatalf("unexpected piper identity: %s/%s", piper.Name(), piper.Type())
+	}
+
+	piperVoices, err := piper.ListVoices(context.Background())
+	if err != nil {
+		t.Fatalf("Piper ListVoices: %v", err)
+	}
+	if len(piperVoices) == 0 {
+		t.Fatal("expected piper voices")
+	}
+
+	piper.SetVoice("zh_CN-huayan-medium")
+	if !strings.Contains(filepath.Base(piper.modelPath), "zh_CN-huayan-medium") {
+		t.Fatalf("expected modelPath to switch, got %s", piper.modelPath)
+	}
+	piper.SetVoiceDir(tmpDir)
+
+	coqui, err := NewCoquiProvider(
+		WithCoquiModel(CoquiModelXTTSv2),
+		WithCoquiSpeaker("speaker-a"),
+		WithCoquiLanguage("fr"),
+		WithCoquiDefaultLanguage("en"),
+		WithCoquiUseGPU(true),
+		WithCoquiPythonCmd("python-test"),
+		WithCoquiVoiceDir(tmpDir),
+		WithCoquiOutputFormat("wav"),
+	)
+	if err != nil {
+		t.Fatalf("NewCoquiProvider: %v", err)
+	}
+	if coqui.Name() != "coqui" || coqui.Type() != ProviderType("coqui") {
+		t.Fatalf("unexpected coqui identity: %s/%s", coqui.Name(), coqui.Type())
+	}
+
+	coquiVoices, err := coqui.ListVoices(context.Background())
+	if err != nil {
+		t.Fatalf("Coqui ListVoices (xtts): %v", err)
+	}
+	if len(coquiVoices) == 0 {
+		t.Fatal("expected xtts voices")
+	}
+
+	coqui.SetModel(CoquiModelVits)
+	coqui.SetSpeaker("speaker-b")
+	coqui.SetLanguage("ja")
+	coquiVoices, err = coqui.ListVoices(context.Background())
+	if err != nil {
+		t.Fatalf("Coqui ListVoices (vits): %v", err)
+	}
+	if len(coquiVoices) == 0 {
+		t.Fatal("expected vits voices")
+	}
+}

--- a/pkg/speech/manager_cache_provider_test.go
+++ b/pkg/speech/manager_cache_provider_test.go
@@ -1,0 +1,329 @@
+package speech
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+type testSpeechProvider struct {
+	name       string
+	typ        ProviderType
+	voices     []Voice
+	synthErr   error
+	synthCalls int
+	lastText   string
+	lastOpts   SynthesizeOptions
+}
+
+func (p *testSpeechProvider) Name() string {
+	if p.name == "" {
+		return "test"
+	}
+	return p.name
+}
+
+func (p *testSpeechProvider) Type() ProviderType {
+	if p.typ == "" {
+		return ProviderCustom
+	}
+	return p.typ
+}
+
+func (p *testSpeechProvider) Synthesize(ctx context.Context, text string, opts ...SynthesizeOption) (*AudioResult, error) {
+	_ = ctx
+	p.synthCalls++
+
+	options := SynthesizeOptions{
+		Voice:  "default",
+		Speed:  1.0,
+		Format: FormatMP3,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	p.lastText = text
+	p.lastOpts = options
+	if p.synthErr != nil {
+		return nil, p.synthErr
+	}
+
+	return &AudioResult{
+		Data:       []byte(text + "|" + options.Voice),
+		Format:     options.Format,
+		SampleRate: 24000,
+	}, nil
+}
+
+func (p *testSpeechProvider) ListVoices(ctx context.Context) ([]Voice, error) {
+	_ = ctx
+	return append([]Voice(nil), p.voices...), nil
+}
+
+func TestManagerLifecycleAndCache(t *testing.T) {
+	primary := &testSpeechProvider{
+		name:   "primary",
+		voices: []Voice{{ID: "primary-voice", Name: "Primary"}},
+	}
+	secondary := &testSpeechProvider{
+		name:   "secondary",
+		voices: []Voice{{ID: "secondary-voice", Name: "Secondary"}},
+	}
+
+	manager := NewManager(
+		WithManagerCache(CacheConfig{MaxSize: 2, MaxBytes: 64, TTL: time.Minute}),
+		WithManagerProvider("primary", primary),
+		WithManagerDefault("primary"),
+	)
+
+	if manager.Cache() == nil {
+		t.Fatal("expected cache to be enabled")
+	}
+
+	if got, err := manager.GetDefault(); err != nil || got != primary {
+		t.Fatalf("GetDefault() = (%v, %v), want primary provider", got, err)
+	}
+
+	if err := manager.Register("", primary); err == nil {
+		t.Fatal("expected empty provider name to fail")
+	}
+	if err := manager.Register("nil", nil); err == nil {
+		t.Fatal("expected nil provider to fail")
+	}
+	if err := manager.Register("primary", primary); err == nil {
+		t.Fatal("expected duplicate provider registration to fail")
+	}
+	if err := manager.Register("secondary", secondary); err != nil {
+		t.Fatalf("Register secondary: %v", err)
+	}
+	if _, err := manager.Get("missing"); err == nil {
+		t.Fatal("expected missing provider lookup to fail")
+	}
+	if err := manager.SetDefault("missing"); err == nil {
+		t.Fatal("expected SetDefault on missing provider to fail")
+	}
+	if err := manager.SetDefault("secondary"); err != nil {
+		t.Fatalf("SetDefault secondary: %v", err)
+	}
+
+	if got, err := manager.GetDefault(); err != nil || got != secondary {
+		t.Fatalf("GetDefault() = (%v, %v), want secondary provider", got, err)
+	}
+
+	names := manager.ListProviders()
+	sort.Strings(names)
+	if len(names) != 2 || names[0] != "primary" || names[1] != "secondary" {
+		t.Fatalf("ListProviders() = %v, want [primary secondary]", names)
+	}
+
+	result1, err := manager.Synthesize(context.Background(), "hello", "secondary", WithVoice("nova"))
+	if err != nil {
+		t.Fatalf("Synthesize first call: %v", err)
+	}
+	result2, err := manager.Synthesize(context.Background(), "hello", "secondary", WithVoice("nova"))
+	if err != nil {
+		t.Fatalf("Synthesize second call: %v", err)
+	}
+
+	if secondary.synthCalls != 1 {
+		t.Fatalf("expected cached synthesize call count 1, got %d", secondary.synthCalls)
+	}
+	if string(result1.Data) != string(result2.Data) {
+		t.Fatalf("cached audio mismatch: %q != %q", result1.Data, result2.Data)
+	}
+
+	voices, err := manager.ListVoices(context.Background(), "secondary")
+	if err != nil {
+		t.Fatalf("ListVoices: %v", err)
+	}
+	if len(voices) != 1 || voices[0].ID != "secondary-voice" {
+		t.Fatalf("ListVoices() = %+v, want secondary voice", voices)
+	}
+
+	if err := manager.Remove("missing"); err == nil {
+		t.Fatal("expected Remove on missing provider to fail")
+	}
+	if err := manager.Remove("secondary"); err != nil {
+		t.Fatalf("Remove secondary: %v", err)
+	}
+	if got, err := manager.GetDefault(); err != nil || got != primary {
+		t.Fatalf("GetDefault() after remove = (%v, %v), want primary provider", got, err)
+	}
+
+	manager.ClearCache()
+	if size, bytes := manager.CacheStats(); size != 0 || bytes != 0 {
+		t.Fatalf("CacheStats() = (%d, %d), want (0, 0)", size, bytes)
+	}
+
+	manager.DisableCache()
+	if manager.Cache() != nil {
+		t.Fatal("expected cache to be disabled")
+	}
+	if _, err := manager.Synthesize(context.Background(), "uncached", "primary"); err != nil {
+		t.Fatalf("uncached synthesize: %v", err)
+	}
+	if primary.synthCalls != 1 {
+		t.Fatalf("expected primary synth calls = 1, got %d", primary.synthCalls)
+	}
+
+	manager.EnableCache(DefaultCacheConfig())
+	if manager.Cache() == nil {
+		t.Fatal("expected cache to be re-enabled")
+	}
+}
+
+func TestAudioCacheLifecycle(t *testing.T) {
+	cache := NewAudioCache(CacheConfig{MaxSize: 2, MaxBytes: 5, TTL: time.Minute})
+
+	cache.Set("nil", nil)
+	cache.Set("empty", &AudioResult{})
+	if cache.Len() != 0 || cache.SizeBytes() != 0 {
+		t.Fatalf("empty cache writes should be ignored, got len=%d bytes=%d", cache.Len(), cache.SizeBytes())
+	}
+
+	cache.Set("a", &AudioResult{Data: []byte("aa")})
+	cache.Set("b", &AudioResult{Data: []byte("bb")})
+	if cache.Len() != 2 || cache.SizeBytes() != 4 {
+		t.Fatalf("after Set() len=%d bytes=%d, want len=2 bytes=4", cache.Len(), cache.SizeBytes())
+	}
+
+	if got, ok := cache.Get("a"); !ok || string(got.Data) != "aa" {
+		t.Fatalf("Get(a) = (%v, %v), want audio 'aa'", got, ok)
+	}
+
+	cache.Set("oversize", &AudioResult{Data: []byte("123456")})
+	if _, ok := cache.Get("oversize"); ok {
+		t.Fatal("expected oversize entry to be ignored")
+	}
+
+	cache.Set("c", &AudioResult{Data: []byte("c")})
+	if cache.Len() > 2 || cache.SizeBytes() > 5 {
+		t.Fatalf("cache limits exceeded: len=%d bytes=%d", cache.Len(), cache.SizeBytes())
+	}
+
+	cache.items["expired"] = audioCacheItem{
+		result:    &AudioResult{Data: []byte("z")},
+		expiresAt: time.Now().Add(-time.Second),
+		sizeBytes: 1,
+	}
+	cache.currentBytes++
+
+	if got, ok := cache.Get("expired"); ok || got != nil {
+		t.Fatalf("Get(expired) = (%v, %v), want (nil, false)", got, ok)
+	}
+	if removed := cache.Cleanup(); removed != 1 {
+		t.Fatalf("Cleanup() = %d, want 1", removed)
+	}
+
+	cache.Remove("a")
+	cache.Clear()
+	if cache.Len() != 0 || cache.SizeBytes() != 0 {
+		t.Fatalf("after Clear() len=%d bytes=%d, want 0/0", cache.Len(), cache.SizeBytes())
+	}
+
+	key1 := MakeCacheKey("hello", "provider", WithVoice("nova"), WithSpeed(1.25), WithFormat(FormatWAV), WithLanguage("en-US"))
+	key2 := MakeCacheKey("hello", "provider", WithVoice("nova"), WithSpeed(1.25), WithFormat(FormatWAV), WithLanguage("en-US"))
+	key3 := MakeCacheKey("hello", "provider", WithVoice("echo"))
+
+	if key1 != key2 {
+		t.Fatalf("expected identical cache keys, got %q != %q", key1, key2)
+	}
+	if key1 == key3 {
+		t.Fatalf("expected different cache keys, got identical key %q", key1)
+	}
+}
+
+func TestProviderHelpersAndFactory(t *testing.T) {
+	opts := SynthesizeOptions{}
+	WithVoice("voice-a")(&opts)
+	WithSpeed(1.5)(&opts)
+	WithPitch(0.2)(&opts)
+	WithVolume(0.8)(&opts)
+	WithFormat(FormatWAV)(&opts)
+	WithLanguage("ja-JP")(&opts)
+	WithSampleRate(44100)(&opts)
+
+	if opts.Voice != "voice-a" || opts.Speed != 1.5 || opts.Pitch != 0.2 || opts.Volume != 0.8 || opts.Format != FormatWAV || opts.Language != "ja-JP" || opts.SampleRate != 44100 {
+		t.Fatalf("unexpected synth options: %+v", opts)
+	}
+
+	audio := []byte("audio-data")
+	encoded := AudioToBase64(audio)
+	decoded, err := Base64ToAudio(encoded)
+	if err != nil {
+		t.Fatalf("Base64ToAudio(valid): %v", err)
+	}
+	if string(decoded) != string(audio) {
+		t.Fatalf("decoded audio mismatch: %q != %q", decoded, audio)
+	}
+	if _, err := Base64ToAudio("%%%"); err == nil {
+		t.Fatal("expected invalid base64 to fail")
+	}
+
+	if _, err := NewProvider(Config{Type: ProviderOpenAI}); err == nil {
+		t.Fatal("expected openai provider without API key to fail")
+	}
+	if _, err := NewProvider(Config{Type: ProviderElevenLabs}); err == nil {
+		t.Fatal("expected elevenlabs provider without API key to fail")
+	}
+
+	edgeProvider, err := NewProvider(Config{
+		Type:     ProviderEdge,
+		BaseURL:  "http://edge.local",
+		Voice:    "edge-voice",
+		Language: "zh-CN",
+		Timeout:  2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewProvider(edge): %v", err)
+	}
+	edge := edgeProvider.(*EdgeProvider)
+	if edge.baseURL != "http://edge.local" || edge.voice != "edge-voice" || edge.language != "zh-CN" || edge.client.Timeout != 2*time.Second {
+		t.Fatalf("unexpected edge provider config: %+v", edge)
+	}
+
+	tmpDir := t.TempDir()
+	modelPath := filepath.Join(tmpDir, "test-model.onnx")
+	configPath := strings.TrimSuffix(modelPath, ".onnx") + ".onnx.json"
+	if err := os.WriteFile(modelPath, []byte("model"), 0o644); err != nil {
+		t.Fatalf("WriteFile(model): %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("WriteFile(config): %v", err)
+	}
+
+	piperProvider, err := NewProvider(Config{
+		Type:     ProviderPiper,
+		Voice:    modelPath,
+		Language: "ja-JP",
+	})
+	if err != nil {
+		t.Fatalf("NewProvider(piper): %v", err)
+	}
+	piper := piperProvider.(*PiperProvider)
+	if piper.modelPath != modelPath || piper.configFile != configPath || piper.defaultLang != "ja-JP" {
+		t.Fatalf("unexpected piper provider config: %+v", piper)
+	}
+
+	coquiProvider, err := NewProvider(Config{
+		Type:     ProviderCoqui,
+		Voice:    "speaker-a",
+		Language: "fr",
+	})
+	if err != nil {
+		t.Fatalf("NewProvider(coqui): %v", err)
+	}
+	coqui := coquiProvider.(*CoquiProvider)
+	if coqui.speakerName != "speaker-a" || coqui.defaultLang != "fr" {
+		t.Fatalf("unexpected coqui provider config: %+v", coqui)
+	}
+
+	if _, err := NewProvider(Config{Type: ProviderCustom}); err == nil {
+		t.Fatal("expected unknown provider type to fail")
+	}
+}

--- a/pkg/speech/pipeline_integration_test.go
+++ b/pkg/speech/pipeline_integration_test.go
@@ -1,0 +1,324 @@
+package speech
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/capability/tools"
+	transportreply "github.com/1024XEngineer/anyclaw/pkg/gateway/transport/reply"
+)
+
+type testAudioSenderImpl struct {
+	id         string
+	sendErr    error
+	sendCalls  int
+	captions   []string
+	channels   []string
+	recipients []string
+}
+
+func (s *testAudioSenderImpl) SendAudio(ctx context.Context, channel string, recipient string, audio *AudioResult, caption string) (string, error) {
+	_ = ctx
+	_ = audio
+	s.sendCalls++
+	s.channels = append(s.channels, channel)
+	s.recipients = append(s.recipients, recipient)
+	s.captions = append(s.captions, caption)
+	if s.sendErr != nil {
+		return "", s.sendErr
+	}
+	if s.id == "" {
+		return "audio-id", nil
+	}
+	return s.id, nil
+}
+
+func (s *testAudioSenderImpl) CanSend(channel string) bool {
+	return channel != ""
+}
+
+type testPipelineHook struct {
+	beforeCalls int
+	afterCalls  int
+	sendCalls   int
+	beforeErr   error
+	afterErr    error
+}
+
+func (h *testPipelineHook) OnBeforeSynthesize(ctx context.Context, text string, opts *SynthesizeOptions) error {
+	_, _, _ = ctx, text, opts
+	h.beforeCalls++
+	return h.beforeErr
+}
+
+func (h *testPipelineHook) OnAfterSynthesize(ctx context.Context, result *AudioResult) error {
+	_, _ = ctx, result
+	h.afterCalls++
+	return h.afterErr
+}
+
+func (h *testPipelineHook) OnSendComplete(ctx context.Context, channel string, audioID string) error {
+	_, _, _ = ctx, channel, audioID
+	h.sendCalls++
+	return nil
+}
+
+type testChannelManager struct {
+	messages []*ChannelMessage
+}
+
+func (m *testChannelManager) SendMessage(ctx context.Context, channelID string, message *ChannelMessage) error {
+	_ = ctx
+	_ = channelID
+	copyMsg := *message
+	m.messages = append(m.messages, &copyMsg)
+	return nil
+}
+
+type testIntegrationHook struct {
+	beforeCalls   int
+	afterCalls    int
+	fallbackCalls int
+	beforeErr     error
+}
+
+func (h *testIntegrationHook) OnBeforeTTS(ctx context.Context, req *TTSRequest) error {
+	_, _ = ctx, req
+	h.beforeCalls++
+	return h.beforeErr
+}
+
+func (h *testIntegrationHook) OnAfterTTS(ctx context.Context, resp *TTSResponse) error {
+	_, _ = ctx, resp
+	h.afterCalls++
+	return nil
+}
+
+func (h *testIntegrationHook) OnFallbackText(ctx context.Context, channel string, recipient string, text string) error {
+	_, _, _, _ = ctx, channel, recipient, text
+	h.fallbackCalls++
+	return nil
+}
+
+func TestTTSPipelineProcessAndReplyHook(t *testing.T) {
+	provider := &testSpeechProvider{name: "openai"}
+	manager := NewManager(WithManagerProvider("openai", provider))
+
+	cfg := DefaultPipelineConfig()
+	cfg.DefaultProvider = "openai"
+	cfg.Timeout = time.Second
+
+	pipeline := NewTTSPipeline(manager, cfg)
+	hook := &testPipelineHook{}
+	sender := &testAudioSenderImpl{id: "audio-1"}
+	pipeline.RegisterHook(hook)
+	pipeline.RegisterAudioSender("telegram", sender)
+	pipeline.SetDefaultSender(sender)
+
+	resp, err := pipeline.Process(context.Background(), &TTSRequest{
+		Text:      "hello there",
+		Channel:   "telegram",
+		Recipient: "user-1",
+		Provider:  "openai",
+		Voice:     "nova",
+		Speed:     1.2,
+		Format:    FormatWAV,
+	})
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if resp.AudioID != "audio-1" || resp.Audio == nil {
+		t.Fatalf("unexpected pipeline response: %+v", resp)
+	}
+	if hook.beforeCalls != 1 || hook.afterCalls != 1 || hook.sendCalls != 1 {
+		t.Fatalf("unexpected hook counts: before=%d after=%d send=%d", hook.beforeCalls, hook.afterCalls, hook.sendCalls)
+	}
+	if provider.lastOpts.Voice != "nova" || provider.lastOpts.Format != FormatWAV {
+		t.Fatalf("unexpected synth options: %+v", provider.lastOpts)
+	}
+	if sender.sendCalls != 1 || sender.captions[0] != "hello there" {
+		t.Fatalf("unexpected sender state: %+v", sender)
+	}
+
+	if !pipeline.ShouldAutoTrigger("/speak hello") {
+		t.Fatal("expected trigger keyword to auto trigger")
+	}
+	if pipeline.ShouldAutoTrigger("plain text") {
+		t.Fatal("expected plain text to not auto trigger")
+	}
+
+	replyHook := NewReplyHook(pipeline)
+	if err := replyHook.OnMessage(context.Background(), &Message{ID: "msg-1"}); err != nil {
+		t.Fatalf("ReplyHook OnMessage: %v", err)
+	}
+	if err := replyHook.OnResponse(context.Background(), &Response{
+		Text: "/speak follow up",
+		Metadata: map[string]any{
+			"channel":   "telegram",
+			"recipient": "user-2",
+		},
+	}); err != nil {
+		t.Fatalf("ReplyHook OnResponse: %v", err)
+	}
+	if sender.sendCalls != 2 {
+		t.Fatalf("expected reply hook to send audio, got %d sends", sender.sendCalls)
+	}
+}
+
+func TestTTSPipelineFallbackAndConfigHelpers(t *testing.T) {
+	brokenProvider := &testSpeechProvider{name: "broken", synthErr: errors.New("boom")}
+	manager := NewManager(WithManagerProvider("broken", brokenProvider))
+
+	cfg := DefaultPipelineConfig()
+	cfg.DefaultProvider = "broken"
+	cfg.FallbackToText = true
+	cfg.Enabled = false
+
+	pipeline := NewTTSPipeline(manager, cfg)
+	if _, err := pipeline.Process(context.Background(), &TTSRequest{Text: "hello"}); err == nil {
+		t.Fatal("expected disabled pipeline to fail")
+	}
+
+	pipeline.SetEnabled(true)
+	if !pipeline.Enabled() {
+		t.Fatal("expected pipeline to be enabled")
+	}
+
+	pipeline.UpdateConfig(DefaultPipelineConfig())
+	updated := pipeline.Config()
+	updated.DefaultProvider = "broken"
+	updated.FallbackToText = true
+	pipeline.UpdateConfig(updated)
+
+	resp, err := pipeline.Process(context.Background(), &TTSRequest{Text: "hello"})
+	if err != nil {
+		t.Fatalf("expected fallback response, got error: %v", err)
+	}
+	if resp.Text != "hello" || resp.Audio != nil {
+		t.Fatalf("unexpected fallback response: %+v", resp)
+	}
+}
+
+func TestIntegrationFlows(t *testing.T) {
+	provider := &testSpeechProvider{name: "openai"}
+	manager := NewManager(WithManagerProvider("openai", provider))
+
+	pipelineCfg := DefaultPipelineConfig()
+	pipelineCfg.DefaultProvider = "openai"
+	pipeline := NewTTSPipeline(manager, pipelineCfg)
+	sender := &testAudioSenderImpl{id: "tts-id"}
+	pipeline.RegisterAudioSender("telegram", sender)
+
+	dispatcher := transportreply.NewDispatcher(tools.NewRegistry())
+	dispatcher.RegisterCommand(transportreply.CommandHandler{
+		Name: "echo",
+		Handler: func(ctx context.Context, args map[string]string) (string, error) {
+			_ = ctx
+			if _, ok := args["hello"]; ok {
+				return "echo:hello", nil
+			}
+			return "echo", nil
+		},
+	})
+
+	channelMgr := &testChannelManager{}
+	integration := NewIntegration(pipeline, dispatcher, channelMgr, DefaultIntegrationConfig())
+	hook := &testIntegrationHook{}
+	integration.RegisterHook(hook)
+
+	if err := integration.ProcessMessage(context.Background(), "telegram", "user-1", "/echo hello", map[string]any{"k": "v"}); err != nil {
+		t.Fatalf("ProcessMessage text-only: %v", err)
+	}
+	if len(channelMgr.messages) != 1 || channelMgr.messages[0].Content != "echo:hello" {
+		t.Fatalf("unexpected channel messages: %+v", channelMgr.messages)
+	}
+
+	integration.EnableAutoTTS()
+	if err := integration.ProcessMessage(context.Background(), "telegram", "user-2", "speak now", nil); err != nil {
+		t.Fatalf("ProcessMessage auto TTS: %v", err)
+	}
+	if sender.sendCalls == 0 {
+		t.Fatal("expected TTS sender to be used")
+	}
+	if hook.beforeCalls == 0 || hook.afterCalls == 0 {
+		t.Fatalf("expected integration hooks to run, got before=%d after=%d", hook.beforeCalls, hook.afterCalls)
+	}
+
+	integration.DisableAutoTTS()
+	integration.SetTriggerPrefix("/say")
+	integration.AllowChannel("telegram")
+	integration.ExcludeChannel("ignore-me")
+
+	cfg := integration.Config()
+	if cfg.TTSTriggerPrefix != "/say" || !cfg.Channels["telegram"] || !cfg.ExcludeChannels["ignore-me"] {
+		t.Fatalf("unexpected integration config: %+v", cfg)
+	}
+	cfg.Enabled = true
+	integration.UpdateConfig(cfg)
+
+	adapter := NewReplyDispatcherAdapter(integration)
+	if err := adapter.OnMessage(context.Background(), &transportreply.Message{ID: "msg-2"}); err != nil {
+		t.Fatalf("ReplyDispatcherAdapter OnMessage: %v", err)
+	}
+	integration.EnableAutoTTS()
+	if err := adapter.OnResponse(context.Background(), &transportreply.Response{
+		Text: "adapter text",
+		Metadata: map[string]any{
+			"channel":   "telegram",
+			"recipient": "user-3",
+		},
+	}); err != nil {
+		t.Fatalf("ReplyDispatcherAdapter OnResponse: %v", err)
+	}
+	if sender.sendCalls < 2 {
+		t.Fatalf("expected adapter to trigger TTS, got %d sends", sender.sendCalls)
+	}
+}
+
+func TestIntegrationFallbackAndWrapInboundHandler(t *testing.T) {
+	brokenProvider := &testSpeechProvider{name: "broken", synthErr: errors.New("boom")}
+	manager := NewManager(WithManagerProvider("broken", brokenProvider))
+
+	pipelineCfg := DefaultPipelineConfig()
+	pipelineCfg.DefaultProvider = "broken"
+	pipelineCfg.FallbackToText = false
+	pipeline := NewTTSPipeline(manager, pipelineCfg)
+
+	channelMgr := &testChannelManager{}
+	cfg := DefaultIntegrationConfig()
+	cfg.AutoTTS = true
+	cfg.FallbackToText = true
+	cfg.VoiceProvider = "broken"
+	integration := NewIntegration(pipeline, nil, channelMgr, cfg)
+
+	hook := &testIntegrationHook{beforeErr: errors.New("hook-failed")}
+	integration.RegisterHook(hook)
+
+	if err := integration.ProcessMessage(context.Background(), "telegram", "user-1", "hello", nil); err != nil {
+		t.Fatalf("expected fallback path to succeed, got %v", err)
+	}
+	if len(channelMgr.messages) != 1 || channelMgr.messages[0].Content != "hello" {
+		t.Fatalf("unexpected fallback messages: %+v", channelMgr.messages)
+	}
+	if hook.fallbackCalls != 1 {
+		t.Fatalf("expected fallback hook to run once, got %d", hook.fallbackCalls)
+	}
+
+	wrapped := integration.WrapInboundHandler(func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		_, _, _ = ctx, message, meta
+		return sessionID + "-next", "ok", nil
+	})
+
+	nextSession, replyText, err := wrapped(context.Background(), "sess-1", "hi", map[string]string{
+		"channel":   "telegram",
+		"recipient": "user-2",
+	})
+	if err != nil {
+		t.Fatalf("WrapInboundHandler: %v", err)
+	}
+	if nextSession != "sess-1-next" || replyText != "ok" {
+		t.Fatalf("unexpected wrapped handler result: %q / %q", nextSession, replyText)
+	}
+}

--- a/pkg/speech/senders_test.go
+++ b/pkg/speech/senders_test.go
@@ -1,0 +1,145 @@
+package speech
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAudioSenders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll(%s): %v", r.URL.Path, err)
+		}
+
+		switch r.URL.Path {
+		case "/botbot-token/sendAudio":
+			if !strings.Contains(string(body), "chat-1") {
+				t.Fatalf("telegram body missing recipient: %s", string(body))
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"result":{"message_id":42}}`))
+		case "/api/v10/channels/channel-1/messages":
+			if got := r.Header.Get("Authorization"); got != "Bot discord-token" {
+				t.Fatalf("unexpected discord auth header: %s", got)
+			}
+			_, _ = w.Write([]byte(`{"id":"discord-msg"}`))
+		case "/api/files.upload":
+			if got := r.Header.Get("Authorization"); got != "Bearer slack-token" {
+				t.Fatalf("unexpected slack auth header: %s", got)
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"file":{"id":"slack-file","name":"tts.mp3"}}`))
+		case "/wa-123/media":
+			if got := r.Header.Get("Authorization"); got != "Bearer wa-token" {
+				t.Fatalf("unexpected whatsapp auth header: %s", got)
+			}
+			_, _ = w.Write([]byte(`{"id":"media-1"}`))
+		case "/wa-123/messages":
+			if got := r.Header.Get("Authorization"); got != "Bearer wa-token" {
+				t.Fatalf("unexpected whatsapp send auth header: %s", got)
+			}
+			_, _ = w.Write([]byte(`{"messages":[{"id":"wa-message"}]}`))
+		case "/signal/v2/send":
+			if !strings.Contains(string(body), "base64_audio") {
+				t.Fatalf("signal body missing base64 audio: %s", string(body))
+			}
+			_, _ = w.Write([]byte(`{"timestamp":12345}`))
+		case "/hook":
+			if got := r.Header.Get("X-Test"); got != "ok" {
+				t.Fatalf("unexpected webhook header: %s", got)
+			}
+			_, _ = w.Write([]byte(`hook-id`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	audio := &AudioResult{
+		Data:       []byte("audio-bytes"),
+		Format:     FormatMP3,
+		SampleRate: 24000,
+	}
+
+	telegram := NewTelegramAudioSender("bot-token")
+	telegram.baseURL = server.URL + "/botbot-token"
+	telegram.client = server.Client()
+	if _, err := telegram.SendAudio(context.Background(), "telegram", "", audio, "hello"); err == nil {
+		t.Fatal("expected telegram sender to require recipient")
+	}
+	telegramID, err := telegram.SendAudio(context.Background(), "telegram", "chat-1", audio, "hello")
+	if err != nil {
+		t.Fatalf("Telegram SendAudio: %v", err)
+	}
+	if telegramID != "42" || !telegram.CanSend("telegram") {
+		t.Fatalf("unexpected telegram result: id=%s", telegramID)
+	}
+
+	discord := NewDiscordAudioSender("discord-token")
+	discord.apiBase = server.URL + "/api/v10"
+	discord.client = server.Client()
+	if _, err := discord.SendAudio(context.Background(), "discord", "", audio, "hello"); err == nil {
+		t.Fatal("expected discord sender to require recipient")
+	}
+	discordID, err := discord.SendAudio(context.Background(), "discord", "channel-1", audio, "hello")
+	if err != nil {
+		t.Fatalf("Discord SendAudio: %v", err)
+	}
+	if discordID != "discord-msg" || !discord.CanSend("discord") {
+		t.Fatalf("unexpected discord result: id=%s", discordID)
+	}
+
+	slack := NewSlackAudioSender("slack-token")
+	slack.baseURL = server.URL + "/api"
+	slack.client = server.Client()
+	if _, err := slack.SendAudio(context.Background(), "slack", "", audio, "hello"); err == nil {
+		t.Fatal("expected slack sender to require recipient")
+	}
+	slackID, err := slack.SendAudio(context.Background(), "slack", "channel-1", audio, "hello")
+	if err != nil {
+		t.Fatalf("Slack SendAudio: %v", err)
+	}
+	if slackID != "slack-file" || !slack.CanSend("slack") {
+		t.Fatalf("unexpected slack result: id=%s", slackID)
+	}
+
+	whatsApp := NewWhatsAppAudioSender("wa-123", "wa-token")
+	whatsApp.baseURL = server.URL
+	whatsApp.client = server.Client()
+	if _, err := whatsApp.SendAudio(context.Background(), "whatsapp", "", audio, "hello"); err == nil {
+		t.Fatal("expected whatsapp sender to require recipient")
+	}
+	waID, err := whatsApp.SendAudio(context.Background(), "whatsapp", "13800138000", audio, "hello")
+	if err != nil {
+		t.Fatalf("WhatsApp SendAudio: %v", err)
+	}
+	if waID != "wa-message" || !whatsApp.CanSend("whatsapp") {
+		t.Fatalf("unexpected whatsapp result: id=%s", waID)
+	}
+
+	signal := NewSignalAudioSender(server.URL+"/signal", "+10086")
+	signal.client = server.Client()
+	if _, err := signal.SendAudio(context.Background(), "signal", "", audio, "hello"); err == nil {
+		t.Fatal("expected signal sender to require recipient")
+	}
+	signalID, err := signal.SendAudio(context.Background(), "signal", "+10010", audio, "hello")
+	if err != nil {
+		t.Fatalf("Signal SendAudio: %v", err)
+	}
+	if signalID != "12345" || !signal.CanSend("signal") {
+		t.Fatalf("unexpected signal result: id=%s", signalID)
+	}
+
+	webhook := NewGenericWebhookAudioSender(server.URL+"/hook", map[string]string{"X-Test": "ok"})
+	webhook.client = server.Client()
+	webhookID, err := webhook.SendAudio(context.Background(), "custom", "recipient-1", audio, "hello")
+	if err != nil {
+		t.Fatalf("GenericWebhook SendAudio: %v", err)
+	}
+	if webhookID != "hook-id" || !webhook.CanSend("anything") {
+		t.Fatalf("unexpected webhook result: id=%s", webhookID)
+	}
+}

--- a/pkg/speech/stt_google.go
+++ b/pkg/speech/stt_google.go
@@ -1,0 +1,513 @@
+package speech
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type GoogleModel string
+
+const (
+	GoogleModelLatestLong            GoogleModel = "latest_long"
+	GoogleModelLatestShort           GoogleModel = "latest_short"
+	GoogleModelCommandAndSearch      GoogleModel = "command_and_search"
+	GoogleModelPhoneCall             GoogleModel = "phone_call"
+	GoogleModelVideo                 GoogleModel = "video"
+	GoogleModelDefault               GoogleModel = "default"
+	GoogleModelMedicalConversational GoogleModel = "medical_conversational"
+	GoogleModelMedicalDictation      GoogleModel = "medical_dictation"
+)
+
+type GoogleRecognitionConfig struct {
+	Encoding                            RecognitionEncoding
+	SampleRateHertz                     int32
+	AudioChannelCount                   int32
+	EnableSeparateRecognitionPerChannel bool
+	LanguageCode                        string
+	MaxAlternatives                     int32
+	ProfanityFilter                     bool
+	SpeechContexts                      []GoogleSpeechContext
+	EnableWordTimeOffsets               bool
+	EnableWordConfidence                bool
+	EnableAutomaticPunctuation          bool
+	EnableSpokenPunctuation             bool
+	Model                               string
+	UseEnhanced                         bool
+}
+
+type RecognitionEncoding string
+
+const (
+	EncodingLinear16             RecognitionEncoding = "LINEAR16"
+	EncodingFLAC                 RecognitionEncoding = "FLAC"
+	EncodingMULAW                RecognitionEncoding = "MULAW"
+	EncodingAMR                  RecognitionEncoding = "AMR"
+	EncodingAMRWB                RecognitionEncoding = "AMR_WB"
+	EncodingOGGOpus              RecognitionEncoding = "OGG_OPUS"
+	EncodingSpeexWithHeaderByte  RecognitionEncoding = "SPEEX_WITH_HEADER_BYTE"
+	EncodingMP3                  RecognitionEncoding = "MP3"
+	EncodingWEBMOpus             RecognitionEncoding = "WEBM_OPUS"
+	EncodingENCODING_UNSPECIFIED RecognitionEncoding = "ENCODING_UNSPECIFIED"
+)
+
+type GoogleSpeechContext struct {
+	Phrases []string
+	Boost   float32
+}
+
+type GoogleProvider struct {
+	apiKey          string
+	credentialsJSON string
+	baseURL         string
+	languageCode    string
+	model           GoogleModel
+	useEnhanced     bool
+	timeout         time.Duration
+	retries         int
+	client          *http.Client
+}
+
+type GoogleOption func(*GoogleProvider)
+
+func WithGoogleBaseURL(url string) GoogleOption {
+	return func(p *GoogleProvider) {
+		p.baseURL = strings.TrimRight(url, "/")
+	}
+}
+
+func WithGoogleLanguageCode(code string) GoogleOption {
+	return func(p *GoogleProvider) {
+		p.languageCode = code
+	}
+}
+
+func WithGoogleModel(model GoogleModel) GoogleOption {
+	return func(p *GoogleProvider) {
+		p.model = model
+	}
+}
+
+func WithGoogleEnhanced(enabled bool) GoogleOption {
+	return func(p *GoogleProvider) {
+		p.useEnhanced = enabled
+	}
+}
+
+func WithGoogleTimeout(timeout time.Duration) GoogleOption {
+	return func(p *GoogleProvider) {
+		p.timeout = timeout
+	}
+}
+
+func WithGoogleRetries(retries int) GoogleOption {
+	return func(p *GoogleProvider) {
+		p.retries = retries
+	}
+}
+
+func WithGoogleCredentialsJSON(credentialsJSON string) GoogleOption {
+	return func(p *GoogleProvider) {
+		p.credentialsJSON = credentialsJSON
+	}
+}
+
+func NewGoogleProvider(apiKey string, opts ...GoogleOption) (*GoogleProvider, error) {
+	if apiKey == "" {
+		return nil, NewSTTError(ErrAuthentication, "google: API key is required")
+	}
+
+	p := &GoogleProvider{
+		apiKey:       apiKey,
+		baseURL:      "https://speech.googleapis.com",
+		languageCode: "en-US",
+		model:        GoogleModelDefault,
+		timeout:      120 * time.Second,
+		retries:      2,
+		client:       &http.Client{Timeout: 120 * time.Second},
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	p.client.Timeout = p.timeout
+
+	return p, nil
+}
+
+func (p *GoogleProvider) Name() string {
+	return "google-speech"
+}
+
+func (p *GoogleProvider) Type() STTProviderType {
+	return STTProviderGoogle
+}
+
+func (p *GoogleProvider) Transcribe(ctx context.Context, audio []byte, opts ...TranscribeOption) (*TranscriptResult, error) {
+	options := TranscribeOptions{
+		Language:    p.languageCode,
+		Mode:        ModeTranscription,
+		InputFormat: InputMP3,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	if len(audio) == 0 {
+		return nil, NewSTTError(ErrAudioFormatInvalid, "google-speech: audio data is empty")
+	}
+
+	const maxAudioSize = 100 * 1024 * 1024
+	if len(audio) > maxAudioSize {
+		return nil, NewSTTErrorf(ErrAudioTooLarge, "google-speech: audio exceeds 100MB limit (%d bytes)", len(audio))
+	}
+
+	if !validInputFormats[options.InputFormat] {
+		return nil, NewSTTErrorf(ErrAudioFormatInvalid, "google-speech: unsupported input format: %s", options.InputFormat)
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= p.retries; attempt++ {
+		if attempt > 0 {
+			backoff := time.Duration(attempt) * time.Second
+			select {
+			case <-ctx.Done():
+				return nil, NewSTTErrorf(ErrTranscriptionFailed, "google-speech: context cancelled during retry: %v", ctx.Err())
+			case <-time.After(backoff):
+			}
+		}
+
+		result, err := p.doTranscribe(ctx, audio, options)
+		if err == nil {
+			return result, nil
+		}
+
+		lastErr = err
+
+		if sttErr, ok := err.(*STTError); ok {
+			if sttErr.Code == ErrAuthentication || sttErr.Code == ErrAudioFormatInvalid || sttErr.Code == ErrAudioTooLarge || sttErr.Code == ErrRateLimited {
+				return nil, err
+			}
+		}
+	}
+
+	return nil, NewSTTErrorf(ErrTranscriptionFailed, "google-speech: all %d retries failed: %v", p.retries, lastErr)
+}
+
+func (p *GoogleProvider) TranscribeFile(ctx context.Context, filePath string, opts ...TranscribeOption) (*TranscriptResult, error) {
+	return nil, NewSTTError(ErrProviderNotSupported, "google-speech: file transcription requires GCS URI, use Transcribe with file content instead")
+}
+
+func (p *GoogleProvider) TranscribeStream(ctx context.Context, reader io.Reader, opts ...TranscribeOption) (*TranscriptResult, error) {
+	if reader == nil {
+		return nil, NewSTTError(ErrAudioFormatInvalid, "google-speech: reader is nil")
+	}
+
+	audio, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "google-speech: failed to read stream: %v", err)
+	}
+
+	return p.Transcribe(ctx, audio, opts...)
+}
+
+func (p *GoogleProvider) doTranscribe(ctx context.Context, audio []byte, options TranscribeOptions) (*TranscriptResult, error) {
+	encoding := p.mapInputFormatToEncoding(options.InputFormat)
+
+	sampleRate := int32(options.SampleRate)
+	if sampleRate == 0 {
+		sampleRate = p.guessSampleRate(options.InputFormat)
+	}
+
+	reqBody := googleRecognizeRequest{
+		Config: googleRecognitionConfigRequest{
+			Encoding:                   string(encoding),
+			SampleRateHertz:            sampleRate,
+			LanguageCode:               options.Language,
+			Model:                      string(p.model),
+			UseEnhanced:                p.useEnhanced,
+			MaxAlternatives:            int32(options.MaxAlternatives),
+			EnableWordTimeOffsets:      options.WordTimestamps,
+			EnableWordConfidence:       true,
+			EnableAutomaticPunctuation: true,
+		},
+		Audio: googleAudioRequest{
+			Content: base64.StdEncoding.EncodeToString(audio),
+		},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "google-speech: failed to marshal request: %v", err)
+	}
+
+	url := fmt.Sprintf("%s/v1/speech:recognize?key=%s", p.baseURL, p.apiKey)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "google-speech: failed to create request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "anyclaw-stt/1.0")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "google-speech: request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, p.handleErrorResponse(resp.StatusCode, respBody)
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "google-speech: failed to read response: %v", err)
+	}
+
+	return p.parseResponse(respBody, options)
+}
+
+func (p *GoogleProvider) mapInputFormatToEncoding(format AudioInputFormat) RecognitionEncoding {
+	switch format {
+	case InputWAV, InputPCM:
+		return EncodingLinear16
+	case InputFLAC:
+		return EncodingFLAC
+	case InputMP3:
+		return EncodingMP3
+	case InputOGG, InputWEBM:
+		return EncodingWEBMOpus
+	case InputM4A, InputMP4:
+		return EncodingWEBMOpus
+	case InputMPEG, InputMPGA:
+		return EncodingMP3
+	default:
+		return EncodingMP3
+	}
+}
+
+func (p *GoogleProvider) guessSampleRate(format AudioInputFormat) int32 {
+	switch format {
+	case InputWAV, InputPCM:
+		return 16000
+	case InputFLAC:
+		return 16000
+	case InputMP3:
+		return 16000
+	case InputOGG, InputWEBM:
+		return 48000
+	case InputM4A, InputMP4:
+		return 44100
+	default:
+		return 16000
+	}
+}
+
+func (p *GoogleProvider) handleErrorResponse(statusCode int, body []byte) error {
+	var errResp googleErrorResponse
+	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Error.Message != "" {
+		msg := fmt.Sprintf("google-speech: API error: %s (status: %s)", errResp.Error.Message, errResp.Error.Status)
+		switch statusCode {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			return NewSTTError(ErrAuthentication, msg)
+		case http.StatusTooManyRequests:
+			return NewSTTError(ErrRateLimited, msg)
+		case http.StatusBadRequest:
+			return NewSTTError(ErrAudioFormatInvalid, msg)
+		default:
+			return NewSTTError(ErrTranscriptionFailed, msg)
+		}
+	}
+
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return NewSTTError(ErrAuthentication, fmt.Sprintf("google-speech: authentication failed: %s", string(body)))
+	case http.StatusTooManyRequests:
+		return NewSTTError(ErrRateLimited, fmt.Sprintf("google-speech: rate limited: %s", string(body)))
+	case http.StatusBadRequest:
+		return NewSTTError(ErrAudioFormatInvalid, fmt.Sprintf("google-speech: invalid request: %s", string(body)))
+	case http.StatusServiceUnavailable:
+		return NewSTTError(ErrTranscriptionFailed, fmt.Sprintf("google-speech: service unavailable: %s", string(body)))
+	default:
+		return NewSTTErrorf(ErrTranscriptionFailed, "google-speech: unexpected status %d: %s", statusCode, string(body))
+	}
+}
+
+type googleRecognizeRequest struct {
+	Config googleRecognitionConfigRequest `json:"config"`
+	Audio  googleAudioRequest             `json:"audio"`
+}
+
+type googleRecognitionConfigRequest struct {
+	Encoding                   string `json:"encoding"`
+	SampleRateHertz            int32  `json:"sampleRateHertz"`
+	LanguageCode               string `json:"languageCode"`
+	Model                      string `json:"model,omitempty"`
+	UseEnhanced                bool   `json:"useEnhanced,omitempty"`
+	MaxAlternatives            int32  `json:"maxAlternatives,omitempty"`
+	EnableWordTimeOffsets      bool   `json:"enableWordTimeOffsets,omitempty"`
+	EnableWordConfidence       bool   `json:"enableWordConfidence,omitempty"`
+	EnableAutomaticPunctuation bool   `json:"enableAutomaticPunctuation,omitempty"`
+	EnableSpokenPunctuation    bool   `json:"enableSpokenPunctuation,omitempty"`
+}
+
+type googleAudioRequest struct {
+	Content string `json:"content"`
+}
+
+type googleResponse struct {
+	Results []googleResult `json:"results"`
+}
+
+type googleResult struct {
+	Alternatives  []googleAlternative `json:"alternatives"`
+	LanguageCode  string              `json:"languageCode"`
+	ResultEndTime struct {
+		Seconds string `json:"seconds"`
+		Nanos   int    `json:"nanos"`
+	} `json:"resultEndTime"`
+}
+
+type googleAlternative struct {
+	Transcript string           `json:"transcript"`
+	Confidence float64          `json:"confidence"`
+	Words      []googleWordInfo `json:"words"`
+}
+
+type googleWordInfo struct {
+	StartTime  googleDuration `json:"startTime"`
+	EndTime    googleDuration `json:"endTime"`
+	Word       string         `json:"word"`
+	Confidence float64        `json:"confidence"`
+}
+
+type googleDuration struct {
+	Seconds string `json:"seconds"`
+	Nanos   int    `json:"nanos"`
+}
+
+type googleErrorResponse struct {
+	Error struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Status  string `json:"status"`
+	} `json:"error"`
+}
+
+func (p *GoogleProvider) parseResponse(body []byte, options TranscribeOptions) (*TranscriptResult, error) {
+	var resp googleResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "google-speech: failed to parse JSON response: %v", err)
+	}
+
+	if len(resp.Results) == 0 {
+		return &TranscriptResult{
+			Text:     "",
+			Language: options.Language,
+		}, nil
+	}
+
+	result := &TranscriptResult{}
+	var totalConfidence float64
+	var confidenceCount int
+
+	for i, res := range resp.Results {
+		if len(res.Alternatives) == 0 {
+			continue
+		}
+
+		primary := res.Alternatives[0]
+
+		segment := SegmentInfo{
+			ID:   i,
+			Text: primary.Transcript,
+		}
+
+		if primary.Confidence > 0 {
+			segment.Confidence = primary.Confidence
+			totalConfidence += primary.Confidence
+			confidenceCount++
+		}
+
+		if len(primary.Words) > 0 {
+			segment.Words = make([]WordInfo, 0, len(primary.Words))
+			for _, w := range primary.Words {
+				segment.Words = append(segment.Words, WordInfo{
+					Word:       w.Word,
+					StartTime:  parseGoogleDuration(w.StartTime),
+					EndTime:    parseGoogleDuration(w.EndTime),
+					Confidence: w.Confidence,
+				})
+			}
+		}
+
+		if options.WordTimestamps && len(segment.Words) > 0 {
+			result.Words = append(result.Words, segment.Words...)
+		}
+
+		result.Segments = append(result.Segments, segment)
+
+		if i == 0 {
+			result.Text = primary.Transcript
+			result.Language = res.LanguageCode
+		} else {
+			result.Text += " " + primary.Transcript
+		}
+
+		if options.MaxAlternatives > 1 && len(res.Alternatives) > 1 {
+			for _, alt := range res.Alternatives[1:] {
+				result.Alternatives = append(result.Alternatives, alt.Transcript)
+			}
+		}
+	}
+
+	if confidenceCount > 0 {
+		result.Confidence = totalConfidence / float64(confidenceCount)
+	}
+
+	if len(resp.Results) > 0 {
+		endTime := resp.Results[len(resp.Results)-1].ResultEndTime
+		result.Duration = parseGoogleDuration(googleDuration{
+			Seconds: endTime.Seconds,
+			Nanos:   endTime.Nanos,
+		})
+	}
+
+	return result, nil
+}
+
+func parseGoogleDuration(d googleDuration) time.Duration {
+	var seconds int64
+	if d.Seconds != "" {
+		fmt.Sscanf(d.Seconds, "%d", &seconds)
+	}
+	return time.Duration(seconds)*time.Second + time.Duration(d.Nanos)*time.Nanosecond
+}
+
+func (p *GoogleProvider) ListLanguages(ctx context.Context) ([]string, error) {
+	return []string{
+		"af-ZA", "am-ET", "hy-AM", "az-AZ", "id-ID", "ms-MY", "bn-BD", "bn-IN", "ca-ES", "cs-CZ",
+		"da-DK", "de-DE", "en-AU", "en-CA", "en-GH", "en-GB", "en-IN", "en-IE", "en-KE", "en-NZ",
+		"en-NG", "en-PH", "en-SG", "en-ZA", "en-TZ", "en-US", "es-AR", "es-BO", "es-CL", "es-CO",
+		"es-CR", "es-EC", "es-SV", "es-ES", "es-US", "es-GT", "es-HN", "es-MX", "es-NI", "es-PA",
+		"es-PY", "es-PE", "es-PR", "es-DO", "es-UY", "es-VE", "eu-ES", "fil-PH", "fr-CA", "fr-FR",
+		"gl-ES", "ka-GE", "gu-IN", "hr-HR", "zu-ZA", "is-IS", "it-IT", "jv-ID", "kn-IN", "km-KH",
+		"lo-LA", "lv-LV", "lt-LT", "hu-HU", "ml-IN", "mr-IN", "nl-NL", "ne-NP", "nb-NO", "pl-PL",
+		"pt-BR", "pt-PT", "ro-RO", "si-LK", "sk-SK", "sl-SI", "sr-RS", "fi-FI", "sv-SE", "ta-IN",
+		"ta-SG", "ta-LK", "ta-MY", "te-IN", "vi-VN", "tr-TR", "ur-IN", "ur-PK", "el-GR", "bg-BG",
+		"ru-RU", "sr-RS", "uk-UA", "he-IL", "ar-AE", "ar-BH", "ar-DZ", "ar-EG", "ar-IQ", "ar-JO",
+		"ar-KW", "ar-LB", "ar-LY", "ar-MA", "ar-OM", "ar-QA", "ar-SA", "ar-PS", "ar-SY", "ar-TN",
+		"ar-YE", "fa-IR", "hi-IN", "th-TH", "ko-KR", "zh-TW", "ja-JP", "zh", "zh-CN", "zh-HK",
+		"yue-Hant-HK",
+	}, nil
+}

--- a/pkg/speech/stt_google_test.go
+++ b/pkg/speech/stt_google_test.go
@@ -1,0 +1,693 @@
+package speech
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewGoogleProvider(t *testing.T) {
+	t.Run("requires API key", func(t *testing.T) {
+		_, err := NewGoogleProvider("")
+		if err == nil {
+			t.Fatal("expected error when API key is empty")
+		}
+		sttErr, ok := err.(*STTError)
+		if !ok {
+			t.Fatalf("expected *STTError, got %T", err)
+		}
+		if sttErr.Code != ErrAuthentication {
+			t.Errorf("expected ErrAuthentication, got %s", sttErr.Code)
+		}
+	})
+
+	t.Run("creates provider with defaults", func(t *testing.T) {
+		p, err := NewGoogleProvider("test-key")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if p.Name() != "google-speech" {
+			t.Errorf("expected name google-speech, got %s", p.Name())
+		}
+		if p.Type() != STTProviderGoogle {
+			t.Errorf("expected type %s, got %s", STTProviderGoogle, p.Type())
+		}
+		if p.baseURL != "https://speech.googleapis.com" {
+			t.Errorf("expected default baseURL, got %s", p.baseURL)
+		}
+		if p.languageCode != "en-US" {
+			t.Errorf("expected default language en-US, got %s", p.languageCode)
+		}
+		if p.model != GoogleModelDefault {
+			t.Errorf("expected default model %s, got %s", GoogleModelDefault, p.model)
+		}
+		if p.retries != 2 {
+			t.Errorf("expected 2 retries, got %d", p.retries)
+		}
+	})
+
+	t.Run("applies options", func(t *testing.T) {
+		p, err := NewGoogleProvider("test-key",
+			WithGoogleBaseURL("https://custom.speech.api.com"),
+			WithGoogleLanguageCode("zh-CN"),
+			WithGoogleModel(GoogleModelLatestLong),
+			WithGoogleEnhanced(true),
+			WithGoogleTimeout(30*time.Second),
+			WithGoogleRetries(5),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if p.baseURL != "https://custom.speech.api.com" {
+			t.Errorf("expected custom baseURL, got %s", p.baseURL)
+		}
+		if p.languageCode != "zh-CN" {
+			t.Errorf("expected language zh-CN, got %s", p.languageCode)
+		}
+		if p.model != GoogleModelLatestLong {
+			t.Errorf("expected model %s, got %s", GoogleModelLatestLong, p.model)
+		}
+		if !p.useEnhanced {
+			t.Error("expected useEnhanced to be true")
+		}
+		if p.timeout != 30*time.Second {
+			t.Errorf("expected 30s timeout, got %v", p.timeout)
+		}
+		if p.retries != 5 {
+			t.Errorf("expected 5 retries, got %d", p.retries)
+		}
+	})
+
+	t.Run("trims trailing slash from baseURL", func(t *testing.T) {
+		p, err := NewGoogleProvider("test-key", WithGoogleBaseURL("https://api.example.com/"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.HasSuffix(p.baseURL, "/") {
+			t.Errorf("baseURL should not have trailing slash: %s", p.baseURL)
+		}
+	})
+}
+
+func TestGoogleProviderTranscribe(t *testing.T) {
+	t.Run("rejects empty audio", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer server.Close()
+
+		p, _ := NewGoogleProvider("test-key", WithGoogleBaseURL(server.URL))
+		_, err := p.Transcribe(context.Background(), nil)
+		if err == nil {
+			t.Fatal("expected error for empty audio")
+		}
+	})
+
+	t.Run("rejects audio too large", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer server.Close()
+
+		p, _ := NewGoogleProvider("test-key", WithGoogleBaseURL(server.URL))
+		largeAudio := make([]byte, 101*1024*1024)
+		_, err := p.Transcribe(context.Background(), largeAudio)
+		if err == nil {
+			t.Fatal("expected error for audio too large")
+		}
+		sttErr, ok := err.(*STTError)
+		if !ok {
+			t.Fatalf("expected *STTError, got %T", err)
+		}
+		if sttErr.Code != ErrAudioTooLarge {
+			t.Errorf("expected ErrAudioTooLarge, got %s", sttErr.Code)
+		}
+	})
+
+	t.Run("successful transcription", func(t *testing.T) {
+		response := googleResponse{
+			Results: []googleResult{
+				{
+					Alternatives: []googleAlternative{
+						{
+							Transcript: "Hello world",
+							Confidence: 0.95,
+							Words: []googleWordInfo{
+								{Word: "Hello", Confidence: 0.96, StartTime: googleDuration{Seconds: "0", Nanos: 0}, EndTime: googleDuration{Seconds: "0", Nanos: 500000000}},
+								{Word: "world", Confidence: 0.94, StartTime: googleDuration{Seconds: "0", Nanos: 600000000}, EndTime: googleDuration{Seconds: "1", Nanos: 0}},
+							},
+						},
+					},
+					LanguageCode: "en-US",
+					ResultEndTime: struct {
+						Seconds string `json:"seconds"`
+						Nanos   int    `json:"nanos"`
+					}{Seconds: "2", Nanos: 500000000},
+				},
+			},
+		}
+
+		respBody, _ := json.Marshal(response)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "POST" {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			if !strings.Contains(r.URL.Query().Get("key"), "test-key") {
+				t.Error("missing API key in query")
+			}
+			if r.Header.Get("Content-Type") != "application/json" {
+				t.Errorf("expected application/json, got %s", r.Header.Get("Content-Type"))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write(respBody)
+		}))
+		defer server.Close()
+
+		p, _ := NewGoogleProvider("test-key", WithGoogleBaseURL(server.URL))
+		result, err := p.Transcribe(context.Background(), []byte("fake-audio-data"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.Text != "Hello world" {
+			t.Errorf("expected 'Hello world', got '%s'", result.Text)
+		}
+		if result.Language != "en-US" {
+			t.Errorf("expected language 'en-US', got '%s'", result.Language)
+		}
+		if result.Duration != 2500*time.Millisecond {
+			t.Errorf("expected duration 2.5s, got %v", result.Duration)
+		}
+		if len(result.Segments) != 1 {
+			t.Fatalf("expected 1 segment, got %d", len(result.Segments))
+		}
+		if len(result.Segments[0].Words) != 2 {
+			t.Fatalf("expected 2 words, got %d", len(result.Segments[0].Words))
+		}
+		if result.Confidence != 0.95 {
+			t.Errorf("expected confidence 0.95, got %f", result.Confidence)
+		}
+	})
+
+	t.Run("multiple segments", func(t *testing.T) {
+		response := googleResponse{
+			Results: []googleResult{
+				{Alternatives: []googleAlternative{{Transcript: "First segment"}}, LanguageCode: "en-US"},
+				{Alternatives: []googleAlternative{{Transcript: "Second segment"}}, LanguageCode: "en-US"},
+			},
+		}
+
+		respBody, _ := json.Marshal(response)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(respBody)
+		}))
+		defer server.Close()
+
+		p, _ := NewGoogleProvider("test-key", WithGoogleBaseURL(server.URL))
+		result, err := p.Transcribe(context.Background(), []byte("fake-audio"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		expectedText := "First segment Second segment"
+		if result.Text != expectedText {
+			t.Errorf("expected '%s', got '%s'", expectedText, result.Text)
+		}
+		if len(result.Segments) != 2 {
+			t.Fatalf("expected 2 segments, got %d", len(result.Segments))
+		}
+	})
+
+	t.Run("alternatives", func(t *testing.T) {
+		response := googleResponse{
+			Results: []googleResult{
+				{
+					Alternatives: []googleAlternative{
+						{Transcript: "Hello world", Confidence: 0.95},
+						{Transcript: "Hello word", Confidence: 0.80},
+						{Transcript: "Halo world", Confidence: 0.70},
+					},
+					LanguageCode: "en-US",
+				},
+			},
+		}
+
+		respBody, _ := json.Marshal(response)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(respBody)
+		}))
+		defer server.Close()
+
+		p, _ := NewGoogleProvider("test-key", WithGoogleBaseURL(server.URL))
+		result, err := p.Transcribe(context.Background(), []byte("fake-audio"),
+			WithSTTMaxAlternatives(3))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(result.Alternatives) != 2 {
+			t.Fatalf("expected 2 alternatives, got %d", len(result.Alternatives))
+		}
+		if result.Alternatives[0] != "Hello word" {
+			t.Errorf("expected first alternative 'Hello word', got '%s'", result.Alternatives[0])
+		}
+	})
+
+	t.Run("empty results", func(t *testing.T) {
+		response := googleResponse{Results: []googleResult{}}
+		respBody, _ := json.Marshal(response)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(respBody)
+		}))
+		defer server.Close()
+
+		p, _ := NewGoogleProvider("test-key", WithGoogleBaseURL(server.URL))
+		result, err := p.Transcribe(context.Background(), []byte("fake-audio"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.Text != "" {
+			t.Errorf("expected empty text, got '%s'", result.Text)
+		}
+	})
+
+	t.Run("handles authentication error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error":{"code":401,"message":"API key not valid. Please pass a valid API key.","status":"UNAUTHENTICATED"}}`))
+		}))
+		defer server.Close()
+
+		p, _ := NewGoogleProvider("bad-key", WithGoogleBaseURL(server.URL), WithGoogleRetries(0))
+		_, err := p.Transcribe(context.Background(), []byte("fake-audio"))
+		if err == nil {
+			t.Fatal("expected authentication error")
+		}
+		sttErr, ok := err.(*STTError)
+		if !ok {
+			t.Fatalf("expected *STTError, got %T", err)
+		}
+		if sttErr.Code != ErrAuthentication {
+			t.Errorf("expected ErrAuthentication, got %s", sttErr.Code)
+		}
+	})
+
+	t.Run("handles forbidden error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(`{"error":{"code":403,"message":"API key expired.","status":"PERMISSION_DENIED"}}`))
+		}))
+		defer server.Close()
+
+		p, _ := NewGoogleProvider("expired-key", WithGoogleBaseURL(server.URL), WithGoogleRetries(0))
+		_, err := p.Transcribe(context.Background(), []byte("fake-audio"))
+		if err == nil {
+			t.Fatal("expected authentication error")
+		}
+		sttErr, ok := err.(*STTError)
+		if !ok {
+			t.Fatalf("expected *STTError, got %T", err)
+		}
+		if sttErr.Code != ErrAuthentication {
+			t.Errorf("expected ErrAuthentication, got %s", sttErr.Code)
+		}
+	})
+
+	t.Run("handles rate limit error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte(`{"error":{"code":429,"message":"Quota exceeded.","status":"RESOURCE_EXHAUSTED"}}`))
+		}))
+		defer server.Close()
+
+		p, _ := NewGoogleProvider("test-key", WithGoogleBaseURL(server.URL), WithGoogleRetries(0))
+		_, err := p.Transcribe(context.Background(), []byte("fake-audio"))
+		if err == nil {
+			t.Fatal("expected rate limit error")
+		}
+		sttErr, ok := err.(*STTError)
+		if !ok {
+			t.Fatalf("expected *STTError, got %T", err)
+		}
+		if sttErr.Code != ErrRateLimited {
+			t.Errorf("expected ErrRateLimited, got %s", sttErr.Code)
+		}
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer server.Close()
+
+		p, _ := NewGoogleProvider("test-key", WithGoogleBaseURL(server.URL), WithGoogleRetries(1))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := p.Transcribe(ctx, []byte("fake-audio"))
+		if err == nil {
+			t.Fatal("expected context cancellation error")
+		}
+	})
+
+	t.Run("uses correct URL with API key", func(t *testing.T) {
+		var receivedURL string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			receivedURL = r.URL.String()
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results":[{"alternatives":[{"transcript":"test"}],"languageCode":"en-US"}]}`))
+		}))
+		defer server.Close()
+
+		p, _ := NewGoogleProvider("my-api-key", WithGoogleBaseURL(server.URL))
+		_, err := p.Transcribe(context.Background(), []byte("fake-audio"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(receivedURL, "key=my-api-key") {
+			t.Errorf("expected URL to contain 'key=my-api-key', got %s", receivedURL)
+		}
+		if !strings.Contains(receivedURL, "/v1/speech:recognize") {
+			t.Errorf("expected URL to contain '/v1/speech:recognize', got %s", receivedURL)
+		}
+	})
+
+	t.Run("sends correct request body", func(t *testing.T) {
+		var receivedBody googleRecognizeRequest
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewDecoder(r.Body).Decode(&receivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results":[{"alternatives":[{"transcript":"test"}],"languageCode":"en-US"}]}`))
+		}))
+		defer server.Close()
+
+		p, _ := NewGoogleProvider("test-key", WithGoogleBaseURL(server.URL))
+		_, err := p.Transcribe(context.Background(), []byte("fake-audio"),
+			WithSTTLanguage("zh-CN"),
+			WithSTTWordTimestamps(true),
+			WithSTTMaxAlternatives(3))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if receivedBody.Config.LanguageCode != "zh-CN" {
+			t.Errorf("expected language zh-CN, got %s", receivedBody.Config.LanguageCode)
+		}
+		if !receivedBody.Config.EnableWordTimeOffsets {
+			t.Error("expected EnableWordTimeOffsets to be true")
+		}
+		if receivedBody.Config.MaxAlternatives != 3 {
+			t.Errorf("expected maxAlternatives 3, got %d", receivedBody.Config.MaxAlternatives)
+		}
+		if receivedBody.Config.EnableAutomaticPunctuation != true {
+			t.Error("expected EnableAutomaticPunctuation to be true")
+		}
+	})
+}
+
+func TestGoogleProviderTranscribeStream(t *testing.T) {
+	t.Run("rejects nil reader", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer server.Close()
+
+		p, _ := NewGoogleProvider("test-key", WithGoogleBaseURL(server.URL))
+		_, err := p.TranscribeStream(context.Background(), nil)
+		if err == nil {
+			t.Fatal("expected error for nil reader")
+		}
+	})
+
+	t.Run("successful stream transcription", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results":[{"alternatives":[{"transcript":"Stream content","confidence":0.9}],"languageCode":"en-US"}]}`))
+		}))
+		defer server.Close()
+
+		p, _ := NewGoogleProvider("test-key", WithGoogleBaseURL(server.URL))
+		reader := strings.NewReader("stream-audio-data")
+		result, err := p.TranscribeStream(context.Background(), reader)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.Text != "Stream content" {
+			t.Errorf("expected 'Stream content', got '%s'", result.Text)
+		}
+	})
+}
+
+func TestGoogleProviderTranscribeFile(t *testing.T) {
+	t.Run("returns not supported error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer server.Close()
+
+		p, _ := NewGoogleProvider("test-key", WithGoogleBaseURL(server.URL))
+		_, err := p.TranscribeFile(context.Background(), "/some/file.mp3")
+		if err == nil {
+			t.Fatal("expected error for file transcription")
+		}
+		sttErr, ok := err.(*STTError)
+		if !ok {
+			t.Fatalf("expected *STTError, got %T", err)
+		}
+		if sttErr.Code != ErrProviderNotSupported {
+			t.Errorf("expected ErrProviderNotSupported, got %s", sttErr.Code)
+		}
+	})
+}
+
+func TestGoogleProviderListLanguages(t *testing.T) {
+	p, _ := NewGoogleProvider("test-key")
+	langs, err := p.ListLanguages(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(langs) == 0 {
+		t.Fatal("expected non-empty language list")
+	}
+
+	found := false
+	for _, lang := range langs {
+		if lang == "en-US" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'en-US' in language list")
+	}
+
+	found = false
+	for _, lang := range langs {
+		if lang == "zh-CN" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'zh-CN' in language list")
+	}
+}
+
+func TestGoogleProviderEncodingMapping(t *testing.T) {
+	p, _ := NewGoogleProvider("test-key")
+
+	tests := []struct {
+		format AudioInputFormat
+		want   RecognitionEncoding
+	}{
+		{InputWAV, EncodingLinear16},
+		{InputPCM, EncodingLinear16},
+		{InputFLAC, EncodingFLAC},
+		{InputMP3, EncodingMP3},
+		{InputOGG, EncodingWEBMOpus},
+		{InputWEBM, EncodingWEBMOpus},
+		{InputM4A, EncodingWEBMOpus},
+		{InputMP4, EncodingWEBMOpus},
+		{InputMPEG, EncodingMP3},
+		{InputMPGA, EncodingMP3},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.format), func(t *testing.T) {
+			got := p.mapInputFormatToEncoding(tt.format)
+			if got != tt.want {
+				t.Errorf("mapInputFormatToEncoding(%s) = %s, want %s", tt.format, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGoogleProviderSampleRateGuessing(t *testing.T) {
+	p, _ := NewGoogleProvider("test-key")
+
+	tests := []struct {
+		format AudioInputFormat
+		want   int32
+	}{
+		{InputWAV, 16000},
+		{InputPCM, 16000},
+		{InputFLAC, 16000},
+		{InputMP3, 16000},
+		{InputOGG, 48000},
+		{InputWEBM, 48000},
+		{InputM4A, 44100},
+		{InputMP4, 44100},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.format), func(t *testing.T) {
+			got := p.guessSampleRate(tt.format)
+			if got != tt.want {
+				t.Errorf("guessSampleRate(%s) = %d, want %d", tt.format, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGoogleProviderRetries(t *testing.T) {
+	t.Run("retries on server error then succeeds", func(t *testing.T) {
+		callCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			if callCount < 2 {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusServiceUnavailable)
+				w.Write([]byte(`{"error":{"code":503,"message":"Service unavailable","status":"UNAVAILABLE"}}`))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results":[{"alternatives":[{"transcript":"Success after retry"}],"languageCode":"en-US"}]}`))
+		}))
+		defer server.Close()
+
+		p, _ := NewGoogleProvider("test-key", WithGoogleBaseURL(server.URL), WithGoogleRetries(2))
+		result, err := p.Transcribe(context.Background(), []byte("fake-audio"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.Text != "Success after retry" {
+			t.Errorf("expected 'Success after retry', got '%s'", result.Text)
+		}
+		if callCount != 2 {
+			t.Errorf("expected 2 calls, got %d", callCount)
+		}
+	})
+
+	t.Run("does not retry on auth error", func(t *testing.T) {
+		callCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error":{"code":401,"message":"Invalid API key","status":"UNAUTHENTICATED"}}`))
+		}))
+		defer server.Close()
+
+		p, _ := NewGoogleProvider("bad-key", WithGoogleBaseURL(server.URL), WithGoogleRetries(3))
+		_, err := p.Transcribe(context.Background(), []byte("fake-audio"))
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if callCount != 1 {
+			t.Errorf("expected 1 call (no retry on auth error), got %d", callCount)
+		}
+	})
+}
+
+func TestParseGoogleDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		d    googleDuration
+		want time.Duration
+	}{
+		{"zero", googleDuration{Seconds: "0", Nanos: 0}, 0},
+		{"one second", googleDuration{Seconds: "1", Nanos: 0}, time.Second},
+		{"500ms", googleDuration{Seconds: "0", Nanos: 500000000}, 500 * time.Millisecond},
+		{"2.5s", googleDuration{Seconds: "2", Nanos: 500000000}, 2500 * time.Millisecond},
+		{"1.234s", googleDuration{Seconds: "1", Nanos: 234000000}, time.Second + 234*time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseGoogleDuration(tt.d)
+			if got != tt.want {
+				t.Errorf("parseGoogleDuration(%v) = %v, want %v", tt.d, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewSTTProviderGoogle(t *testing.T) {
+	t.Run("creates Google provider", func(t *testing.T) {
+		p, err := NewSTTProvider(STTConfig{
+			Type:    STTProviderGoogle,
+			APIKey:  "test-key",
+			Timeout: 30 * time.Second,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if p.Type() != STTProviderGoogle {
+			t.Errorf("expected STTProviderGoogle, got %s", p.Type())
+		}
+		if p.Name() != "google-speech" {
+			t.Errorf("expected name 'google-speech', got %s", p.Name())
+		}
+	})
+
+	t.Run("creates Google provider with language", func(t *testing.T) {
+		p, err := NewSTTProvider(STTConfig{
+			Type:     STTProviderGoogle,
+			APIKey:   "test-key",
+			Language: "zh-CN",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		gp, ok := p.(*GoogleProvider)
+		if !ok {
+			t.Fatalf("expected *GoogleProvider, got %T", p)
+		}
+		if gp.languageCode != "zh-CN" {
+			t.Errorf("expected language zh-CN, got %s", gp.languageCode)
+		}
+	})
+}
+
+func TestGoogleSTTManager(t *testing.T) {
+	t.Run("register and use Google provider", func(t *testing.T) {
+		m := NewSTTManager()
+		p, _ := NewGoogleProvider("test-key")
+
+		err := m.Register("google", p)
+		if err != nil {
+			t.Fatalf("failed to register provider: %v", err)
+		}
+
+		providers := m.ListProviders()
+		if len(providers) != 1 {
+			t.Fatalf("expected 1 provider, got %d", len(providers))
+		}
+
+		got, err := m.Get("google")
+		if err != nil {
+			t.Fatalf("failed to get provider: %v", err)
+		}
+		if got.Type() != STTProviderGoogle {
+			t.Errorf("expected STTProviderGoogle, got %s", got.Type())
+		}
+	})
+}

--- a/pkg/speech/stt_integration.go
+++ b/pkg/speech/stt_integration.go
@@ -1,0 +1,509 @@
+package speech
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+type STTIntegration struct {
+	mu       sync.RWMutex
+	pipeline *STTPipeline
+	config   STTIntegrationConfig
+	hooks    []STTIntegrationHook
+}
+
+type STTIntegrationConfig struct {
+	Enabled          bool
+	AutoSTT          bool
+	TriggerPrefix    string
+	Provider         string
+	DefaultLang      string
+	MaxDuration      time.Duration
+	MinConfidence    float64
+	Timeout          time.Duration
+	Channels         map[string]bool
+	ExcludeChannels  map[string]bool
+	FallbackToVoice  bool
+	AppendTranscript bool
+}
+
+func DefaultSTTIntegrationConfig() STTIntegrationConfig {
+	return STTIntegrationConfig{
+		Enabled:          true,
+		AutoSTT:          true,
+		TriggerPrefix:    "/transcribe",
+		Provider:         "",
+		DefaultLang:      "auto",
+		MaxDuration:      10 * time.Minute,
+		MinConfidence:    0.0,
+		Timeout:          120 * time.Second,
+		Channels:         map[string]bool{},
+		ExcludeChannels:  map[string]bool{},
+		FallbackToVoice:  false,
+		AppendTranscript: true,
+	}
+}
+
+type STTIntegrationHook interface {
+	OnBeforeSTT(ctx context.Context, req *STTTranscribeRequest) error
+	OnAfterSTT(ctx context.Context, result *TranscriptResult) error
+}
+
+func NewSTTIntegration(pipeline *STTPipeline, cfg STTIntegrationConfig) *STTIntegration {
+	return &STTIntegration{
+		pipeline: pipeline,
+		config:   cfg,
+	}
+}
+
+func (i *STTIntegration) RegisterHook(hook STTIntegrationHook) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.hooks = append(i.hooks, hook)
+}
+
+type StreamChunkHandler func(ctx context.Context, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, error)
+
+func (i *STTIntegration) WrapStreamInboundHandler(handler StreamChunkHandler) StreamChunkHandler {
+	return func(ctx context.Context, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, error) {
+		i.mu.RLock()
+		enabled := i.config.Enabled
+		autoSTT := i.config.AutoSTT
+		triggerPrefix := i.config.TriggerPrefix
+		channels := i.config.Channels
+		excludeChannels := i.config.ExcludeChannels
+		i.mu.RUnlock()
+
+		if !enabled {
+			return handler(ctx, sessionID, message, meta, onChunk)
+		}
+
+		channel := ""
+		if meta != nil {
+			if ch, ok := meta["channel"]; ok {
+				channel = ch
+			}
+		}
+
+		if len(channels) > 0 && !channels[channel] {
+			return handler(ctx, sessionID, message, meta, onChunk)
+		}
+
+		if excludeChannels[channel] {
+			return handler(ctx, sessionID, message, meta, onChunk)
+		}
+
+		messageType := ""
+		if meta != nil {
+			if mt, ok := meta["message_type"]; ok {
+				messageType = mt
+			}
+		}
+
+		isVoiceMessage := messageType == "voice" || messageType == "audio" || messageType == "voice_note" || messageType == "audio_file"
+
+		if !isVoiceMessage && strings.HasPrefix(message, triggerPrefix) {
+			cleanText := strings.TrimSpace(message[len(triggerPrefix):])
+			if cleanText == "" {
+				return handler(ctx, sessionID, message, meta, onChunk)
+			}
+			message = cleanText
+			return handler(ctx, sessionID, message, meta, onChunk)
+		}
+
+		if !isVoiceMessage && !autoSTT {
+			return handler(ctx, sessionID, message, meta, onChunk)
+		}
+
+		audioURL := ""
+		audioMIME := ""
+		sender := ""
+		if meta != nil {
+			if url, ok := meta["audio_url"]; ok {
+				audioURL = url
+			}
+			if mime, ok := meta["audio_mime"]; ok {
+				audioMIME = mime
+			}
+			if s, ok := meta["sender"]; ok {
+				sender = s
+			}
+		}
+
+		if audioURL == "" && message != "" {
+			audioURL = message
+			message = ""
+		}
+
+		if audioURL == "" {
+			if i.config.FallbackToVoice {
+				meta["stt_error"] = "no audio data"
+			}
+			return handler(ctx, sessionID, message, meta, onChunk)
+		}
+
+		req := &STTTranscribeRequest{
+			AudioURL:  audioURL,
+			AudioMIME: audioMIME,
+			Channel:   channel,
+			Sender:    sender,
+			Language:  i.config.DefaultLang,
+			Provider:  i.config.Provider,
+			Metadata:  map[string]any{},
+		}
+
+		result, err := i.pipeline.Transcribe(ctx, req)
+		if err != nil {
+			if i.config.FallbackToVoice {
+				meta["stt_error"] = err.Error()
+			}
+			return handler(ctx, sessionID, message, meta, onChunk)
+		}
+
+		transcribedText := result.Text
+		if transcribedText == "" {
+			return handler(ctx, sessionID, message, meta, onChunk)
+		}
+
+		if i.config.AppendTranscript && message != "" {
+			transcribedText = message + "\n\n[Transcript]: " + transcribedText
+		}
+
+		for _, hook := range i.hooks {
+			_ = hook.OnAfterSTT(ctx, &TranscriptResult{Text: transcribedText})
+		}
+
+		return handler(ctx, sessionID, transcribedText, meta, onChunk)
+	}
+}
+
+func (i *STTIntegration) WrapInboundHandler(handler InboundHandler) InboundHandler {
+	return func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		i.mu.RLock()
+		enabled := i.config.Enabled
+		autoSTT := i.config.AutoSTT
+		triggerPrefix := i.config.TriggerPrefix
+		channels := i.config.Channels
+		excludeChannels := i.config.ExcludeChannels
+		i.mu.RUnlock()
+
+		if !enabled {
+			return handler(ctx, sessionID, message, meta)
+		}
+
+		channel := ""
+		if meta != nil {
+			if ch, ok := meta["channel"]; ok {
+				channel = ch
+			}
+		}
+
+		if len(channels) > 0 && !channels[channel] {
+			return handler(ctx, sessionID, message, meta)
+		}
+
+		if excludeChannels[channel] {
+			return handler(ctx, sessionID, message, meta)
+		}
+
+		messageType := ""
+		if meta != nil {
+			if mt, ok := meta["message_type"]; ok {
+				messageType = mt
+			}
+		}
+
+		isVoiceMessage := messageType == "voice" || messageType == "audio" || messageType == "voice_note" || messageType == "audio_file"
+
+		if !isVoiceMessage && !strings.HasPrefix(message, triggerPrefix) && !autoSTT {
+			return handler(ctx, sessionID, message, meta)
+		}
+
+		if !isVoiceMessage && strings.HasPrefix(message, triggerPrefix) {
+			cleanText := strings.TrimSpace(message[len(triggerPrefix):])
+			if cleanText == "" {
+				return handler(ctx, sessionID, message, meta)
+			}
+			message = cleanText
+			return handler(ctx, sessionID, message, meta)
+		}
+
+		if !isVoiceMessage {
+			return handler(ctx, sessionID, message, meta)
+		}
+
+		audioURL := ""
+		audioMIME := ""
+		sender := ""
+		if meta != nil {
+			if url, ok := meta["audio_url"]; ok {
+				audioURL = url
+			}
+			if mime, ok := meta["audio_mime"]; ok {
+				audioMIME = mime
+			}
+			if s, ok := meta["sender"]; ok {
+				sender = s
+			}
+		}
+
+		if audioURL == "" && message != "" {
+			audioURL = message
+			message = ""
+		}
+
+		if audioURL == "" {
+			if i.config.FallbackToVoice {
+				meta["stt_error"] = "no audio data"
+			}
+			return handler(ctx, sessionID, message, meta)
+		}
+
+		req := &STTTranscribeRequest{
+			AudioURL:  audioURL,
+			AudioMIME: audioMIME,
+			Channel:   channel,
+			Sender:    sender,
+			Language:  i.config.DefaultLang,
+			Provider:  i.config.Provider,
+			Metadata:  map[string]any{},
+		}
+
+		for k, v := range meta {
+			req.Metadata[k] = v
+		}
+
+		for _, hook := range i.hooks {
+			if err := hook.OnBeforeSTT(ctx, req); err != nil {
+				if i.config.FallbackToVoice {
+					meta["stt_error"] = err.Error()
+					return handler(ctx, sessionID, message, meta)
+				}
+				return sessionID, "", fmt.Errorf("stt-integration: before hook failed: %w", err)
+			}
+		}
+
+		result, err := i.pipeline.Transcribe(ctx, req)
+		if err != nil {
+			if i.config.FallbackToVoice {
+				meta["stt_error"] = err.Error()
+				return handler(ctx, sessionID, message, meta)
+			}
+			return sessionID, "", fmt.Errorf("stt-integration: transcription failed: %w", err)
+		}
+
+		for _, hook := range i.hooks {
+			if err := hook.OnAfterSTT(ctx, result); err != nil {
+				return sessionID, "", fmt.Errorf("stt-integration: after hook failed: %w", err)
+			}
+		}
+
+		transcribedText := result.Text
+		if transcribedText == "" {
+			if i.config.FallbackToVoice {
+				return handler(ctx, sessionID, message, meta)
+			}
+			return sessionID, "", fmt.Errorf("stt-integration: empty transcription result")
+		}
+
+		meta["stt_language"] = result.Language
+		meta["stt_confidence"] = fmt.Sprintf("%.2f", result.Confidence)
+		meta["stt_duration"] = result.Duration.String()
+		meta["message_type"] = "text"
+
+		if i.config.AppendTranscript && message != "" {
+			transcribedText = message + " " + transcribedText
+		}
+
+		return handler(ctx, sessionID, transcribedText, meta)
+	}
+}
+
+func (i *STTIntegration) ProcessVoiceMessage(ctx context.Context, channel string, sender string, audioURL string, audioMIME string, metadata map[string]string) (*TranscriptResult, error) {
+	i.mu.RLock()
+	provider := i.config.Provider
+	defaultLang := i.config.DefaultLang
+	enabled := i.config.Enabled
+	i.mu.RUnlock()
+
+	if !enabled {
+		return nil, fmt.Errorf("stt-integration: integration is disabled")
+	}
+
+	req := &STTTranscribeRequest{
+		AudioURL:  audioURL,
+		AudioMIME: audioMIME,
+		Channel:   channel,
+		Sender:    sender,
+		Language:  defaultLang,
+		Provider:  provider,
+		Metadata:  make(map[string]any),
+	}
+
+	for k, v := range metadata {
+		req.Metadata[k] = v
+	}
+
+	for _, hook := range i.hooks {
+		if err := hook.OnBeforeSTT(ctx, req); err != nil {
+			return nil, fmt.Errorf("stt-integration: before hook failed: %w", err)
+		}
+	}
+
+	result, err := i.pipeline.Transcribe(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("stt-integration: transcription failed: %w", err)
+	}
+
+	for _, hook := range i.hooks {
+		if err := hook.OnAfterSTT(ctx, result); err != nil {
+			return nil, fmt.Errorf("stt-integration: after hook failed: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
+func (i *STTIntegration) ProcessVoiceData(ctx context.Context, channel string, sender string, audioData []byte, audioMIME string, metadata map[string]string) (*TranscriptResult, error) {
+	i.mu.RLock()
+	provider := i.config.Provider
+	defaultLang := i.config.DefaultLang
+	enabled := i.config.Enabled
+	i.mu.RUnlock()
+
+	if !enabled {
+		return nil, fmt.Errorf("stt-integration: integration is disabled")
+	}
+
+	req := &STTTranscribeRequest{
+		AudioData: audioData,
+		AudioMIME: audioMIME,
+		Channel:   channel,
+		Sender:    sender,
+		Language:  defaultLang,
+		Provider:  provider,
+		Metadata:  make(map[string]any),
+	}
+
+	for k, v := range metadata {
+		req.Metadata[k] = v
+	}
+
+	for _, hook := range i.hooks {
+		if err := hook.OnBeforeSTT(ctx, req); err != nil {
+			return nil, fmt.Errorf("stt-integration: before hook failed: %w", err)
+		}
+	}
+
+	result, err := i.pipeline.Transcribe(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("stt-integration: transcription failed: %w", err)
+	}
+
+	for _, hook := range i.hooks {
+		if err := hook.OnAfterSTT(ctx, result); err != nil {
+			return nil, fmt.Errorf("stt-integration: after hook failed: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
+func (i *STTIntegration) UpdateConfig(cfg STTIntegrationConfig) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.config = cfg
+}
+
+func (i *STTIntegration) Config() STTIntegrationConfig {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.config
+}
+
+func (i *STTIntegration) EnableAutoSTT() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.config.AutoSTT = true
+}
+
+func (i *STTIntegration) DisableAutoSTT() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.config.AutoSTT = false
+}
+
+func (i *STTIntegration) SetTriggerPrefix(prefix string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.config.TriggerPrefix = prefix
+}
+
+func (i *STTIntegration) AllowChannel(channel string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.config.Channels == nil {
+		i.config.Channels = make(map[string]bool)
+	}
+	i.config.Channels[channel] = true
+}
+
+func (i *STTIntegration) ExcludeChannel(channel string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.config.ExcludeChannels == nil {
+		i.config.ExcludeChannels = make(map[string]bool)
+	}
+	i.config.ExcludeChannels[channel] = true
+}
+
+type STTTranscriptResult struct {
+	Text       string  `json:"text"`
+	Language   string  `json:"language"`
+	Duration   string  `json:"duration"`
+	Confidence float64 `json:"confidence"`
+	Words      []Word  `json:"words,omitempty"`
+}
+
+type Word struct {
+	Text       string  `json:"text"`
+	StartTime  string  `json:"start_time"`
+	EndTime    string  `json:"end_time"`
+	Confidence float64 `json:"confidence"`
+}
+
+func TranscriptToJSON(result *TranscriptResult) STTTranscriptResult {
+	out := STTTranscriptResult{
+		Text:       result.Text,
+		Language:   result.Language,
+		Duration:   result.Duration.String(),
+		Confidence: result.Confidence,
+	}
+
+	if len(result.Words) > 0 {
+		out.Words = make([]Word, 0, len(result.Words))
+		for _, w := range result.Words {
+			out.Words = append(out.Words, Word{
+				Text:       w.Word,
+				StartTime:  w.StartTime.String(),
+				EndTime:    w.EndTime.String(),
+				Confidence: w.Confidence,
+			})
+		}
+	}
+
+	return out
+}
+
+func TranscriptToJSONString(result *TranscriptResult) (string, error) {
+	out := TranscriptToJSON(result)
+	data, err := json.Marshal(out)
+	if err != nil {
+		return "", fmt.Errorf("stt-integration: failed to marshal transcript: %w", err)
+	}
+	return string(data), nil
+}

--- a/pkg/speech/stt_manager.go
+++ b/pkg/speech/stt_manager.go
@@ -1,0 +1,175 @@
+package speech
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+type STTManager struct {
+	mu          sync.RWMutex
+	providers   map[string]STTProvider
+	defaultName string
+}
+
+type STTManagerOption func(*STTManager)
+
+func WithSTTManagerProvider(name string, provider STTProvider) STTManagerOption {
+	return func(m *STTManager) {
+		m.providers[name] = provider
+		if m.defaultName == "" {
+			m.defaultName = name
+		}
+	}
+}
+
+func WithSTTManagerDefault(name string) STTManagerOption {
+	return func(m *STTManager) {
+		m.defaultName = name
+	}
+}
+
+func NewSTTManager(opts ...STTManagerOption) *STTManager {
+	m := &STTManager{
+		providers: make(map[string]STTProvider),
+	}
+
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	return m
+}
+
+func (m *STTManager) Register(name string, provider STTProvider) error {
+	if name == "" {
+		return fmt.Errorf("stt: provider name cannot be empty")
+	}
+	if provider == nil {
+		return fmt.Errorf("stt: provider cannot be nil")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.providers[name]; exists {
+		return fmt.Errorf("stt: provider already registered: %s", name)
+	}
+
+	m.providers[name] = provider
+
+	if m.defaultName == "" {
+		m.defaultName = name
+	}
+
+	return nil
+}
+
+func (m *STTManager) Get(name string) (STTProvider, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	provider, ok := m.providers[name]
+	if !ok {
+		return nil, fmt.Errorf("stt: provider not found: %s", name)
+	}
+
+	return provider, nil
+}
+
+func (m *STTManager) GetDefault() (STTProvider, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.defaultName == "" {
+		return nil, fmt.Errorf("stt: no default provider configured")
+	}
+
+	provider, ok := m.providers[m.defaultName]
+	if !ok {
+		return nil, fmt.Errorf("stt: default provider not found: %s", m.defaultName)
+	}
+
+	return provider, nil
+}
+
+func (m *STTManager) SetDefault(name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.providers[name]; !ok {
+		return fmt.Errorf("stt: provider not found: %s", name)
+	}
+
+	m.defaultName = name
+	return nil
+}
+
+func (m *STTManager) Transcribe(ctx context.Context, audio []byte, provider string, opts ...TranscribeOption) (*TranscriptResult, error) {
+	var p STTProvider
+	var err error
+
+	if provider != "" {
+		p, err = m.Get(provider)
+	} else {
+		p, err = m.GetDefault()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return p.Transcribe(ctx, audio, opts...)
+}
+
+func (m *STTManager) ListLanguages(ctx context.Context, provider string) ([]string, error) {
+	var p STTProvider
+	var err error
+
+	if provider != "" {
+		p, err = m.Get(provider)
+	} else {
+		p, err = m.GetDefault()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return p.ListLanguages(ctx)
+}
+
+func (m *STTManager) ListProviders() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	names := make([]string, 0, len(m.providers))
+	for name := range m.providers {
+		names = append(names, name)
+	}
+
+	return names
+}
+
+func (m *STTManager) Remove(name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.providers[name]; !ok {
+		return fmt.Errorf("stt: provider not found: %s", name)
+	}
+
+	delete(m.providers, name)
+
+	if m.defaultName == name {
+		m.defaultName = ""
+		if len(m.providers) > 0 {
+			for n := range m.providers {
+				m.defaultName = n
+				break
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/speech/stt_pipeline.go
+++ b/pkg/speech/stt_pipeline.go
@@ -1,0 +1,267 @@
+package speech
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+type STTPipeline struct {
+	mu            sync.RWMutex
+	manager       *STTManager
+	provider      string
+	defaultLang   string
+	autoDetect    bool
+	maxDuration   time.Duration
+	minConfidence float64
+	timeout       time.Duration
+	hooks         []STTPipelineHook
+	httpClient    *http.Client
+}
+
+type STTPipelineConfig struct {
+	Provider      string
+	DefaultLang   string
+	AutoDetect    bool
+	MaxDuration   time.Duration
+	MinConfidence float64
+	Timeout       time.Duration
+}
+
+func DefaultSTTPipelineConfig() STTPipelineConfig {
+	return STTPipelineConfig{
+		Provider:      "",
+		DefaultLang:   "auto",
+		AutoDetect:    true,
+		MaxDuration:   10 * time.Minute,
+		MinConfidence: 0.0,
+		Timeout:       120 * time.Second,
+	}
+}
+
+type STTPipelineHook interface {
+	OnBeforeTranscribe(ctx context.Context, req *STTTranscribeRequest) error
+	OnAfterTranscribe(ctx context.Context, result *TranscriptResult) error
+	OnTranscriptionError(ctx context.Context, err error, audioSource string)
+}
+
+type STTTranscribeRequest struct {
+	AudioData []byte
+	AudioURL  string
+	AudioMIME string
+	Channel   string
+	Sender    string
+	Language  string
+	Provider  string
+	Metadata  map[string]any
+}
+
+func NewSTTPipeline(manager *STTManager, cfg STTPipelineConfig) *STTPipeline {
+	return &STTPipeline{
+		manager:       manager,
+		provider:      cfg.Provider,
+		defaultLang:   cfg.DefaultLang,
+		autoDetect:    cfg.AutoDetect,
+		maxDuration:   cfg.MaxDuration,
+		minConfidence: cfg.MinConfidence,
+		timeout:       cfg.Timeout,
+		httpClient:    &http.Client{Timeout: cfg.Timeout},
+	}
+}
+
+func (p *STTPipeline) RegisterHook(hook STTPipelineHook) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.hooks = append(p.hooks, hook)
+}
+
+func (p *STTPipeline) Transcribe(ctx context.Context, req *STTTranscribeRequest) (*TranscriptResult, error) {
+	p.mu.RLock()
+	provider := p.provider
+	defaultLang := p.defaultLang
+	minConfidence := p.minConfidence
+	timeout := p.timeout
+	hooks := make([]STTPipelineHook, len(p.hooks))
+	copy(hooks, p.hooks)
+	p.mu.RUnlock()
+
+	if req.AudioData == nil && req.AudioURL == "" {
+		return nil, NewSTTError(ErrAudioFormatInvalid, "stt-pipeline: no audio data or URL provided")
+	}
+
+	audioData := req.AudioData
+	if audioData == nil && req.AudioURL != "" {
+		var err error
+		audioData, err = p.downloadAudio(ctx, req.AudioURL)
+		if err != nil {
+			for _, hook := range hooks {
+				hook.OnTranscriptionError(ctx, err, req.AudioURL)
+			}
+			return nil, NewSTTErrorf(ErrTranscriptionFailed, "stt-pipeline: failed to download audio: %v", err)
+		}
+	}
+
+	if len(audioData) == 0 {
+		return nil, NewSTTError(ErrAudioFormatInvalid, "stt-pipeline: downloaded audio data is empty")
+	}
+
+	for _, hook := range hooks {
+		if err := hook.OnBeforeTranscribe(ctx, req); err != nil {
+			return nil, fmt.Errorf("stt-pipeline: before transcribe hook failed: %w", err)
+		}
+	}
+
+	transcribeCtx := ctx
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		transcribeCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	var opts []TranscribeOption
+
+	lang := req.Language
+	if lang == "" {
+		lang = defaultLang
+	}
+	if lang != "" && lang != "auto" {
+		opts = append(opts, WithSTTLanguage(lang))
+	}
+
+	if req.AudioMIME != "" {
+		format := p.mimeToFormat(req.AudioMIME)
+		if format != "" {
+			opts = append(opts, WithSTTInputFormat(format))
+		}
+	}
+
+	var result *TranscriptResult
+	var err error
+
+	if provider != "" {
+		result, err = p.manager.Transcribe(transcribeCtx, audioData, provider, opts...)
+	} else {
+		result, err = p.manager.Transcribe(transcribeCtx, audioData, "", opts...)
+	}
+
+	if err != nil {
+		audioSource := req.AudioURL
+		if audioSource == "" {
+			audioSource = fmt.Sprintf("%d bytes", len(audioData))
+		}
+		for _, hook := range hooks {
+			hook.OnTranscriptionError(ctx, err, audioSource)
+		}
+		return nil, fmt.Errorf("stt-pipeline: transcription failed: %w", err)
+	}
+
+	if minConfidence > 0 && result.Confidence > 0 && result.Confidence < minConfidence {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "stt-pipeline: confidence %.2f below threshold %.2f", result.Confidence, minConfidence)
+	}
+
+	for _, hook := range hooks {
+		if err := hook.OnAfterTranscribe(ctx, result); err != nil {
+			return nil, fmt.Errorf("stt-pipeline: after transcribe hook failed: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
+func (p *STTPipeline) TranscribeDirect(ctx context.Context, audio []byte, opts ...TranscribeOption) (*TranscriptResult, error) {
+	req := &STTTranscribeRequest{
+		AudioData: audio,
+	}
+	return p.Transcribe(ctx, req)
+}
+
+func (p *STTPipeline) downloadAudio(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("stt-pipeline: failed to create request: %w", err)
+	}
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("stt-pipeline: failed to download audio: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("stt-pipeline: download failed with status %d", resp.StatusCode)
+	}
+
+	const maxAudioSize = 100 * 1024 * 1024
+	if resp.ContentLength > maxAudioSize {
+		return nil, fmt.Errorf("stt-pipeline: audio too large: %d bytes", resp.ContentLength)
+	}
+
+	audioData := make([]byte, 0, 4096)
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := resp.Body.Read(buf)
+		if n > 0 {
+			if len(audioData)+n > maxAudioSize {
+				return nil, fmt.Errorf("stt-pipeline: audio exceeds size limit during download")
+			}
+			audioData = append(audioData, buf[:n]...)
+		}
+		if err != nil {
+			break
+		}
+	}
+
+	return audioData, nil
+}
+
+func (p *STTPipeline) mimeToFormat(mime string) AudioInputFormat {
+	mime = strings.ToLower(strings.TrimSpace(mime))
+	switch {
+	case strings.Contains(mime, "mp3"), strings.Contains(mime, "mpeg"):
+		return InputMP3
+	case strings.Contains(mime, "wav"):
+		return InputWAV
+	case strings.Contains(mime, "ogg"):
+		return InputOGG
+	case strings.Contains(mime, "flac"):
+		return InputFLAC
+	case strings.Contains(mime, "m4a"):
+		return InputM4A
+	case strings.Contains(mime, "mp4"):
+		return InputMP4
+	case strings.Contains(mime, "webm"):
+		return InputWEBM
+	case strings.Contains(mime, "opus"):
+		return InputOGG
+	default:
+		return ""
+	}
+}
+
+func (p *STTPipeline) UpdateConfig(cfg STTPipelineConfig) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.provider = cfg.Provider
+	p.defaultLang = cfg.DefaultLang
+	p.autoDetect = cfg.AutoDetect
+	p.maxDuration = cfg.MaxDuration
+	p.minConfidence = cfg.MinConfidence
+	p.timeout = cfg.Timeout
+	p.httpClient.Timeout = cfg.Timeout
+}
+
+func (p *STTPipeline) Config() STTPipelineConfig {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return STTPipelineConfig{
+		Provider:      p.provider,
+		DefaultLang:   p.defaultLang,
+		AutoDetect:    p.autoDetect,
+		MaxDuration:   p.maxDuration,
+		MinConfidence: p.minConfidence,
+		Timeout:       p.timeout,
+	}
+}

--- a/pkg/speech/stt_provider.go
+++ b/pkg/speech/stt_provider.go
@@ -1,0 +1,245 @@
+package speech
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+type STTProviderType string
+
+const (
+	STTProviderOpenAI        STTProviderType = "openai"
+	STTProviderAzure         STTProviderType = "azure"
+	STTProviderGoogle        STTProviderType = "google"
+	STTProviderDeepgram      STTProviderType = "deepgram"
+	STTProviderAssemblyAI    STTProviderType = "assemblyai"
+	STTProviderWhisperCPP    STTProviderType = "whisper.cpp"
+	STTProviderVosk          STTProviderType = "vosk"
+	STTProviderFasterWhisper STTProviderType = "faster-whisper"
+	STTProviderCustom        STTProviderType = "custom"
+)
+
+type AudioInputFormat string
+
+const (
+	InputMP3  AudioInputFormat = "mp3"
+	InputWAV  AudioInputFormat = "wav"
+	InputOGG  AudioInputFormat = "ogg"
+	InputFLAC AudioInputFormat = "flac"
+	InputPCM  AudioInputFormat = "pcm"
+	InputM4A  AudioInputFormat = "m4a"
+	InputMP4  AudioInputFormat = "mp4"
+	InputMPEG AudioInputFormat = "mpeg"
+	InputMPGA AudioInputFormat = "mpga"
+	InputWEBM AudioInputFormat = "webm"
+)
+
+type STTProvider interface {
+	Name() string
+	Type() STTProviderType
+	Transcribe(ctx context.Context, audio []byte, opts ...TranscribeOption) (*TranscriptResult, error)
+	ListLanguages(ctx context.Context) ([]string, error)
+}
+
+type STTConfig struct {
+	Type       STTProviderType
+	APIKey     string
+	BaseURL    string
+	Model      string
+	Language   string
+	SampleRate int
+	Timeout    time.Duration
+}
+
+func NewSTTProvider(cfg STTConfig) (STTProvider, error) {
+	switch cfg.Type {
+	case STTProviderOpenAI:
+		opts := []WhisperOption{}
+		if cfg.BaseURL != "" {
+			opts = append(opts, WithWhisperBaseURL(cfg.BaseURL))
+		}
+		if cfg.Model != "" {
+			opts = append(opts, WithWhisperModel(WhisperModel(cfg.Model)))
+		}
+		if cfg.Language != "" {
+			opts = append(opts, WithWhisperLanguage(cfg.Language))
+		}
+		if cfg.Timeout > 0 {
+			opts = append(opts, WithWhisperTimeout(cfg.Timeout))
+		}
+		return NewWhisperProvider(cfg.APIKey, opts...)
+	case STTProviderGoogle:
+		opts := []GoogleOption{}
+		if cfg.BaseURL != "" {
+			opts = append(opts, WithGoogleBaseURL(cfg.BaseURL))
+		}
+		if cfg.Language != "" {
+			opts = append(opts, WithGoogleLanguageCode(cfg.Language))
+		}
+		if cfg.Timeout > 0 {
+			opts = append(opts, WithGoogleTimeout(cfg.Timeout))
+		}
+		return NewGoogleProvider(cfg.APIKey, opts...)
+	case STTProviderWhisperCPP:
+		opts := []WhisperCPPOption{}
+		if cfg.Model != "" {
+			opts = append(opts, WithWhisperCPPModelPath(cfg.Model))
+		}
+		if cfg.Language != "" {
+			opts = append(opts, WithWhisperCPPLanguage(cfg.Language))
+		}
+		if cfg.Timeout > 0 {
+			opts = append(opts, WithWhisperCPPTimeout(cfg.Timeout))
+		}
+		return NewWhisperCPPProvider(opts...)
+	default:
+		return nil, NewSTTError(ErrProviderNotSupported, "unknown STT provider: "+string(cfg.Type))
+	}
+}
+
+type TranscribeMode string
+
+const (
+	ModeTranscription TranscribeMode = "transcription"
+	ModeTranslation   TranscribeMode = "translation"
+)
+
+type TranscribeOptions struct {
+	Language        string
+	Model           string
+	Prompt          string
+	Temperature     float64
+	Mode            TranscribeMode
+	InputFormat     AudioInputFormat
+	SampleRate      int
+	WordTimestamps  bool
+	SpeakerLabels   bool
+	MaxAlternatives int
+}
+
+type TranscribeOption func(*TranscribeOptions)
+
+func WithSTTLanguage(lang string) TranscribeOption {
+	return func(o *TranscribeOptions) {
+		o.Language = lang
+	}
+}
+
+func WithSTTModel(model string) TranscribeOption {
+	return func(o *TranscribeOptions) {
+		o.Model = model
+	}
+}
+
+func WithSTTPrompt(prompt string) TranscribeOption {
+	return func(o *TranscribeOptions) {
+		o.Prompt = prompt
+	}
+}
+
+func WithSTTTemperature(temp float64) TranscribeOption {
+	return func(o *TranscribeOptions) {
+		o.Temperature = temp
+	}
+}
+
+func WithSTTMode(mode TranscribeMode) TranscribeOption {
+	return func(o *TranscribeOptions) {
+		o.Mode = mode
+	}
+}
+
+func WithSTTInputFormat(format AudioInputFormat) TranscribeOption {
+	return func(o *TranscribeOptions) {
+		o.InputFormat = format
+	}
+}
+
+func WithSTTSampleRate(rate int) TranscribeOption {
+	return func(o *TranscribeOptions) {
+		o.SampleRate = rate
+	}
+}
+
+func WithSTTWordTimestamps(enabled bool) TranscribeOption {
+	return func(o *TranscribeOptions) {
+		o.WordTimestamps = enabled
+	}
+}
+
+func WithSTTSpeakerLabels(enabled bool) TranscribeOption {
+	return func(o *TranscribeOptions) {
+		o.SpeakerLabels = enabled
+	}
+}
+
+func WithSTTMaxAlternatives(n int) TranscribeOption {
+	return func(o *TranscribeOptions) {
+		o.MaxAlternatives = n
+	}
+}
+
+type WordInfo struct {
+	Word       string
+	StartTime  time.Duration
+	EndTime    time.Duration
+	Confidence float64
+}
+
+type SegmentInfo struct {
+	ID         int
+	Text       string
+	StartTime  time.Duration
+	EndTime    time.Duration
+	Confidence float64
+	Speaker    string
+	Words      []WordInfo
+}
+
+type TranscriptResult struct {
+	Text         string
+	Language     string
+	Duration     time.Duration
+	Confidence   float64
+	Segments     []SegmentInfo
+	Words        []WordInfo
+	Alternatives []string
+}
+
+type STTErrorCode string
+
+const (
+	ErrProviderNotSupported STTErrorCode = "provider_not_supported"
+	ErrAudioFormatInvalid   STTErrorCode = "audio_format_invalid"
+	ErrTranscriptionFailed  STTErrorCode = "transcription_failed"
+	ErrAudioTooLong         STTErrorCode = "audio_too_long"
+	ErrAudioTooLarge        STTErrorCode = "audio_too_large"
+	ErrRateLimited          STTErrorCode = "rate_limited"
+	ErrAuthentication       STTErrorCode = "authentication_failed"
+)
+
+type STTError struct {
+	Code    STTErrorCode
+	Message string
+	Err     error
+}
+
+func NewSTTError(code STTErrorCode, message string) *STTError {
+	return &STTError{Code: code, Message: message}
+}
+
+func NewSTTErrorf(code STTErrorCode, format string, args ...interface{}) *STTError {
+	return &STTError{Code: code, Message: fmt.Sprintf(format, args...)}
+}
+
+func (e *STTError) Error() string {
+	if e.Err != nil {
+		return string(e.Code) + ": " + e.Message + ": " + e.Err.Error()
+	}
+	return string(e.Code) + ": " + e.Message
+}
+
+func (e *STTError) Unwrap() error {
+	return e.Err
+}

--- a/pkg/speech/stt_whisper.go
+++ b/pkg/speech/stt_whisper.go
@@ -1,0 +1,644 @@
+package speech
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type WhisperModel string
+
+const (
+	WhisperModelV1 WhisperModel = "whisper-1"
+)
+
+var validWhisperModels = map[WhisperModel]bool{
+	WhisperModelV1: true,
+}
+
+var validInputFormats = map[AudioInputFormat]bool{
+	InputMP3:  true,
+	InputWAV:  true,
+	InputOGG:  true,
+	InputFLAC: true,
+	InputM4A:  true,
+	InputMP4:  true,
+	InputMPEG: true,
+	InputMPGA: true,
+	InputWEBM: true,
+}
+
+type WhisperProvider struct {
+	apiKey        string
+	baseURL       string
+	model         WhisperModel
+	language      string
+	timeout       time.Duration
+	retries       int
+	client        *http.Client
+	httpTransport *http.Transport
+}
+
+type WhisperOption func(*WhisperProvider)
+
+func WithWhisperBaseURL(url string) WhisperOption {
+	return func(p *WhisperProvider) {
+		p.baseURL = strings.TrimRight(url, "/")
+	}
+}
+
+func WithWhisperModel(model WhisperModel) WhisperOption {
+	return func(p *WhisperProvider) {
+		p.model = model
+	}
+}
+
+func WithWhisperLanguage(lang string) WhisperOption {
+	return func(p *WhisperProvider) {
+		p.language = lang
+	}
+}
+
+func WithWhisperTimeout(timeout time.Duration) WhisperOption {
+	return func(p *WhisperProvider) {
+		p.timeout = timeout
+	}
+}
+
+func WithWhisperRetries(retries int) WhisperOption {
+	return func(p *WhisperProvider) {
+		p.retries = retries
+	}
+}
+
+func WithWhisperHTTPTransport(transport *http.Transport) WhisperOption {
+	return func(p *WhisperProvider) {
+		p.httpTransport = transport
+	}
+}
+
+func NewWhisperProvider(apiKey string, opts ...WhisperOption) (*WhisperProvider, error) {
+	if apiKey == "" {
+		return nil, NewSTTError(ErrAuthentication, "openai: API key is required")
+	}
+
+	p := &WhisperProvider{
+		apiKey:  apiKey,
+		baseURL: "https://api.openai.com",
+		model:   WhisperModelV1,
+		timeout: 120 * time.Second,
+		retries: 2,
+		client:  &http.Client{Timeout: 120 * time.Second},
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	if p.httpTransport != nil {
+		p.client.Transport = p.httpTransport
+	}
+	p.client.Timeout = p.timeout
+
+	if !validWhisperModels[p.model] {
+		return nil, NewSTTErrorf(ErrProviderNotSupported, "openai: invalid whisper model: %s", p.model)
+	}
+
+	return p, nil
+}
+
+func (p *WhisperProvider) Name() string {
+	return "openai-whisper"
+}
+
+func (p *WhisperProvider) Type() STTProviderType {
+	return STTProviderOpenAI
+}
+
+func (p *WhisperProvider) Transcribe(ctx context.Context, audio []byte, opts ...TranscribeOption) (*TranscriptResult, error) {
+	options := TranscribeOptions{
+		Model:       string(p.model),
+		Language:    p.language,
+		Temperature: 0,
+		Mode:        ModeTranscription,
+		InputFormat: InputMP3,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	if err := p.validateTranscribeOptions(options); err != nil {
+		return nil, err
+	}
+
+	if len(audio) == 0 {
+		return nil, NewSTTError(ErrAudioFormatInvalid, "openai-whisper: audio data is empty")
+	}
+
+	const maxAudioSize = 25 * 1024 * 1024
+	if len(audio) > maxAudioSize {
+		return nil, NewSTTErrorf(ErrAudioTooLarge, "openai-whisper: audio exceeds 25MB limit (%d bytes)", len(audio))
+	}
+
+	if !validInputFormats[options.InputFormat] {
+		return nil, NewSTTErrorf(ErrAudioFormatInvalid, "openai-whisper: unsupported input format: %s", options.InputFormat)
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= p.retries; attempt++ {
+		if attempt > 0 {
+			backoff := time.Duration(attempt) * time.Second
+			select {
+			case <-ctx.Done():
+				return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: context cancelled during retry: %v", ctx.Err())
+			case <-time.After(backoff):
+			}
+		}
+
+		result, err := p.doTranscribe(ctx, audio, options)
+		if err == nil {
+			return result, nil
+		}
+
+		lastErr = err
+
+		if sttErr, ok := err.(*STTError); ok {
+			if sttErr.Code == ErrAuthentication || sttErr.Code == ErrAudioFormatInvalid || sttErr.Code == ErrAudioTooLarge || sttErr.Code == ErrRateLimited {
+				return nil, err
+			}
+		}
+	}
+
+	return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: all %d retries failed: %v", p.retries, lastErr)
+}
+
+func (p *WhisperProvider) TranscribeFile(ctx context.Context, filePath string, opts ...TranscribeOption) (*TranscriptResult, error) {
+	if filePath == "" {
+		return nil, NewSTTError(ErrAudioFormatInvalid, "openai-whisper: file path is empty")
+	}
+
+	info, err := os.Stat(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, NewSTTErrorf(ErrAudioFormatInvalid, "openai-whisper: file not found: %s", filePath)
+		}
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to stat file: %v", err)
+	}
+
+	const maxAudioSize = 25 * 1024 * 1024
+	if info.Size() > maxAudioSize {
+		return nil, NewSTTErrorf(ErrAudioTooLarge, "openai-whisper: file exceeds 25MB limit (%d bytes)", info.Size())
+	}
+
+	audio, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to read file: %v", err)
+	}
+
+	if len(opts) == 0 || anyInputFormatNotSet(opts) {
+		ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(filePath)), ".")
+		if ext != "" {
+			formatOpts := append([]TranscribeOption{WithSTTInputFormat(AudioInputFormat(ext))}, opts...)
+			return p.Transcribe(ctx, audio, formatOpts...)
+		}
+	}
+
+	return p.Transcribe(ctx, audio, opts...)
+}
+
+func anyInputFormatNotSet(opts []TranscribeOption) bool {
+	for _, opt := range opts {
+		o := &TranscribeOptions{}
+		opt(o)
+		if o.InputFormat != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func (p *WhisperProvider) TranscribeStream(ctx context.Context, reader io.Reader, opts ...TranscribeOption) (*TranscriptResult, error) {
+	if reader == nil {
+		return nil, NewSTTError(ErrAudioFormatInvalid, "openai-whisper: reader is nil")
+	}
+
+	audio, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to read stream: %v", err)
+	}
+
+	return p.Transcribe(ctx, audio, opts...)
+}
+
+func (p *WhisperProvider) validateTranscribeOptions(options TranscribeOptions) error {
+	if options.Temperature < 0 || options.Temperature > 1 {
+		return NewSTTErrorf(ErrAudioFormatInvalid, "openai-whisper: temperature must be between 0 and 1, got: %f", options.Temperature)
+	}
+
+	if options.MaxAlternatives < 0 {
+		return NewSTTErrorf(ErrAudioFormatInvalid, "openai-whisper: maxAlternatives cannot be negative")
+	}
+
+	if options.Model == "" {
+		return NewSTTError(ErrAudioFormatInvalid, "openai-whisper: model is required")
+	}
+
+	return nil
+}
+
+func (p *WhisperProvider) doTranscribe(ctx context.Context, audio []byte, options TranscribeOptions) (*TranscriptResult, error) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	filename := "audio." + string(options.InputFormat)
+	part, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to create form file: %v", err)
+	}
+
+	if _, err := part.Write(audio); err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to write audio data: %v", err)
+	}
+
+	if err := writer.WriteField("model", options.Model); err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to write model field: %v", err)
+	}
+
+	if options.Language != "" {
+		if err := writer.WriteField("language", options.Language); err != nil {
+			return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to write language field: %v", err)
+		}
+	}
+
+	if options.Prompt != "" {
+		if err := writer.WriteField("prompt", options.Prompt); err != nil {
+			return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to write prompt field: %v", err)
+		}
+	}
+
+	if options.Temperature > 0 {
+		if err := writer.WriteField("temperature", fmt.Sprintf("%.2f", options.Temperature)); err != nil {
+			return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to write temperature field: %v", err)
+		}
+	}
+
+	if options.MaxAlternatives > 0 {
+		if err := writer.WriteField("max_alternatives", fmt.Sprintf("%d", options.MaxAlternatives)); err != nil {
+			return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to write max_alternatives field: %v", err)
+		}
+	}
+
+	if options.WordTimestamps || options.SpeakerLabels {
+		if options.WordTimestamps {
+			if err := writer.WriteField("timestamp_granularities[]", "word"); err != nil {
+				return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to write word timestamp_granularities: %v", err)
+			}
+		}
+		if options.SpeakerLabels {
+			if err := writer.WriteField("timestamp_granularities[]", "segment"); err != nil {
+				return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to write segment timestamp_granularities: %v", err)
+			}
+		}
+	}
+
+	responseType := "verbose_json"
+	if options.WordTimestamps || options.SpeakerLabels {
+		responseType = "verbose_json"
+	}
+	if err := writer.WriteField("response_format", responseType); err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to write response_format field: %v", err)
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to close multipart writer: %v", err)
+	}
+
+	var endpoint string
+	switch options.Mode {
+	case ModeTranslation:
+		endpoint = "/v1/audio/translations"
+	default:
+		endpoint = "/v1/audio/transcriptions"
+	}
+
+	url := p.baseURL + endpoint
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, &body)
+	if err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to create request: %v", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("User-Agent", "anyclaw-stt/1.0")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, p.handleErrorResponse(resp.StatusCode, respBody)
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to read response: %v", err)
+	}
+
+	return p.parseResponse(respBody, options)
+}
+
+func (p *WhisperProvider) handleErrorResponse(statusCode int, body []byte) error {
+	var errResp whisperErrorResponse
+	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Error.Message != "" {
+		msg := fmt.Sprintf("openai-whisper: API error: %s (type: %s, code: %s)",
+			errResp.Error.Message, errResp.Error.Type, errResp.Error.Code)
+		switch statusCode {
+		case http.StatusUnauthorized:
+			return NewSTTError(ErrAuthentication, msg)
+		case http.StatusTooManyRequests:
+			return NewSTTError(ErrRateLimited, msg)
+		case http.StatusBadRequest:
+			return NewSTTError(ErrAudioFormatInvalid, msg)
+		default:
+			return NewSTTError(ErrTranscriptionFailed, msg)
+		}
+	}
+
+	switch statusCode {
+	case http.StatusUnauthorized:
+		return NewSTTError(ErrAuthentication, fmt.Sprintf("openai-whisper: authentication failed: %s", string(body)))
+	case http.StatusTooManyRequests:
+		return NewSTTError(ErrRateLimited, fmt.Sprintf("openai-whisper: rate limited: %s", string(body)))
+	case http.StatusBadRequest:
+		return NewSTTErrorf(ErrAudioFormatInvalid, "openai-whisper: invalid request: %s", string(body))
+	case http.StatusServiceUnavailable:
+		return NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: service unavailable: %s", string(body))
+	default:
+		return NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: unexpected status %d: %s", statusCode, string(body))
+	}
+}
+
+type whisperResponse struct {
+	Text     string  `json:"text"`
+	Language string  `json:"language"`
+	Duration float64 `json:"duration,omitempty"`
+	Segments []struct {
+		ID           int     `json:"id"`
+		Seek         int     `json:"seek"`
+		Start        float64 `json:"start"`
+		End          float64 `json:"end"`
+		Text         string  `json:"text"`
+		Tokens       []int   `json:"tokens"`
+		Temperature  float64 `json:"temperature"`
+		AvgLogProb   float64 `json:"avg_logprob"`
+		Compression  float64 `json:"compression_ratio"`
+		NoSpeechProb float64 `json:"no_speech_prob"`
+		Words        []struct {
+			Word       string  `json:"word"`
+			Start      float64 `json:"start"`
+			End        float64 `json:"end"`
+			Confidence float64 `json:"probability"`
+		} `json:"words,omitempty"`
+	} `json:"segments,omitempty"`
+	LanguageProbability float64 `json:"language_probability,omitempty"`
+}
+
+type whisperErrorResponse struct {
+	Error struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+		Code    string `json:"code"`
+	} `json:"error"`
+}
+
+func (p *WhisperProvider) parseResponse(body []byte, options TranscribeOptions) (*TranscriptResult, error) {
+	var resp whisperResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to parse JSON response: %v", err)
+	}
+
+	result := &TranscriptResult{
+		Text:       strings.TrimSpace(resp.Text),
+		Language:   resp.Language,
+		Duration:   time.Duration(resp.Duration * float64(time.Second)),
+		Confidence: resp.LanguageProbability,
+	}
+
+	if len(resp.Segments) > 0 {
+		result.Segments = make([]SegmentInfo, 0, len(resp.Segments))
+		for _, seg := range resp.Segments {
+			segment := SegmentInfo{
+				ID:        seg.ID,
+				Text:      seg.Text,
+				StartTime: time.Duration(seg.Start * float64(time.Second)),
+				EndTime:   time.Duration(seg.End * float64(time.Second)),
+			}
+
+			if seg.AvgLogProb != 0 {
+				segment.Confidence = normalizeLogProb(seg.AvgLogProb)
+			}
+
+			if len(seg.Words) > 0 {
+				segment.Words = make([]WordInfo, 0, len(seg.Words))
+				for _, w := range seg.Words {
+					segment.Words = append(segment.Words, WordInfo{
+						Word:       w.Word,
+						StartTime:  time.Duration(w.Start * float64(time.Second)),
+						EndTime:    time.Duration(w.End * float64(time.Second)),
+						Confidence: w.Confidence,
+					})
+				}
+			}
+
+			result.Segments = append(result.Segments, segment)
+		}
+
+		if len(result.Segments) > 0 && result.Confidence == 0 {
+			totalConfidence := 0.0
+			for _, seg := range result.Segments {
+				totalConfidence += seg.Confidence
+			}
+			result.Confidence = totalConfidence / float64(len(result.Segments))
+		}
+	}
+
+	if options.WordTimestamps && len(result.Segments) > 0 {
+		words := make([]WordInfo, 0)
+		for _, seg := range result.Segments {
+			words = append(words, seg.Words...)
+		}
+		result.Words = words
+	}
+
+	return result, nil
+}
+
+func normalizeLogProb(logProb float64) float64 {
+	if logProb > 0 {
+		return 1.0
+	}
+	prob := 1.0 / (1.0 + logProb*-1)
+	if prob < 0 {
+		return 0
+	}
+	if prob > 1 {
+		return 1
+	}
+	return prob
+}
+
+func (p *WhisperProvider) TranscribeSSE(ctx context.Context, audio []byte, onChunk func(chunk *TranscriptResult), opts ...TranscribeOption) error {
+	options := TranscribeOptions{
+		Model:       string(p.model),
+		Language:    p.language,
+		Temperature: 0,
+		Mode:        ModeTranscription,
+		InputFormat: InputMP3,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	if err := p.validateTranscribeOptions(options); err != nil {
+		return err
+	}
+
+	if len(audio) == 0 {
+		return NewSTTError(ErrAudioFormatInvalid, "openai-whisper: audio data is empty")
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	filename := "audio." + string(options.InputFormat)
+	part, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		return NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to create form file: %v", err)
+	}
+
+	if _, err := part.Write(audio); err != nil {
+		return NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to write audio data: %v", err)
+	}
+
+	if err := writer.WriteField("model", options.Model); err != nil {
+		return NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to write model field: %v", err)
+	}
+
+	if options.Language != "" {
+		if err := writer.WriteField("language", options.Language); err != nil {
+			return NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to write language field: %v", err)
+		}
+	}
+
+	if err := writer.WriteField("response_format", "json"); err != nil {
+		return NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to write response_format field: %v", err)
+	}
+
+	if err := writer.WriteField("stream", "true"); err != nil {
+		return NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to write stream field: %v", err)
+	}
+
+	if err := writer.Close(); err != nil {
+		return NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to close multipart writer: %v", err)
+	}
+
+	endpoint := "/v1/audio/transcriptions"
+	if options.Mode == ModeTranslation {
+		endpoint = "/v1/audio/translations"
+	}
+
+	url := p.baseURL + endpoint
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, &body)
+	if err != nil {
+		return NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: failed to create request: %v", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return NewSTTErrorf(ErrTranscriptionFailed, "openai-whisper: streaming request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return p.handleErrorResponse(resp.StatusCode, respBody)
+	}
+
+	return p.readSSEStream(resp.Body, onChunk)
+}
+
+func (p *WhisperProvider) readSSEStream(reader io.Reader, onChunk func(chunk *TranscriptResult)) error {
+	scanner := bufio.NewScanner(reader)
+	scanner.Split(bufio.ScanLines)
+
+	var currentText strings.Builder
+	var detectedLanguage string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if strings.HasPrefix(line, "data: ") {
+			data := strings.TrimPrefix(line, "data: ")
+			if data == "[DONE]" {
+				break
+			}
+
+			var chunk struct {
+				Text     string `json:"text"`
+				Language string `json:"language"`
+				Done     bool   `json:"done"`
+			}
+			if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+				continue
+			}
+
+			if chunk.Text != "" {
+				currentText.WriteString(chunk.Text)
+			}
+			if chunk.Language != "" {
+				detectedLanguage = chunk.Language
+			}
+
+			onChunk(&TranscriptResult{
+				Text:     currentText.String(),
+				Language: detectedLanguage,
+			})
+
+			if chunk.Done {
+				break
+			}
+		}
+	}
+
+	return scanner.Err()
+}
+
+func (p *WhisperProvider) ListLanguages(ctx context.Context) ([]string, error) {
+	return []string{
+		"af", "am", "ar", "as", "az", "ba", "be", "bg", "bn", "bo", "br", "bs", "ca", "cs", "cy", "da",
+		"de", "el", "en", "es", "et", "eu", "fa", "fi", "fo", "fr", "gl", "gu", "ha", "haw", "he", "hi",
+		"hr", "ht", "hu", "hy", "id", "is", "it", "ja", "jw", "ka", "kk", "km", "kn", "ko", "la", "lb",
+		"ln", "lo", "lt", "lv", "mg", "mi", "mk", "ml", "mn", "mr", "ms", "mt", "my", "ne", "nl", "nn",
+		"no", "oc", "pa", "pl", "ps", "pt", "ro", "ru", "sa", "sd", "si", "sk", "sl", "sn", "so", "sq",
+		"sr", "su", "sv", "sw", "ta", "te", "tg", "th", "tk", "tl", "tr", "tt", "uk", "ur", "uz", "vi",
+		"yi", "yo", "zh",
+	}, nil
+}

--- a/pkg/speech/stt_whisper_test.go
+++ b/pkg/speech/stt_whisper_test.go
@@ -1,0 +1,613 @@
+package speech
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewWhisperProvider(t *testing.T) {
+	t.Run("requires API key", func(t *testing.T) {
+		_, err := NewWhisperProvider("")
+		if err == nil {
+			t.Fatal("expected error when API key is empty")
+		}
+		sttErr, ok := err.(*STTError)
+		if !ok {
+			t.Fatalf("expected *STTError, got %T", err)
+		}
+		if sttErr.Code != ErrAuthentication {
+			t.Errorf("expected ErrAuthentication, got %s", sttErr.Code)
+		}
+	})
+
+	t.Run("creates provider with defaults", func(t *testing.T) {
+		p, err := NewWhisperProvider("test-key")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if p.Name() != "openai-whisper" {
+			t.Errorf("expected name openai-whisper, got %s", p.Name())
+		}
+		if p.Type() != STTProviderOpenAI {
+			t.Errorf("expected type %s, got %s", STTProviderOpenAI, p.Type())
+		}
+		if p.baseURL != "https://api.openai.com" {
+			t.Errorf("expected default baseURL, got %s", p.baseURL)
+		}
+		if p.model != WhisperModelV1 {
+			t.Errorf("expected default model %s, got %s", WhisperModelV1, p.model)
+		}
+		if p.retries != 2 {
+			t.Errorf("expected 2 retries, got %d", p.retries)
+		}
+	})
+
+	t.Run("applies options", func(t *testing.T) {
+		p, err := NewWhisperProvider("test-key",
+			WithWhisperBaseURL("https://custom.api.com"),
+			WithWhisperModel(WhisperModelV1),
+			WithWhisperLanguage("zh"),
+			WithWhisperTimeout(30*time.Second),
+			WithWhisperRetries(5),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if p.baseURL != "https://custom.api.com" {
+			t.Errorf("expected custom baseURL, got %s", p.baseURL)
+		}
+		if p.language != "zh" {
+			t.Errorf("expected language zh, got %s", p.language)
+		}
+		if p.timeout != 30*time.Second {
+			t.Errorf("expected 30s timeout, got %v", p.timeout)
+		}
+		if p.retries != 5 {
+			t.Errorf("expected 5 retries, got %d", p.retries)
+		}
+	})
+
+	t.Run("rejects invalid model", func(t *testing.T) {
+		_, err := NewWhisperProvider("test-key", WithWhisperModel(WhisperModel("invalid-model")))
+		if err == nil {
+			t.Fatal("expected error for invalid model")
+		}
+	})
+
+	t.Run("trims trailing slash from baseURL", func(t *testing.T) {
+		p, err := NewWhisperProvider("test-key", WithWhisperBaseURL("https://api.example.com/"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.HasSuffix(p.baseURL, "/") {
+			t.Errorf("baseURL should not have trailing slash: %s", p.baseURL)
+		}
+	})
+}
+
+func TestWhisperProviderTranscribe(t *testing.T) {
+	t.Run("rejects empty audio", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer server.Close()
+
+		p, _ := NewWhisperProvider("test-key", WithWhisperBaseURL(server.URL))
+		_, err := p.Transcribe(context.Background(), nil)
+		if err == nil {
+			t.Fatal("expected error for empty audio")
+		}
+	})
+
+	t.Run("rejects audio too large", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer server.Close()
+
+		p, _ := NewWhisperProvider("test-key", WithWhisperBaseURL(server.URL))
+		largeAudio := make([]byte, 26*1024*1024)
+		_, err := p.Transcribe(context.Background(), largeAudio)
+		if err == nil {
+			t.Fatal("expected error for audio too large")
+		}
+		sttErr, ok := err.(*STTError)
+		if !ok {
+			t.Fatalf("expected *STTError, got %T", err)
+		}
+		if sttErr.Code != ErrAudioTooLarge {
+			t.Errorf("expected ErrAudioTooLarge, got %s", sttErr.Code)
+		}
+	})
+
+	t.Run("successful transcription", func(t *testing.T) {
+		response := whisperResponse{
+			Text:     "Hello world",
+			Language: "en",
+			Duration: 2.5,
+			Segments: []struct {
+				ID           int     `json:"id"`
+				Seek         int     `json:"seek"`
+				Start        float64 `json:"start"`
+				End          float64 `json:"end"`
+				Text         string  `json:"text"`
+				Tokens       []int   `json:"tokens"`
+				Temperature  float64 `json:"temperature"`
+				AvgLogProb   float64 `json:"avg_logprob"`
+				Compression  float64 `json:"compression_ratio"`
+				NoSpeechProb float64 `json:"no_speech_prob"`
+				Words        []struct {
+					Word       string  `json:"word"`
+					Start      float64 `json:"start"`
+					End        float64 `json:"end"`
+					Confidence float64 `json:"probability"`
+				} `json:"words,omitempty"`
+			}{
+				{
+					ID:         0,
+					Start:      0.0,
+					End:        2.5,
+					Text:       "Hello world",
+					AvgLogProb: -0.3,
+					Words: []struct {
+						Word       string  `json:"word"`
+						Start      float64 `json:"start"`
+						End        float64 `json:"end"`
+						Confidence float64 `json:"probability"`
+					}{
+						{Word: "Hello", Start: 0.0, End: 0.5, Confidence: 0.95},
+						{Word: "world", Start: 0.6, End: 1.0, Confidence: 0.92},
+					},
+				},
+			},
+		}
+
+		respBody, _ := json.Marshal(response)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "POST" {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+				t.Error("missing Bearer token")
+			}
+			if !strings.Contains(r.Header.Get("Content-Type"), "multipart/form-data") {
+				t.Errorf("expected multipart/form-data, got %s", r.Header.Get("Content-Type"))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write(respBody)
+		}))
+		defer server.Close()
+
+		p, _ := NewWhisperProvider("test-key", WithWhisperBaseURL(server.URL))
+		result, err := p.Transcribe(context.Background(), []byte("fake-audio-data"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.Text != "Hello world" {
+			t.Errorf("expected 'Hello world', got '%s'", result.Text)
+		}
+		if result.Language != "en" {
+			t.Errorf("expected language 'en', got '%s'", result.Language)
+		}
+		if result.Duration != 2500*time.Millisecond {
+			t.Errorf("expected duration 2.5s, got %v", result.Duration)
+		}
+		if len(result.Segments) != 1 {
+			t.Fatalf("expected 1 segment, got %d", len(result.Segments))
+		}
+		if len(result.Segments[0].Words) != 2 {
+			t.Fatalf("expected 2 words, got %d", len(result.Segments[0].Words))
+		}
+	})
+
+	t.Run("handles authentication error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error":{"message":"Invalid API key","type":"invalid_request_error","code":"invalid_api_key"}}`))
+		}))
+		defer server.Close()
+
+		p, _ := NewWhisperProvider("bad-key", WithWhisperBaseURL(server.URL), WithWhisperRetries(0))
+		_, err := p.Transcribe(context.Background(), []byte("fake-audio"))
+		if err == nil {
+			t.Fatal("expected authentication error")
+		}
+		sttErr, ok := err.(*STTError)
+		if !ok {
+			t.Fatalf("expected *STTError, got %T", err)
+		}
+		if sttErr.Code != ErrAuthentication {
+			t.Errorf("expected ErrAuthentication, got %s", sttErr.Code)
+		}
+	})
+
+	t.Run("handles rate limit error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte(`{"error":{"message":"Rate limit exceeded","type":"rate_limit_error","code":"rate_limit_exceeded"}}`))
+		}))
+		defer server.Close()
+
+		p, _ := NewWhisperProvider("test-key", WithWhisperBaseURL(server.URL), WithWhisperRetries(0))
+		_, err := p.Transcribe(context.Background(), []byte("fake-audio"))
+		if err == nil {
+			t.Fatal("expected rate limit error")
+		}
+		sttErr, ok := err.(*STTError)
+		if !ok {
+			t.Fatalf("expected *STTError, got %T", err)
+		}
+		if sttErr.Code != ErrRateLimited {
+			t.Errorf("expected ErrRateLimited, got %s", sttErr.Code)
+		}
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer server.Close()
+
+		p, _ := NewWhisperProvider("test-key", WithWhisperBaseURL(server.URL), WithWhisperRetries(1))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := p.Transcribe(ctx, []byte("fake-audio"))
+		if err == nil {
+			t.Fatal("expected context cancellation error")
+		}
+	})
+
+	t.Run("translation mode", func(t *testing.T) {
+		var receivedURL string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			receivedURL = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"text":"Hello world","language":"en","duration":1.0}`))
+		}))
+		defer server.Close()
+
+		p, _ := NewWhisperProvider("test-key", WithWhisperBaseURL(server.URL))
+		_, err := p.Transcribe(context.Background(), []byte("fake-audio"),
+			WithSTTMode(ModeTranslation))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if receivedURL != "/v1/audio/translations" {
+			t.Errorf("expected /v1/audio/translations, got %s", receivedURL)
+		}
+	})
+}
+
+func TestWhisperProviderTranscribeFile(t *testing.T) {
+	t.Run("rejects empty file path", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer server.Close()
+
+		p, _ := NewWhisperProvider("test-key", WithWhisperBaseURL(server.URL))
+		_, err := p.TranscribeFile(context.Background(), "")
+		if err == nil {
+			t.Fatal("expected error for empty file path")
+		}
+	})
+
+	t.Run("rejects non-existent file", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer server.Close()
+
+		p, _ := NewWhisperProvider("test-key", WithWhisperBaseURL(server.URL))
+		_, err := p.TranscribeFile(context.Background(), "/nonexistent/file.mp3")
+		if err == nil {
+			t.Fatal("expected error for non-existent file")
+		}
+		sttErr, ok := err.(*STTError)
+		if !ok {
+			t.Fatalf("expected *STTError, got %T", err)
+		}
+		if sttErr.Code != ErrAudioFormatInvalid {
+			t.Errorf("expected ErrAudioFormatInvalid, got %s", sttErr.Code)
+		}
+	})
+
+	t.Run("successful file transcription", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		testFile := filepath.Join(tmpDir, "test.mp3")
+		os.WriteFile(testFile, []byte("fake-audio-content"), 0644)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"text":"File content","language":"en","duration":1.5}`))
+		}))
+		defer server.Close()
+
+		p, _ := NewWhisperProvider("test-key", WithWhisperBaseURL(server.URL))
+		result, err := p.TranscribeFile(context.Background(), testFile)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.Text != "File content" {
+			t.Errorf("expected 'File content', got '%s'", result.Text)
+		}
+	})
+}
+
+func TestWhisperProviderTranscribeStream(t *testing.T) {
+	t.Run("rejects nil reader", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer server.Close()
+
+		p, _ := NewWhisperProvider("test-key", WithWhisperBaseURL(server.URL))
+		_, err := p.TranscribeStream(context.Background(), nil)
+		if err == nil {
+			t.Fatal("expected error for nil reader")
+		}
+	})
+
+	t.Run("successful stream transcription", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"text":"Stream content","language":"en","duration":3.0}`))
+		}))
+		defer server.Close()
+
+		p, _ := NewWhisperProvider("test-key", WithWhisperBaseURL(server.URL))
+		reader := strings.NewReader("stream-audio-data")
+		result, err := p.TranscribeStream(context.Background(), reader)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.Text != "Stream content" {
+			t.Errorf("expected 'Stream content', got '%s'", result.Text)
+		}
+	})
+}
+
+func TestWhisperProviderListLanguages(t *testing.T) {
+	p, _ := NewWhisperProvider("test-key")
+	langs, err := p.ListLanguages(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(langs) == 0 {
+		t.Fatal("expected non-empty language list")
+	}
+
+	found := false
+	for _, lang := range langs {
+		if lang == "en" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'en' in language list")
+	}
+
+	found = false
+	for _, lang := range langs {
+		if lang == "zh" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'zh' in language list")
+	}
+}
+
+func TestWhisperProviderSSE(t *testing.T) {
+	t.Run("successful streaming", func(t *testing.T) {
+		sseData := `data: {"text":"Hello ","language":"en"}
+data: {"text":"world","language":"en"}
+data: [DONE]
+`
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Accept") != "text/event-stream" {
+				t.Errorf("expected text/event-stream accept header, got %s", r.Header.Get("Accept"))
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Write([]byte(sseData))
+		}))
+		defer server.Close()
+
+		p, _ := NewWhisperProvider("test-key", WithWhisperBaseURL(server.URL))
+
+		var chunks []*TranscriptResult
+		err := p.TranscribeSSE(context.Background(), []byte("fake-audio"), func(chunk *TranscriptResult) {
+			chunks = append(chunks, chunk)
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(chunks) != 2 {
+			t.Fatalf("expected 2 chunks, got %d", len(chunks))
+		}
+		if chunks[0].Text != "Hello " {
+			t.Errorf("expected first chunk 'Hello ', got '%s'", chunks[0].Text)
+		}
+		if chunks[1].Text != "Hello world" {
+			t.Errorf("expected accumulated text 'Hello world', got '%s'", chunks[1].Text)
+		}
+	})
+}
+
+func TestNormalizeLogProb(t *testing.T) {
+	tests := []struct {
+		name    string
+		logProb float64
+		want    float64
+	}{
+		{"zero", 0, 1.0},
+		{"positive", 0.5, 1.0},
+		{"negative small", -0.1, 0.9090909090909091},
+		{"negative large", -5.0, 0.16666666666666666},
+		{"negative very large", -100.0, 0.009900990099009901},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeLogProb(tt.logProb)
+			if got < 0 || got > 1 {
+				t.Errorf("normalizeLogProb(%f) = %f, should be in [0,1]", tt.logProb, got)
+			}
+		})
+	}
+}
+
+func TestSTTError(t *testing.T) {
+	t.Run("error message", func(t *testing.T) {
+		err := NewSTTError(ErrAuthentication, "test message")
+		if err.Error() != "authentication_failed: test message" {
+			t.Errorf("unexpected error message: %s", err.Error())
+		}
+	})
+
+	t.Run("error with format", func(t *testing.T) {
+		err := NewSTTErrorf(ErrTranscriptionFailed, "retry %d failed", 3)
+		if err.Error() != "transcription_failed: retry 3 failed" {
+			t.Errorf("unexpected error message: %s", err.Error())
+		}
+	})
+
+	t.Run("error with wrapped error", func(t *testing.T) {
+		inner := context.DeadlineExceeded
+		err := &STTError{
+			Code:    ErrTranscriptionFailed,
+			Message: "timeout",
+			Err:     inner,
+		}
+		if !strings.Contains(err.Error(), "context deadline exceeded") {
+			t.Errorf("expected wrapped error in message: %s", err.Error())
+		}
+		if err.Unwrap() != inner {
+			t.Error("Unwrap() did not return wrapped error")
+		}
+	})
+}
+
+func TestNewSTTProvider(t *testing.T) {
+	t.Run("creates OpenAI provider", func(t *testing.T) {
+		p, err := NewSTTProvider(STTConfig{
+			Type:    STTProviderOpenAI,
+			APIKey:  "test-key",
+			Model:   "whisper-1",
+			Timeout: 30 * time.Second,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if p.Type() != STTProviderOpenAI {
+			t.Errorf("expected STTProviderOpenAI, got %s", p.Type())
+		}
+	})
+
+	t.Run("rejects unknown provider", func(t *testing.T) {
+		_, err := NewSTTProvider(STTConfig{
+			Type:   STTProviderType("unknown"),
+			APIKey: "test-key",
+		})
+		if err == nil {
+			t.Fatal("expected error for unknown provider")
+		}
+		sttErr, ok := err.(*STTError)
+		if !ok {
+			t.Fatalf("expected *STTError, got %T", err)
+		}
+		if sttErr.Code != ErrProviderNotSupported {
+			t.Errorf("expected ErrProviderNotSupported, got %s", sttErr.Code)
+		}
+	})
+}
+
+func TestWhisperProviderRetries(t *testing.T) {
+	t.Run("retries on server error then succeeds", func(t *testing.T) {
+		callCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			if callCount < 2 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"text":"Success after retry","language":"en","duration":1.0}`))
+		}))
+		defer server.Close()
+
+		p, _ := NewWhisperProvider("test-key", WithWhisperBaseURL(server.URL), WithWhisperRetries(2))
+		result, err := p.Transcribe(context.Background(), []byte("fake-audio"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.Text != "Success after retry" {
+			t.Errorf("expected 'Success after retry', got '%s'", result.Text)
+		}
+		if callCount != 2 {
+			t.Errorf("expected 2 calls, got %d", callCount)
+		}
+	})
+
+	t.Run("does not retry on auth error", func(t *testing.T) {
+		callCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error":{"message":"Invalid key","type":"auth_error","code":"bad_key"}}`))
+		}))
+		defer server.Close()
+
+		p, _ := NewWhisperProvider("bad-key", WithWhisperBaseURL(server.URL), WithWhisperRetries(3))
+		_, err := p.Transcribe(context.Background(), []byte("fake-audio"))
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if callCount != 1 {
+			t.Errorf("expected 1 call (no retry on auth error), got %d", callCount)
+		}
+	})
+}
+
+func TestWhisperProviderValidation(t *testing.T) {
+	t.Run("rejects invalid temperature", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer server.Close()
+
+		p, _ := NewWhisperProvider("test-key", WithWhisperBaseURL(server.URL))
+		_, err := p.Transcribe(context.Background(), []byte("fake-audio"),
+			WithSTTTemperature(1.5))
+		if err == nil {
+			t.Fatal("expected error for invalid temperature")
+		}
+	})
+
+	t.Run("rejects negative max alternatives", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer server.Close()
+
+		p, _ := NewWhisperProvider("test-key", WithWhisperBaseURL(server.URL))
+		_, err := p.Transcribe(context.Background(), []byte("fake-audio"),
+			WithSTTMaxAlternatives(-1))
+		if err == nil {
+			t.Fatal("expected error for negative max alternatives")
+		}
+	})
+
+	t.Run("rejects unsupported input format", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer server.Close()
+
+		p, _ := NewWhisperProvider("test-key", WithWhisperBaseURL(server.URL))
+		_, err := p.Transcribe(context.Background(), []byte("fake-audio"),
+			WithSTTInputFormat(AudioInputFormat("xyz")))
+		if err == nil {
+			t.Fatal("expected error for unsupported format")
+		}
+	})
+}

--- a/pkg/speech/stt_whispercpp.go
+++ b/pkg/speech/stt_whispercpp.go
@@ -1,0 +1,611 @@
+package speech
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type WhisperCPPModel string
+
+const (
+	WhisperCPPTiny    WhisperCPPModel = "tiny"
+	WhisperCPPBase    WhisperCPPModel = "base"
+	WhisperCPPSmall   WhisperCPPModel = "small"
+	WhisperCPPMedium  WhisperCPPModel = "medium"
+	WhisperCPPLarge   WhisperCPPModel = "large"
+	WhisperCPPLargeV2 WhisperCPPModel = "large-v2"
+	WhisperCPPLargeV3 WhisperCPPModel = "large-v3"
+	WhisperCPPTurbo   WhisperCPPModel = "turbo"
+)
+
+type WhisperCPPProvider struct {
+	modelPath      string
+	binaryPath     string
+	threads        int
+	language       string
+	temperature    float64
+	beamSize       int
+	bestOf         int
+	useGPU         bool
+	offset         time.Duration
+	duration       time.Duration
+	maxTextLen     int
+	wordTimestamps bool
+	timeout        time.Duration
+	retries        int
+}
+
+type WhisperCPPOption func(*WhisperCPPProvider)
+
+func WithWhisperCPPModelPath(path string) WhisperCPPOption {
+	return func(p *WhisperCPPProvider) {
+		p.modelPath = path
+	}
+}
+
+func WithWhisperCPPBinaryPath(path string) WhisperCPPOption {
+	return func(p *WhisperCPPProvider) {
+		p.binaryPath = path
+	}
+}
+
+func WithWhisperCPPThreads(threads int) WhisperCPPOption {
+	return func(p *WhisperCPPProvider) {
+		p.threads = threads
+	}
+}
+
+func WithWhisperCPPLanguage(lang string) WhisperCPPOption {
+	return func(p *WhisperCPPProvider) {
+		p.language = lang
+	}
+}
+
+func WithWhisperCPPTemperature(temp float64) WhisperCPPOption {
+	return func(p *WhisperCPPProvider) {
+		p.temperature = temp
+	}
+}
+
+func WithWhisperCPPBeamSize(size int) WhisperCPPOption {
+	return func(p *WhisperCPPProvider) {
+		p.beamSize = size
+	}
+}
+
+func WithWhisperCPPBestOf(n int) WhisperCPPOption {
+	return func(p *WhisperCPPProvider) {
+		p.bestOf = n
+	}
+}
+
+func WithWhisperCPPUseGPU(use bool) WhisperCPPOption {
+	return func(p *WhisperCPPProvider) {
+		p.useGPU = use
+	}
+}
+
+func WithWhisperCPPOffset(offset time.Duration) WhisperCPPOption {
+	return func(p *WhisperCPPProvider) {
+		p.offset = offset
+	}
+}
+
+func WithWhisperCPPDuration(d time.Duration) WhisperCPPOption {
+	return func(p *WhisperCPPProvider) {
+		p.duration = d
+	}
+}
+
+func WithWhisperCPPMaxTextLen(n int) WhisperCPPOption {
+	return func(p *WhisperCPPProvider) {
+		p.maxTextLen = n
+	}
+}
+
+func WithWhisperCPPWordTimestamps(enabled bool) WhisperCPPOption {
+	return func(p *WhisperCPPProvider) {
+		p.wordTimestamps = enabled
+	}
+}
+
+func WithWhisperCPPTimeout(timeout time.Duration) WhisperCPPOption {
+	return func(p *WhisperCPPProvider) {
+		p.timeout = timeout
+	}
+}
+
+func WithWhisperCPPRetries(retries int) WhisperCPPOption {
+	return func(p *WhisperCPPProvider) {
+		p.retries = retries
+	}
+}
+
+func NewWhisperCPPProvider(opts ...WhisperCPPOption) (*WhisperCPPProvider, error) {
+	p := &WhisperCPPProvider{
+		binaryPath:  "whisper-main",
+		threads:     4,
+		language:    "auto",
+		temperature: 0.0,
+		beamSize:    5,
+		bestOf:      5,
+		useGPU:      false,
+		timeout:     300 * time.Second,
+		retries:     0,
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	if p.modelPath == "" {
+		return nil, NewSTTError(ErrProviderNotSupported, "whisper.cpp: model path is required")
+	}
+
+	if _, err := os.Stat(p.modelPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, NewSTTErrorf(ErrProviderNotSupported, "whisper.cpp: model file not found: %s", p.modelPath)
+		}
+		return nil, NewSTTErrorf(ErrProviderNotSupported, "whisper.cpp: cannot access model file: %v", err)
+	}
+
+	return p, nil
+}
+
+func (p *WhisperCPPProvider) Name() string {
+	return "whisper.cpp"
+}
+
+func (p *WhisperCPPProvider) Type() STTProviderType {
+	return STTProviderWhisperCPP
+}
+
+func (p *WhisperCPPProvider) Transcribe(ctx context.Context, audio []byte, opts ...TranscribeOption) (*TranscriptResult, error) {
+	options := TranscribeOptions{
+		Language:    p.language,
+		InputFormat: InputMP3,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	if len(audio) == 0 {
+		return nil, NewSTTError(ErrAudioFormatInvalid, "whisper.cpp: audio data is empty")
+	}
+
+	if !validInputFormats[options.InputFormat] {
+		return nil, NewSTTErrorf(ErrAudioFormatInvalid, "whisper.cpp: unsupported input format: %s", options.InputFormat)
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= p.retries; attempt++ {
+		if attempt > 0 {
+			backoff := time.Duration(attempt) * time.Second
+			select {
+			case <-ctx.Done():
+				return nil, NewSTTErrorf(ErrTranscriptionFailed, "whisper.cpp: context cancelled during retry: %v", ctx.Err())
+			case <-time.After(backoff):
+			}
+		}
+
+		result, err := p.doTranscribe(ctx, audio, options)
+		if err == nil {
+			return result, nil
+		}
+
+		lastErr = err
+	}
+
+	return nil, NewSTTErrorf(ErrTranscriptionFailed, "whisper.cpp: all %d retries failed: %v", p.retries, lastErr)
+}
+
+func (p *WhisperCPPProvider) TranscribeFile(ctx context.Context, filePath string, opts ...TranscribeOption) (*TranscriptResult, error) {
+	if filePath == "" {
+		return nil, NewSTTError(ErrAudioFormatInvalid, "whisper.cpp: file path is empty")
+	}
+
+	info, err := os.Stat(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, NewSTTErrorf(ErrAudioFormatInvalid, "whisper.cpp: file not found: %s", filePath)
+		}
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "whisper.cpp: failed to stat file: %v", err)
+	}
+
+	if info.Size() == 0 {
+		return nil, NewSTTError(ErrAudioFormatInvalid, "whisper.cpp: file is empty")
+	}
+
+	options := TranscribeOptions{
+		Language:    p.language,
+		InputFormat: InputWAV,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(filePath)), ".")
+	if ext != "" {
+		options.InputFormat = AudioInputFormat(ext)
+	}
+
+	return p.doTranscribeFile(ctx, filePath, options)
+}
+
+func (p *WhisperCPPProvider) TranscribeStream(ctx context.Context, reader io.Reader, opts ...TranscribeOption) (*TranscriptResult, error) {
+	if reader == nil {
+		return nil, NewSTTError(ErrAudioFormatInvalid, "whisper.cpp: reader is nil")
+	}
+
+	audio, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "whisper.cpp: failed to read stream: %v", err)
+	}
+
+	return p.Transcribe(ctx, audio, opts...)
+}
+
+func (p *WhisperCPPProvider) doTranscribe(ctx context.Context, audio []byte, options TranscribeOptions) (*TranscriptResult, error) {
+	tmpAudio, err := os.CreateTemp("", "whisper-cpp-input-*."+string(options.InputFormat))
+	if err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "whisper.cpp: failed to create temp audio file: %v", err)
+	}
+	tmpAudioPath := tmpAudio.Name()
+	tmpAudio.Close()
+	defer os.Remove(tmpAudioPath)
+
+	if err := os.WriteFile(tmpAudioPath, audio, 0644); err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "whisper.cpp: failed to write temp audio file: %v", err)
+	}
+
+	return p.doTranscribeFile(ctx, tmpAudioPath, options)
+}
+
+func (p *WhisperCPPProvider) doTranscribeFile(ctx context.Context, filePath string, options TranscribeOptions) (*TranscriptResult, error) {
+	outputDir, err := os.MkdirTemp("", "whisper-cpp-output-*")
+	if err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "whisper.cpp: failed to create temp output dir: %v", err)
+	}
+	defer os.RemoveAll(outputDir)
+
+	outputBase := filepath.Join(outputDir, "output")
+
+	args := p.buildArgs(filePath, outputBase, options)
+
+	binaryPath := p.binaryPath
+	if _, err := exec.LookPath(binaryPath); err != nil {
+		if _, err := os.Stat(binaryPath); err != nil {
+			return nil, NewSTTErrorf(ErrProviderNotSupported, "whisper.cpp: binary not found at %s", binaryPath)
+		}
+	}
+
+	cmdCtx := ctx
+	if p.timeout > 0 {
+		var cancel context.CancelFunc
+		cmdCtx, cancel = context.WithTimeout(ctx, p.timeout)
+		defer cancel()
+	}
+
+	cmd := exec.CommandContext(cmdCtx, binaryPath, args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if cmdCtx.Err() != nil {
+			return nil, NewSTTErrorf(ErrTranscriptionFailed, "whisper.cpp: transcription timed out: %v", cmdCtx.Err())
+		}
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "whisper.cpp: transcription failed: %v, stderr: %s", err, stderr.String())
+	}
+
+	jsonPath := outputBase + ".json"
+	if _, err := os.Stat(jsonPath); err == nil {
+		return p.parseJSONOutput(jsonPath, options)
+	}
+
+	txtPath := outputBase + ".txt"
+	if _, err := os.Stat(txtPath); err == nil {
+		return p.parseTextOutput(txtPath, options)
+	}
+
+	if stdout.Len() > 0 {
+		return p.parseStdoutOutput(stdout.String(), options)
+	}
+
+	return nil, NewSTTError(ErrTranscriptionFailed, "whisper.cpp: no output produced")
+}
+
+func (p *WhisperCPPProvider) buildArgs(inputFile, outputBase string, options TranscribeOptions) []string {
+	args := []string{
+		"-m", p.modelPath,
+		"-f", inputFile,
+		"-oj",
+		"-of", outputBase,
+		"-t", strconv.Itoa(p.threads),
+	}
+
+	if options.Language != "" && options.Language != "auto" {
+		args = append(args, "-l", options.Language)
+	} else if p.language != "" && p.language != "auto" {
+		args = append(args, "-l", p.language)
+	}
+
+	if p.temperature > 0 {
+		args = append(args, "--temperature", fmt.Sprintf("%.2f", p.temperature))
+	}
+
+	if p.beamSize > 0 {
+		args = append(args, "--beam-size", strconv.Itoa(p.beamSize))
+	}
+
+	if p.bestOf > 0 {
+		args = append(args, "--best-of", strconv.Itoa(p.bestOf))
+	}
+
+	if p.useGPU {
+		args = append(args, "-ng", "1")
+	} else {
+		args = append(args, "-ng", "0")
+	}
+
+	if p.offset > 0 {
+		args = append(args, "-o", strconv.FormatInt(int64(p.offset.Milliseconds()), 10))
+	}
+
+	if p.duration > 0 {
+		args = append(args, "-d", strconv.FormatInt(int64(p.duration.Milliseconds()), 10))
+	}
+
+	if p.maxTextLen > 0 {
+		args = append(args, "-ml", strconv.Itoa(p.maxTextLen))
+	}
+
+	if p.wordTimestamps || options.WordTimestamps {
+		args = append(args, "-owts")
+	}
+
+	return args
+}
+
+type whisperCPPJSONOutput struct {
+	SystemInfo struct {
+		Threads  int    `json:"n_threads"`
+		Model    string `json:"model"`
+		Language string `json:"language"`
+	} `json:"system_info"`
+	Transcription []struct {
+		Timestamps []struct {
+			T0    float64 `json:"t0"`
+			T1    float64 `json:"t1"`
+			Text  string  `json:"text"`
+			Words []struct {
+				T0   float64 `json:"t0"`
+				T1   float64 `json:"t1"`
+				Text string  `json:"text"`
+				Prob float64 `json:"p"`
+			} `json:"words,omitempty"`
+		} `json:"timestamps"`
+		Text string `json:"text"`
+	} `json:"transcription"`
+}
+
+func (p *WhisperCPPProvider) parseJSONOutput(jsonPath string, options TranscribeOptions) (*TranscriptResult, error) {
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "whisper.cpp: failed to read JSON output: %v", err)
+	}
+
+	var output whisperCPPJSONOutput
+	if err := json.Unmarshal(data, &output); err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "whisper.cpp: failed to parse JSON output: %v", err)
+	}
+
+	result := &TranscriptResult{
+		Language: output.SystemInfo.Language,
+	}
+
+	var totalConfidence float64
+	var confidenceCount int
+
+	for i, seg := range output.Transcription {
+		segment := SegmentInfo{
+			ID:   i,
+			Text: strings.TrimSpace(seg.Text),
+		}
+
+		for _, ts := range seg.Timestamps {
+			if ts.T1 > 0 {
+				segment.EndTime = time.Duration(ts.T1 * float64(time.Second))
+			}
+			if segment.StartTime == 0 && ts.T0 > 0 {
+				segment.StartTime = time.Duration(ts.T0 * float64(time.Second))
+			}
+
+			for _, word := range ts.Words {
+				wi := WordInfo{
+					Word:      strings.TrimSpace(word.Text),
+					StartTime: time.Duration(word.T0 * float64(time.Second)),
+					EndTime:   time.Duration(word.T1 * float64(time.Second)),
+				}
+				if word.Prob > 0 {
+					wi.Confidence = word.Prob
+					totalConfidence += word.Prob
+					confidenceCount++
+				}
+				segment.Words = append(segment.Words, wi)
+
+				if options.WordTimestamps {
+					result.Words = append(result.Words, wi)
+				}
+			}
+		}
+
+		result.Segments = append(result.Segments, segment)
+
+		if result.Text == "" {
+			result.Text = strings.TrimSpace(seg.Text)
+		} else {
+			result.Text += " " + strings.TrimSpace(seg.Text)
+		}
+	}
+
+	result.Text = strings.TrimSpace(result.Text)
+
+	if confidenceCount > 0 {
+		result.Confidence = totalConfidence / float64(confidenceCount)
+	}
+
+	if len(result.Segments) > 0 {
+		lastSeg := result.Segments[len(result.Segments)-1]
+		if lastSeg.EndTime > 0 {
+			result.Duration = lastSeg.EndTime
+		}
+	}
+
+	return result, nil
+}
+
+func (p *WhisperCPPProvider) parseTextOutput(txtPath string, options TranscribeOptions) (*TranscriptResult, error) {
+	data, err := os.ReadFile(txtPath)
+	if err != nil {
+		return nil, NewSTTErrorf(ErrTranscriptionFailed, "whisper.cpp: failed to read text output: %v", err)
+	}
+
+	text := strings.TrimSpace(string(data))
+
+	var segments []SegmentInfo
+	var currentText string
+	timestampRegex := regexp.MustCompile(`\[(\d{2}:\d{2}:\d{2}\.\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2}\.\d{3})\]\s*(.*)`)
+
+	lines := strings.Split(text, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		matches := timestampRegex.FindStringSubmatch(line)
+		if matches != nil {
+			if currentText != "" {
+				segments = append(segments, SegmentInfo{
+					ID:   len(segments),
+					Text: strings.TrimSpace(currentText),
+				})
+			}
+
+			startTime := parseTimestamp(matches[1])
+			endTime := parseTimestamp(matches[2])
+			segText := strings.TrimSpace(matches[3])
+
+			segments = append(segments, SegmentInfo{
+				ID:        len(segments),
+				Text:      segText,
+				StartTime: startTime,
+				EndTime:   endTime,
+			})
+			currentText = ""
+		} else {
+			if currentText != "" {
+				currentText += " " + line
+			} else {
+				currentText = line
+			}
+		}
+	}
+
+	if currentText != "" {
+		segments = append(segments, SegmentInfo{
+			ID:   len(segments),
+			Text: strings.TrimSpace(currentText),
+		})
+	}
+
+	fullText := strings.Join(func() []string {
+		var texts []string
+		for _, s := range segments {
+			texts = append(texts, s.Text)
+		}
+		return texts
+	}(), " ")
+
+	return &TranscriptResult{
+		Text:     strings.TrimSpace(fullText),
+		Segments: segments,
+	}, nil
+}
+
+func (p *WhisperCPPProvider) parseStdoutOutput(stdout string, options TranscribeOptions) (*TranscriptResult, error) {
+	lines := strings.Split(stdout, "\n")
+	var textLines []string
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		if strings.HasPrefix(line, "[") && strings.Contains(line, "]") {
+			idx := strings.Index(line, "]")
+			if idx+1 < len(line) {
+				content := strings.TrimSpace(line[idx+1:])
+				if content != "" {
+					textLines = append(textLines, content)
+				}
+			}
+		} else {
+			textLines = append(textLines, line)
+		}
+	}
+
+	return &TranscriptResult{
+		Text: strings.TrimSpace(strings.Join(textLines, " ")),
+	}, nil
+}
+
+func parseTimestamp(ts string) time.Duration {
+	parts := strings.Split(ts, ":")
+	if len(parts) != 3 {
+		return 0
+	}
+
+	hours, _ := strconv.Atoi(parts[0])
+	minutes, _ := strconv.Atoi(parts[1])
+
+	secParts := strings.Split(parts[2], ".")
+	seconds, _ := strconv.Atoi(secParts[0])
+	millis := 0
+	if len(secParts) > 1 {
+		millis, _ = strconv.Atoi(secParts[1])
+		for millis > 0 && millis < 100 {
+			millis *= 10
+		}
+	}
+
+	return time.Duration(hours)*time.Hour +
+		time.Duration(minutes)*time.Minute +
+		time.Duration(seconds)*time.Second +
+		time.Duration(millis)*time.Millisecond
+}
+
+func (p *WhisperCPPProvider) ListLanguages(ctx context.Context) ([]string, error) {
+	return []string{
+		"auto", "af", "am", "ar", "as", "az", "ba", "be", "bg", "bn", "bo", "br", "bs", "ca", "cs", "cy", "da",
+		"de", "el", "en", "es", "et", "eu", "fa", "fi", "fo", "fr", "gl", "gu", "ha", "haw", "he", "hi",
+		"hr", "ht", "hu", "hy", "id", "is", "it", "ja", "jw", "ka", "kk", "km", "kn", "ko", "la", "lb",
+		"ln", "lo", "lt", "lv", "mg", "mi", "mk", "ml", "mn", "mr", "ms", "mt", "my", "ne", "nl", "nn",
+		"no", "oc", "pa", "pl", "ps", "pt", "ro", "ru", "sa", "sd", "si", "sk", "sl", "sn", "so", "sq",
+		"sr", "su", "sv", "sw", "ta", "te", "tg", "th", "tk", "tl", "tr", "tt", "uk", "ur", "uz", "vi",
+		"yi", "yo", "zh",
+	}, nil
+}

--- a/pkg/speech/stt_whispercpp.go
+++ b/pkg/speech/stt_whispercpp.go
@@ -172,8 +172,9 @@ func (p *WhisperCPPProvider) Type() STTProviderType {
 
 func (p *WhisperCPPProvider) Transcribe(ctx context.Context, audio []byte, opts ...TranscribeOption) (*TranscriptResult, error) {
 	options := TranscribeOptions{
-		Language:    p.language,
-		InputFormat: InputMP3,
+		Language:       p.language,
+		InputFormat:    InputMP3,
+		WordTimestamps: p.wordTimestamps,
 	}
 	for _, opt := range opts {
 		opt(&options)
@@ -227,8 +228,9 @@ func (p *WhisperCPPProvider) TranscribeFile(ctx context.Context, filePath string
 	}
 
 	options := TranscribeOptions{
-		Language:    p.language,
-		InputFormat: InputWAV,
+		Language:       p.language,
+		InputFormat:    InputWAV,
+		WordTimestamps: p.wordTimestamps,
 	}
 	for _, opt := range opts {
 		opt(&options)
@@ -445,7 +447,7 @@ func (p *WhisperCPPProvider) parseJSONOutput(jsonPath string, options Transcribe
 				}
 				segment.Words = append(segment.Words, wi)
 
-				if options.WordTimestamps {
+				if p.wordTimestamps || options.WordTimestamps {
 					result.Words = append(result.Words, wi)
 				}
 			}

--- a/pkg/speech/stt_whispercpp_test.go
+++ b/pkg/speech/stt_whispercpp_test.go
@@ -1,0 +1,968 @@
+package speech
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewWhisperCPPProvider(t *testing.T) {
+	t.Run("requires model path", func(t *testing.T) {
+		_, err := NewWhisperCPPProvider()
+		if err == nil {
+			t.Fatal("expected error when model path is empty")
+		}
+		sttErr, ok := err.(*STTError)
+		if !ok {
+			t.Fatalf("expected *STTError, got %T", err)
+		}
+		if sttErr.Code != ErrProviderNotSupported {
+			t.Errorf("expected ErrProviderNotSupported, got %s", sttErr.Code)
+		}
+	})
+
+	t.Run("rejects non-existent model", func(t *testing.T) {
+		_, err := NewWhisperCPPProvider(WithWhisperCPPModelPath("/nonexistent/model.bin"))
+		if err == nil {
+			t.Fatal("expected error for non-existent model")
+		}
+		sttErr, ok := err.(*STTError)
+		if !ok {
+			t.Fatalf("expected *STTError, got %T", err)
+		}
+		if sttErr.Code != ErrProviderNotSupported {
+			t.Errorf("expected ErrProviderNotSupported, got %s", sttErr.Code)
+		}
+	})
+
+	t.Run("creates provider with defaults", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		modelPath := filepath.Join(tmpDir, "model.bin")
+		os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+		p, err := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if p.Name() != "whisper.cpp" {
+			t.Errorf("expected name whisper.cpp, got %s", p.Name())
+		}
+		if p.Type() != STTProviderWhisperCPP {
+			t.Errorf("expected type %s, got %s", STTProviderWhisperCPP, p.Type())
+		}
+		if p.threads != 4 {
+			t.Errorf("expected 4 threads, got %d", p.threads)
+		}
+		if p.language != "auto" {
+			t.Errorf("expected language auto, got %s", p.language)
+		}
+		if p.beamSize != 5 {
+			t.Errorf("expected beam size 5, got %d", p.beamSize)
+		}
+		if p.timeout != 300*time.Second {
+			t.Errorf("expected 300s timeout, got %v", p.timeout)
+		}
+	})
+
+	t.Run("applies options", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		modelPath := filepath.Join(tmpDir, "model.bin")
+		os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+		p, err := NewWhisperCPPProvider(
+			WithWhisperCPPModelPath(modelPath),
+			WithWhisperCPPBinaryPath("/custom/whisper-main"),
+			WithWhisperCPPThreads(8),
+			WithWhisperCPPLanguage("zh"),
+			WithWhisperCPPTemperature(0.5),
+			WithWhisperCPPBeamSize(3),
+			WithWhisperCPPBestOf(3),
+			WithWhisperCPPUseGPU(true),
+			WithWhisperCPPTimeout(60*time.Second),
+			WithWhisperCPPRetries(2),
+			WithWhisperCPPWordTimestamps(true),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if p.binaryPath != "/custom/whisper-main" {
+			t.Errorf("expected custom binary path, got %s", p.binaryPath)
+		}
+		if p.threads != 8 {
+			t.Errorf("expected 8 threads, got %d", p.threads)
+		}
+		if p.language != "zh" {
+			t.Errorf("expected language zh, got %s", p.language)
+		}
+		if p.temperature != 0.5 {
+			t.Errorf("expected temperature 0.5, got %f", p.temperature)
+		}
+		if p.beamSize != 3 {
+			t.Errorf("expected beam size 3, got %d", p.beamSize)
+		}
+		if p.bestOf != 3 {
+			t.Errorf("expected best of 3, got %d", p.bestOf)
+		}
+		if !p.useGPU {
+			t.Error("expected useGPU to be true")
+		}
+		if p.timeout != 60*time.Second {
+			t.Errorf("expected 60s timeout, got %v", p.timeout)
+		}
+		if p.retries != 2 {
+			t.Errorf("expected 2 retries, got %d", p.retries)
+		}
+		if !p.wordTimestamps {
+			t.Error("expected wordTimestamps to be true")
+		}
+	})
+}
+
+func TestWhisperCPPProviderTranscribe(t *testing.T) {
+	t.Run("rejects empty audio", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		modelPath := filepath.Join(tmpDir, "model.bin")
+		os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+		_, err := p.Transcribe(context.Background(), nil)
+		if err == nil {
+			t.Fatal("expected error for empty audio")
+		}
+	})
+
+	t.Run("rejects unsupported format", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		modelPath := filepath.Join(tmpDir, "model.bin")
+		os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+		_, err := p.Transcribe(context.Background(), []byte("fake-audio"),
+			WithSTTInputFormat(AudioInputFormat("xyz")))
+		if err == nil {
+			t.Fatal("expected error for unsupported format")
+		}
+	})
+}
+
+func TestWhisperCPPProviderTranscribeFile(t *testing.T) {
+	t.Run("rejects empty file path", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		modelPath := filepath.Join(tmpDir, "model.bin")
+		os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+		_, err := p.TranscribeFile(context.Background(), "")
+		if err == nil {
+			t.Fatal("expected error for empty file path")
+		}
+	})
+
+	t.Run("rejects non-existent file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		modelPath := filepath.Join(tmpDir, "model.bin")
+		os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+		_, err := p.TranscribeFile(context.Background(), "/nonexistent/file.wav")
+		if err == nil {
+			t.Fatal("expected error for non-existent file")
+		}
+		sttErr, ok := err.(*STTError)
+		if !ok {
+			t.Fatalf("expected *STTError, got %T", err)
+		}
+		if sttErr.Code != ErrAudioFormatInvalid {
+			t.Errorf("expected ErrAudioFormatInvalid, got %s", sttErr.Code)
+		}
+	})
+
+	t.Run("rejects empty file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		modelPath := filepath.Join(tmpDir, "model.bin")
+		os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+		emptyFile := filepath.Join(tmpDir, "empty.wav")
+		os.WriteFile(emptyFile, []byte{}, 0644)
+
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+		_, err := p.TranscribeFile(context.Background(), emptyFile)
+		if err == nil {
+			t.Fatal("expected error for empty file")
+		}
+	})
+}
+
+func TestWhisperCPPProviderTranscribeStream(t *testing.T) {
+	t.Run("rejects nil reader", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		modelPath := filepath.Join(tmpDir, "model.bin")
+		os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+		_, err := p.TranscribeStream(context.Background(), nil)
+		if err == nil {
+			t.Fatal("expected error for nil reader")
+		}
+	})
+}
+
+func TestWhisperCPPProviderBuildArgs(t *testing.T) {
+	tmpDir := t.TempDir()
+	modelPath := filepath.Join(tmpDir, "model.bin")
+	os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+	t.Run("default args", func(t *testing.T) {
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+		args := p.buildArgs("input.wav", "/tmp/output", TranscribeOptions{})
+
+		if !containsArg(args, "-m", modelPath) {
+			t.Errorf("expected -m %s in args, got %v", modelPath, args)
+		}
+		if !containsArg(args, "-f", "input.wav") {
+			t.Errorf("expected -f input.wav in args, got %v", args)
+		}
+		if !containsArg(args, "-oj", "") {
+			t.Errorf("expected -oj in args, got %v", args)
+		}
+		if !containsArg(args, "-of", "/tmp/output") {
+			t.Errorf("expected -of /tmp/output in args, got %v", args)
+		}
+		if !containsArg(args, "-t", "4") {
+			t.Errorf("expected -t 4 in args, got %v", args)
+		}
+		if !containsArg(args, "-ng", "0") {
+			t.Errorf("expected -ng 0 (CPU) in args, got %v", args)
+		}
+	})
+
+	t.Run("with language", func(t *testing.T) {
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath), WithWhisperCPPLanguage("zh"))
+		args := p.buildArgs("input.wav", "/tmp/output", TranscribeOptions{})
+
+		if !containsArg(args, "-l", "zh") {
+			t.Errorf("expected -l zh in args, got %v", args)
+		}
+	})
+
+	t.Run("with word timestamps", func(t *testing.T) {
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath), WithWhisperCPPWordTimestamps(true))
+		args := p.buildArgs("input.wav", "/tmp/output", TranscribeOptions{})
+
+		if !containsArg(args, "-owts", "") {
+			t.Errorf("expected -owts in args, got %v", args)
+		}
+	})
+
+	t.Run("with GPU", func(t *testing.T) {
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath), WithWhisperCPPUseGPU(true))
+		args := p.buildArgs("input.wav", "/tmp/output", TranscribeOptions{})
+
+		if !containsArg(args, "-ng", "1") {
+			t.Errorf("expected -ng 1 (GPU) in args, got %v", args)
+		}
+	})
+
+	t.Run("with temperature", func(t *testing.T) {
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath), WithWhisperCPPTemperature(0.7))
+		args := p.buildArgs("input.wav", "/tmp/output", TranscribeOptions{})
+
+		if !containsArg(args, "--temperature", "0.70") {
+			t.Errorf("expected --temperature 0.70 in args, got %v", args)
+		}
+	})
+
+	t.Run("with beam size", func(t *testing.T) {
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath), WithWhisperCPPBeamSize(3))
+		args := p.buildArgs("input.wav", "/tmp/output", TranscribeOptions{})
+
+		if !containsArg(args, "--beam-size", "3") {
+			t.Errorf("expected --beam-size 3 in args, got %v", args)
+		}
+	})
+
+	t.Run("auto language not added", func(t *testing.T) {
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+		args := p.buildArgs("input.wav", "/tmp/output", TranscribeOptions{Language: "auto"})
+
+		for i, arg := range args {
+			if arg == "-l" && i+1 < len(args) && args[i+1] == "auto" {
+				t.Errorf("should not add -l auto to args, got %v", args)
+			}
+		}
+	})
+}
+
+func containsArg(args []string, flag, value string) bool {
+	for i, arg := range args {
+		if arg == flag {
+			if value == "" {
+				return true
+			}
+			if i+1 < len(args) && args[i+1] == value {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestWhisperCPPProviderListLanguages(t *testing.T) {
+	tmpDir := t.TempDir()
+	modelPath := filepath.Join(tmpDir, "model.bin")
+	os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+	p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+	langs, err := p.ListLanguages(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(langs) == 0 {
+		t.Fatal("expected non-empty language list")
+	}
+
+	found := false
+	for _, lang := range langs {
+		if lang == "auto" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'auto' in language list")
+	}
+
+	found = false
+	for _, lang := range langs {
+		if lang == "en" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'en' in language list")
+	}
+
+	found = false
+	for _, lang := range langs {
+		if lang == "zh" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'zh' in language list")
+	}
+}
+
+func TestParseTimestamp(t *testing.T) {
+	tests := []struct {
+		name string
+		ts   string
+		want time.Duration
+	}{
+		{"zero", "00:00:00.000", 0},
+		{"one second", "00:00:01.000", time.Second},
+		{"500ms", "00:00:00.500", 500 * time.Millisecond},
+		{"2.5s", "00:00:02.500", 2500 * time.Millisecond},
+		{"1 minute", "00:01:00.000", time.Minute},
+		{"1 hour", "01:00:00.000", time.Hour},
+		{"complex", "00:01:23.456", time.Minute + 23*time.Second + 456*time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTimestamp(tt.ts)
+			if got != tt.want {
+				t.Errorf("parseTimestamp(%s) = %v, want %v", tt.ts, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("invalid format", func(t *testing.T) {
+		got := parseTimestamp("invalid")
+		if got != 0 {
+			t.Errorf("expected 0 for invalid timestamp, got %v", got)
+		}
+	})
+}
+
+func TestWhisperCPPProviderParseJSONOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	modelPath := filepath.Join(tmpDir, "model.bin")
+	os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+	t.Run("parses JSON output", func(t *testing.T) {
+		jsonContent := `{
+			"system_info": {
+				"n_threads": 4,
+				"model": "model.bin",
+				"language": "en"
+			},
+			"transcription": [
+				{
+					"timestamps": [
+						{
+							"t0": 0.0,
+							"t1": 1.5,
+							"text": "Hello world",
+							"words": [
+								{"t0": 0.0, "t1": 0.5, "text": "Hello", "p": 0.95},
+								{"t0": 0.6, "t1": 1.0, "text": "world", "p": 0.92}
+							]
+						}
+					],
+					"text": "Hello world"
+				}
+			]
+		}`
+
+		jsonPath := filepath.Join(tmpDir, "test_output.json")
+		os.WriteFile(jsonPath, []byte(jsonContent), 0644)
+
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+		result, err := p.parseJSONOutput(jsonPath, TranscribeOptions{WordTimestamps: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.Text != "Hello world" {
+			t.Errorf("expected 'Hello world', got '%s'", result.Text)
+		}
+		if result.Language != "en" {
+			t.Errorf("expected language 'en', got '%s'", result.Language)
+		}
+		if len(result.Segments) != 1 {
+			t.Fatalf("expected 1 segment, got %d", len(result.Segments))
+		}
+		if len(result.Words) != 2 {
+			t.Fatalf("expected 2 words, got %d", len(result.Words))
+		}
+		if result.Words[0].Word != "Hello" {
+			t.Errorf("expected first word 'Hello', got '%s'", result.Words[0].Word)
+		}
+		if result.Words[0].Confidence != 0.95 {
+			t.Errorf("expected confidence 0.95, got %f", result.Words[0].Confidence)
+		}
+		if result.Words[0].StartTime != 0 {
+			t.Errorf("expected start time 0, got %v", result.Words[0].StartTime)
+		}
+		if result.Words[0].EndTime != 500*time.Millisecond {
+			t.Errorf("expected end time 500ms, got %v", result.Words[0].EndTime)
+		}
+	})
+
+	t.Run("parses multi-segment output", func(t *testing.T) {
+		jsonContent := `{
+			"system_info": {
+				"n_threads": 4,
+				"model": "model.bin",
+				"language": "zh"
+			},
+			"transcription": [
+				{
+					"timestamps": [{"t0": 0.0, "t1": 2.0, "text": "第一段"}],
+					"text": "第一段"
+				},
+				{
+					"timestamps": [{"t0": 2.0, "t1": 4.0, "text": "第二段"}],
+					"text": "第二段"
+				}
+			]
+		}`
+
+		jsonPath := filepath.Join(tmpDir, "multi_output.json")
+		os.WriteFile(jsonPath, []byte(jsonContent), 0644)
+
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+		result, err := p.parseJSONOutput(jsonPath, TranscribeOptions{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.Text != "第一段 第二段" {
+			t.Errorf("expected '第一段 第二段', got '%s'", result.Text)
+		}
+		if len(result.Segments) != 2 {
+			t.Fatalf("expected 2 segments, got %d", len(result.Segments))
+		}
+		if result.Language != "zh" {
+			t.Errorf("expected language 'zh', got '%s'", result.Language)
+		}
+	})
+
+	t.Run("parses output without word timestamps", func(t *testing.T) {
+		jsonContent := `{
+			"system_info": {
+				"n_threads": 4,
+				"model": "model.bin",
+				"language": "en"
+			},
+			"transcription": [
+				{
+					"timestamps": [{"t0": 0.0, "t1": 1.0, "text": "Test"}],
+					"text": "Test"
+				}
+			]
+		}`
+
+		jsonPath := filepath.Join(tmpDir, "no_words_output.json")
+		os.WriteFile(jsonPath, []byte(jsonContent), 0644)
+
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+		result, err := p.parseJSONOutput(jsonPath, TranscribeOptions{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(result.Words) != 0 {
+			t.Errorf("expected 0 words when WordTimestamps is false, got %d", len(result.Words))
+		}
+	})
+}
+
+func TestWhisperCPPProviderParseTextOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	modelPath := filepath.Join(tmpDir, "model.bin")
+	os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+	t.Run("parses text output with timestamps", func(t *testing.T) {
+		textContent := `[00:00:00.000 --> 00:00:01.000]  Hello world
+[00:00:01.000 --> 00:00:02.000]  Second segment`
+
+		txtPath := filepath.Join(tmpDir, "output.txt")
+		os.WriteFile(txtPath, []byte(textContent), 0644)
+
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+		result, err := p.parseTextOutput(txtPath, TranscribeOptions{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !strings.Contains(result.Text, "Hello world") {
+			t.Errorf("expected text to contain 'Hello world', got '%s'", result.Text)
+		}
+		if len(result.Segments) != 2 {
+			t.Fatalf("expected 2 segments, got %d", len(result.Segments))
+		}
+	})
+
+	t.Run("parses plain text output", func(t *testing.T) {
+		textContent := `This is plain text without timestamps.`
+
+		txtPath := filepath.Join(tmpDir, "plain_output.txt")
+		os.WriteFile(txtPath, []byte(textContent), 0644)
+
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+		result, err := p.parseTextOutput(txtPath, TranscribeOptions{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.Text != "This is plain text without timestamps." {
+			t.Errorf("expected 'This is plain text without timestamps.', got '%s'", result.Text)
+		}
+	})
+}
+
+func TestWhisperCPPProviderParseStdoutOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	modelPath := filepath.Join(tmpDir, "model.bin")
+	os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+	t.Run("parses stdout with timestamps", func(t *testing.T) {
+		stdout := `[00:00:00.000 --> 00:00:01.000]  Hello world
+[00:00:01.000 --> 00:00:02.000]  Second line`
+
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+		result, err := p.parseStdoutOutput(stdout, TranscribeOptions{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !strings.Contains(result.Text, "Hello world") {
+			t.Errorf("expected text to contain 'Hello world', got '%s'", result.Text)
+		}
+	})
+
+	t.Run("parses plain stdout", func(t *testing.T) {
+		stdout := `Plain text output`
+
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+		result, err := p.parseStdoutOutput(stdout, TranscribeOptions{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.Text != "Plain text output" {
+			t.Errorf("expected 'Plain text output', got '%s'", result.Text)
+		}
+	})
+}
+
+func TestNewSTTProviderWhisperCPP(t *testing.T) {
+	t.Run("creates Whisper.cpp provider", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		modelPath := filepath.Join(tmpDir, "model.bin")
+		os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+		p, err := NewSTTProvider(STTConfig{
+			Type:    STTProviderWhisperCPP,
+			Model:   modelPath,
+			Timeout: 60 * time.Second,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if p.Type() != STTProviderWhisperCPP {
+			t.Errorf("expected STTProviderWhisperCPP, got %s", p.Type())
+		}
+		if p.Name() != "whisper.cpp" {
+			t.Errorf("expected name 'whisper.cpp', got %s", p.Name())
+		}
+	})
+
+	t.Run("creates Whisper.cpp provider with language", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		modelPath := filepath.Join(tmpDir, "model.bin")
+		os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+		p, err := NewSTTProvider(STTConfig{
+			Type:     STTProviderWhisperCPP,
+			Model:    modelPath,
+			Language: "zh",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		wcpp, ok := p.(*WhisperCPPProvider)
+		if !ok {
+			t.Fatalf("expected *WhisperCPPProvider, got %T", p)
+		}
+		if wcpp.language != "zh" {
+			t.Errorf("expected language zh, got %s", wcpp.language)
+		}
+	})
+}
+
+func TestWhisperCPPProviderWithMockedBinary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mocked binary tests require bash, skipping on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	modelPath := filepath.Join(tmpDir, "model.bin")
+	os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+	outputDir := filepath.Join(tmpDir, "output")
+	os.MkdirAll(outputDir, 0755)
+
+	mockScript := filepath.Join(tmpDir, "mock-whisper")
+	scriptContent := `#!/bin/bash
+OUTPUT_DIR=""
+OUTPUT_BASE=""
+for i in "$@"; do
+  if [ "$prev" = "-of" ]; then
+    OUTPUT_BASE="$i"
+  fi
+  prev="$i"
+done
+
+# Create JSON output
+cat > "${OUTPUT_BASE}.json" << 'JSONEOF'
+{
+  "system_info": {
+    "n_threads": 4,
+    "model": "model.bin",
+    "language": "en"
+  },
+  "transcription": [
+    {
+      "timestamps": [
+        {"t0": 0.0, "t1": 1.5, "text": "Hello from mock", "words": [
+          {"t0": 0.0, "t1": 0.5, "text": "Hello", "p": 0.95},
+          {"t0": 0.6, "t1": 1.0, "text": "from", "p": 0.90},
+          {"t0": 1.1, "t1": 1.5, "text": "mock", "p": 0.88}
+        ]}
+      ],
+      "text": "Hello from mock"
+    }
+  ]
+}
+JSONEOF
+`
+	os.WriteFile(mockScript, []byte(scriptContent), 0755)
+
+	p, _ := NewWhisperCPPProvider(
+		WithWhisperCPPModelPath(modelPath),
+		WithWhisperCPPBinaryPath(mockScript),
+	)
+
+	t.Run("successful transcription with mocked binary", func(t *testing.T) {
+		result, err := p.Transcribe(context.Background(), []byte("fake-audio-data"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.Text != "Hello from mock" {
+			t.Errorf("expected 'Hello from mock', got '%s'", result.Text)
+		}
+		if result.Language != "en" {
+			t.Errorf("expected language 'en', got '%s'", result.Language)
+		}
+		if len(result.Words) != 3 {
+			t.Fatalf("expected 3 words, got %d", len(result.Words))
+		}
+	})
+
+	t.Run("file transcription with mocked binary", func(t *testing.T) {
+		testFile := filepath.Join(tmpDir, "test.wav")
+		os.WriteFile(testFile, []byte("fake-audio-content"), 0644)
+
+		result, err := p.TranscribeFile(context.Background(), testFile)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.Text != "Hello from mock" {
+			t.Errorf("expected 'Hello from mock', got '%s'", result.Text)
+		}
+	})
+
+	t.Run("stream transcription with mocked binary", func(t *testing.T) {
+		reader := strings.NewReader("stream-audio-data")
+		result, err := p.TranscribeStream(context.Background(), reader)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.Text != "Hello from mock" {
+			t.Errorf("expected 'Hello from mock', got '%s'", result.Text)
+		}
+	})
+}
+
+func TestWhisperCPPProviderBinaryNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	modelPath := filepath.Join(tmpDir, "model.bin")
+	os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+	p, _ := NewWhisperCPPProvider(
+		WithWhisperCPPModelPath(modelPath),
+		WithWhisperCPPBinaryPath("/nonexistent/whisper-binary"),
+	)
+
+	_, err := p.Transcribe(context.Background(), []byte("fake-audio"))
+	if err == nil {
+		t.Fatal("expected error for missing binary")
+	}
+	sttErr, ok := err.(*STTError)
+	if !ok {
+		t.Fatalf("expected *STTError, got %T", err)
+	}
+	if sttErr.Code != ErrProviderNotSupported && sttErr.Code != ErrTranscriptionFailed {
+		t.Errorf("expected ErrProviderNotSupported or ErrTranscriptionFailed, got %s", sttErr.Code)
+	}
+}
+
+func TestWhisperCPPProviderTimeout(t *testing.T) {
+	tmpDir := t.TempDir()
+	modelPath := filepath.Join(tmpDir, "model.bin")
+	os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+	slowScript := filepath.Join(tmpDir, "slow-whisper")
+	scriptContent := `#!/bin/bash
+sleep 10
+`
+	os.WriteFile(slowScript, []byte(scriptContent), 0755)
+
+	p, _ := NewWhisperCPPProvider(
+		WithWhisperCPPModelPath(modelPath),
+		WithWhisperCPPBinaryPath(slowScript),
+		WithWhisperCPPTimeout(100*time.Millisecond),
+	)
+
+	_, err := p.Transcribe(context.Background(), []byte("fake-audio"))
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	sttErr, ok := err.(*STTError)
+	if !ok {
+		t.Fatalf("expected *STTError, got %T", err)
+	}
+	if sttErr.Code != ErrTranscriptionFailed {
+		t.Errorf("expected ErrTranscriptionFailed, got %s", sttErr.Code)
+	}
+}
+
+func TestWhisperCPPProviderFailingBinary(t *testing.T) {
+	tmpDir := t.TempDir()
+	modelPath := filepath.Join(tmpDir, "model.bin")
+	os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+	failingScript := filepath.Join(tmpDir, "failing-whisper")
+	scriptContent := `#!/bin/bash
+echo "Error: model loading failed" >&2
+exit 1
+`
+	os.WriteFile(failingScript, []byte(scriptContent), 0755)
+
+	p, _ := NewWhisperCPPProvider(
+		WithWhisperCPPModelPath(modelPath),
+		WithWhisperCPPBinaryPath(failingScript),
+	)
+
+	_, err := p.Transcribe(context.Background(), []byte("fake-audio"))
+	if err == nil {
+		t.Fatal("expected error for failing binary")
+	}
+	sttErr, ok := err.(*STTError)
+	if !ok {
+		t.Fatalf("expected *STTError, got %T", err)
+	}
+	if sttErr.Code != ErrTranscriptionFailed {
+		t.Errorf("expected ErrTranscriptionFailed, got %s", sttErr.Code)
+	}
+	if !strings.Contains(err.Error(), "stderr") {
+		t.Errorf("expected stderr in error message, got: %s", err.Error())
+	}
+}
+
+func TestWhisperCPPSTTManager(t *testing.T) {
+	t.Run("register and use Whisper.cpp provider", func(t *testing.T) {
+		m := NewSTTManager()
+
+		tmpDir := t.TempDir()
+		modelPath := filepath.Join(tmpDir, "model.bin")
+		os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+
+		err := m.Register("whisper-cpp", p)
+		if err != nil {
+			t.Fatalf("failed to register provider: %v", err)
+		}
+
+		providers := m.ListProviders()
+		if len(providers) != 1 {
+			t.Fatalf("expected 1 provider, got %d", len(providers))
+		}
+
+		got, err := m.Get("whisper-cpp")
+		if err != nil {
+			t.Fatalf("failed to get provider: %v", err)
+		}
+		if got.Type() != STTProviderWhisperCPP {
+			t.Errorf("expected STTProviderWhisperCPP, got %s", got.Type())
+		}
+	})
+}
+
+func TestWhisperCPPModelConstants(t *testing.T) {
+	expectedModels := []WhisperCPPModel{
+		WhisperCPPTiny,
+		WhisperCPPBase,
+		WhisperCPPSmall,
+		WhisperCPPMedium,
+		WhisperCPPLarge,
+		WhisperCPPLargeV2,
+		WhisperCPPLargeV3,
+		WhisperCPPTurbo,
+	}
+
+	for _, model := range expectedModels {
+		if string(model) == "" {
+			t.Errorf("model constant %v has empty string value", model)
+		}
+	}
+}
+
+func TestWhisperCPPProviderNoOutputFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	modelPath := filepath.Join(tmpDir, "model.bin")
+	os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+	noopScript := filepath.Join(tmpDir, "noop-whisper")
+	os.WriteFile(noopScript, []byte("#!/bin/bash\n"), 0755)
+
+	p, _ := NewWhisperCPPProvider(
+		WithWhisperCPPModelPath(modelPath),
+		WithWhisperCPPBinaryPath(noopScript),
+	)
+
+	_, err := p.Transcribe(context.Background(), []byte("fake-audio"))
+	if err == nil {
+		t.Fatal("expected error when no output is produced")
+	}
+	sttErr, ok := err.(*STTError)
+	if !ok {
+		t.Fatalf("expected *STTError, got %T", err)
+	}
+	if sttErr.Code != ErrTranscriptionFailed {
+		t.Errorf("expected ErrTranscriptionFailed, got %s", sttErr.Code)
+	}
+}
+
+func TestWhisperCPPProviderParseJSONOutputInvalid(t *testing.T) {
+	tmpDir := t.TempDir()
+	modelPath := filepath.Join(tmpDir, "model.bin")
+	os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		jsonPath := filepath.Join(tmpDir, "invalid.json")
+		os.WriteFile(jsonPath, []byte("not valid json{{{"), 0644)
+
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+		_, err := p.parseJSONOutput(jsonPath, TranscribeOptions{})
+		if err == nil {
+			t.Fatal("expected error for invalid JSON")
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+		_, err := p.parseJSONOutput("/nonexistent/file.json", TranscribeOptions{})
+		if err == nil {
+			t.Fatal("expected error for missing JSON file")
+		}
+	})
+}
+
+func TestWhisperCPPProviderParseTextOutputMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	modelPath := filepath.Join(tmpDir, "model.bin")
+	os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+	p, _ := NewWhisperCPPProvider(WithWhisperCPPModelPath(modelPath))
+	_, err := p.parseTextOutput("/nonexistent/file.txt", TranscribeOptions{})
+	if err == nil {
+		t.Fatal("expected error for missing text file")
+	}
+}
+
+func TestWhisperCPPProviderContextCancellation(t *testing.T) {
+	tmpDir := t.TempDir()
+	modelPath := filepath.Join(tmpDir, "model.bin")
+	os.WriteFile(modelPath, []byte("fake-model"), 0644)
+
+	slowScript := filepath.Join(tmpDir, "slow-whisper")
+	os.WriteFile(slowScript, []byte("#!/bin/bash\nsleep 10\n"), 0755)
+
+	p, _ := NewWhisperCPPProvider(
+		WithWhisperCPPModelPath(modelPath),
+		WithWhisperCPPBinaryPath(slowScript),
+		WithWhisperCPPTimeout(30*time.Second),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := p.Transcribe(ctx, []byte("fake-audio"))
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+}

--- a/pkg/speech/stt_whispercpp_test.go
+++ b/pkg/speech/stt_whispercpp_test.go
@@ -700,6 +700,7 @@ JSONEOF
 	p, _ := NewWhisperCPPProvider(
 		WithWhisperCPPModelPath(modelPath),
 		WithWhisperCPPBinaryPath(mockScript),
+		WithWhisperCPPWordTimestamps(true),
 	)
 
 	t.Run("successful transcription with mocked binary", func(t *testing.T) {

--- a/pkg/speech/vad.go
+++ b/pkg/speech/vad.go
@@ -1,0 +1,306 @@
+package speech
+
+import (
+	"math"
+	"sync"
+)
+
+type VADState string
+
+const (
+	VADStateSilence VADState = "silence"
+	VADStateSpeech  VADState = "speech"
+)
+
+type VADConfig struct {
+	SampleRate         int
+	FrameSize          int
+	EnergyThreshold    float64
+	ZeroCrossThreshold int
+	SpeechMinFrames    int
+	SilenceFrames      int
+	HangoverFrames     int
+}
+
+func DefaultVADConfig() VADConfig {
+	return VADConfig{
+		SampleRate:         16000,
+		FrameSize:          320,
+		EnergyThreshold:    0.01,
+		ZeroCrossThreshold: 50,
+		SpeechMinFrames:    3,
+		SilenceFrames:      30,
+		HangoverFrames:     10,
+	}
+}
+
+type VAD struct {
+	mu                 sync.Mutex
+	cfg                VADConfig
+	state              VADState
+	consecutiveSpeech  int
+	consecutiveSilence int
+	listeners          []VADStateListener
+}
+
+type VADStateListener func(state VADState, energy float64, zcr float64)
+
+func NewVAD(cfg VADConfig) *VAD {
+	if cfg.SampleRate == 0 {
+		cfg.SampleRate = 16000
+	}
+	if cfg.FrameSize == 0 {
+		cfg.FrameSize = 320
+	}
+	if cfg.EnergyThreshold == 0 {
+		cfg.EnergyThreshold = 0.01
+	}
+	if cfg.ZeroCrossThreshold == 0 {
+		cfg.ZeroCrossThreshold = 50
+	}
+	if cfg.SpeechMinFrames == 0 {
+		cfg.SpeechMinFrames = 3
+	}
+	if cfg.SilenceFrames == 0 {
+		cfg.SilenceFrames = 30
+	}
+	if cfg.HangoverFrames == 0 {
+		cfg.HangoverFrames = 10
+	}
+
+	return &VAD{
+		cfg:   cfg,
+		state: VADStateSilence,
+	}
+}
+
+func (v *VAD) RegisterListener(listener VADStateListener) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.listeners = append(v.listeners, listener)
+}
+
+func (v *VAD) ProcessFrame(samples []int16) VADState {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	energy := v.calculateRMS(samples)
+	zcr := v.calculateZeroCrossingRate(samples)
+
+	isSpeech := v.isSpeechFrame(energy, zcr)
+
+	if isSpeech {
+		v.consecutiveSpeech++
+		v.consecutiveSilence = 0
+	} else {
+		v.consecutiveSilence++
+		v.consecutiveSpeech = 0
+	}
+
+	switch v.state {
+	case VADStateSilence:
+		if isSpeech {
+			if v.consecutiveSpeech >= v.cfg.SpeechMinFrames {
+				v.state = VADStateSpeech
+				v.notifyListeners(VADStateSpeech, energy, zcr)
+			}
+		} else {
+			v.consecutiveSpeech = 0
+		}
+
+	case VADStateSpeech:
+		if isSpeech {
+			v.consecutiveSilence = 0
+		} else {
+			if v.consecutiveSilence >= v.cfg.HangoverFrames {
+				v.state = VADStateSilence
+				v.consecutiveSpeech = 0
+				v.consecutiveSilence = 0
+				v.notifyListeners(VADStateSilence, energy, zcr)
+			}
+		}
+	}
+
+	return v.state
+}
+
+func (v *VAD) ProcessFloatFrame(samples []float32) VADState {
+	intSamples := make([]int16, len(samples))
+	for i, s := range samples {
+		clamped := s
+		if clamped > 1.0 {
+			clamped = 1.0
+		}
+		if clamped < -1.0 {
+			clamped = -1.0
+		}
+		intSamples[i] = int16(clamped * 32767.0)
+	}
+	return v.ProcessFrame(intSamples)
+}
+
+func (v *VAD) isSpeechFrame(energy float64, zcr float64) bool {
+	return energy > v.cfg.EnergyThreshold || zcr > float64(v.cfg.ZeroCrossThreshold)
+}
+
+func (v *VAD) calculateRMS(samples []int16) float64 {
+	if len(samples) == 0 {
+		return 0
+	}
+
+	var sumSquares float64
+	for _, s := range samples {
+		normalized := float64(s) / 32768.0
+		sumSquares += normalized * normalized
+	}
+
+	return math.Sqrt(sumSquares / float64(len(samples)))
+}
+
+func (v *VAD) calculateZeroCrossingRate(samples []int16) float64 {
+	if len(samples) < 2 {
+		return 0
+	}
+
+	var crossings int
+	for i := 1; i < len(samples); i++ {
+		if (samples[i] >= 0 && samples[i-1] < 0) || (samples[i] < 0 && samples[i-1] >= 0) {
+			crossings++
+		}
+	}
+
+	return float64(crossings)
+}
+
+func (v *VAD) State() VADState {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.state
+}
+
+func (v *VAD) Reset() {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.state = VADStateSilence
+	v.consecutiveSpeech = 0
+	v.consecutiveSilence = 0
+}
+
+func (v *VAD) notifyListeners(state VADState, energy float64, zcr float64) {
+	for _, listener := range v.listeners {
+		listener(state, energy, zcr)
+	}
+}
+
+func (v *VAD) UpdateConfig(cfg VADConfig) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if cfg.EnergyThreshold > 0 {
+		v.cfg.EnergyThreshold = cfg.EnergyThreshold
+	}
+	if cfg.ZeroCrossThreshold > 0 {
+		v.cfg.ZeroCrossThreshold = cfg.ZeroCrossThreshold
+	}
+	if cfg.SpeechMinFrames > 0 {
+		v.cfg.SpeechMinFrames = cfg.SpeechMinFrames
+	}
+	if cfg.SilenceFrames > 0 {
+		v.cfg.SilenceFrames = cfg.SilenceFrames
+	}
+	if cfg.HangoverFrames > 0 {
+		v.cfg.HangoverFrames = cfg.HangoverFrames
+	}
+}
+
+func (v *VAD) Config() VADConfig {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.cfg
+}
+
+func NormalizeAudio(samples []int16) []float64 {
+	result := make([]float64, len(samples))
+	for i, s := range samples {
+		result[i] = float64(s) / 32768.0
+	}
+	return result
+}
+
+func Float32ToInt16(samples []float32) []int16 {
+	result := make([]int16, len(samples))
+	for i, s := range samples {
+		clamped := s
+		if clamped > 1.0 {
+			clamped = 1.0
+		}
+		if clamped < -1.0 {
+			clamped = -1.0
+		}
+		result[i] = int16(clamped * 32767.0)
+	}
+	return result
+}
+
+func Int16ToWAV(samples []int16, sampleRate int, channels int) []byte {
+	if len(samples) == 0 {
+		return nil
+	}
+
+	bitsPerSample := 16
+	byteRate := sampleRate * channels * bitsPerSample / 8
+	blockAlign := channels * bitsPerSample / 8
+	dataSize := len(samples) * 2
+	fileSize := 36 + dataSize
+
+	buf := make([]byte, 44+dataSize)
+
+	copy(buf[0:4], []byte("RIFF"))
+	buf[4] = byte(fileSize)
+	buf[5] = byte(fileSize >> 8)
+	buf[6] = byte(fileSize >> 16)
+	buf[7] = byte(fileSize >> 24)
+
+	copy(buf[8:12], []byte("WAVE"))
+
+	copy(buf[12:16], []byte("fmt "))
+	buf[16] = 16
+	buf[17] = 0
+	buf[18] = 0
+	buf[19] = 0
+
+	buf[20] = 1
+	buf[21] = 0
+
+	buf[22] = byte(channels)
+	buf[23] = 0
+
+	buf[24] = byte(sampleRate)
+	buf[25] = byte(sampleRate >> 8)
+	buf[26] = byte(sampleRate >> 16)
+	buf[27] = byte(sampleRate >> 24)
+
+	buf[28] = byte(byteRate)
+	buf[29] = byte(byteRate >> 8)
+	buf[30] = byte(byteRate >> 16)
+	buf[31] = byte(byteRate >> 24)
+
+	buf[32] = byte(blockAlign)
+	buf[33] = 0
+
+	buf[34] = byte(bitsPerSample)
+	buf[35] = 0
+
+	copy(buf[36:40], []byte("data"))
+	buf[40] = byte(dataSize)
+	buf[41] = byte(dataSize >> 8)
+	buf[42] = byte(dataSize >> 16)
+	buf[43] = byte(dataSize >> 24)
+
+	for i, s := range samples {
+		offset := 44 + i*2
+		buf[offset] = byte(s)
+		buf[offset+1] = byte(s >> 8)
+	}
+
+	return buf
+}

--- a/pkg/speech/voice_arbitration.go
+++ b/pkg/speech/voice_arbitration.go
@@ -1,0 +1,338 @@
+package speech
+
+import (
+	"sync"
+	"time"
+)
+
+type WakeArbitrationConfig struct {
+	ArbitrationWindow time.Duration
+	MinConfidence     float64
+	PreferLocal       bool
+	LocalPriority     int
+	ElectionMode      ElectionMode
+}
+
+type ElectionMode string
+
+const (
+	ElectionFirstResponse   ElectionMode = "first-response"
+	ElectionBestSignal      ElectionMode = "best-signal"
+	ElectionHighestPriority ElectionMode = "highest-priority"
+)
+
+func DefaultWakeArbitrationConfig() WakeArbitrationConfig {
+	return WakeArbitrationConfig{
+		ArbitrationWindow: 500 * time.Millisecond,
+		MinConfidence:     0.3,
+		PreferLocal:       true,
+		LocalPriority:     50,
+		ElectionMode:      ElectionBestSignal,
+	}
+}
+
+type WakeEvent struct {
+	DeviceID   string
+	DeviceName string
+	Phrase     string
+	Confidence float64
+	Energy     float64
+	Timestamp  time.Time
+	Engine     string
+	Priority   int
+}
+
+type WakeArbitrationResult struct {
+	WinnerID   string
+	WinnerName string
+	IsLocal    bool
+	Confidence float64
+	AllEvents  []WakeEvent
+	DecidedAt  time.Time
+}
+
+type WakeArbitration struct {
+	mu         sync.Mutex
+	cfg        WakeArbitrationConfig
+	localID    string
+	pending    map[string][]WakeEvent
+	timers     map[string]*time.Timer
+	listeners  []ArbitrationListener
+	suppressor *WakeSuppressor
+	history    []WakeArbitrationResult
+	maxHistory int
+}
+
+type ArbitrationListener func(result WakeArbitrationResult)
+
+func NewWakeArbitration(localID string, cfg WakeArbitrationConfig) *WakeArbitration {
+	if cfg.ArbitrationWindow == 0 {
+		cfg.ArbitrationWindow = 500 * time.Millisecond
+	}
+	if cfg.MinConfidence == 0 {
+		cfg.MinConfidence = 0.3
+	}
+	if cfg.LocalPriority == 0 {
+		cfg.LocalPriority = 50
+	}
+
+	return &WakeArbitration{
+		cfg:        cfg,
+		localID:    localID,
+		pending:    make(map[string][]WakeEvent),
+		timers:     make(map[string]*time.Timer),
+		maxHistory: 100,
+	}
+}
+
+func (a *WakeArbitration) SetSuppressor(s *WakeSuppressor) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.suppressor = s
+}
+
+func (a *WakeArbitration) RegisterListener(listener ArbitrationListener) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.listeners = append(a.listeners, listener)
+}
+
+func (a *WakeArbitration) SubmitLocalWake(event WakeEvent) {
+	event.DeviceID = a.localID
+	event.Timestamp = time.Now()
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if event.Confidence < a.cfg.MinConfidence {
+		return
+	}
+
+	if a.suppressor != nil && a.suppressor.IsSuppressed() {
+		return
+	}
+
+	groupID := a.groupWakeEvents(event.Phrase, event.Timestamp)
+
+	a.pending[groupID] = append(a.pending[groupID], event)
+
+	if _, hasTimer := a.timers[groupID]; !hasTimer {
+		timer := time.AfterFunc(a.cfg.ArbitrationWindow, func() {
+			a.decide(groupID)
+		})
+		a.timers[groupID] = timer
+	}
+}
+
+func (a *WakeArbitration) SubmitRemoteWake(event WakeEvent) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if event.Confidence < a.cfg.MinConfidence {
+		return
+	}
+
+	groupID := a.groupWakeEvents(event.Phrase, event.Timestamp)
+
+	a.pending[groupID] = append(a.pending[groupID], event)
+
+	if _, hasTimer := a.timers[groupID]; !hasTimer {
+		timer := time.AfterFunc(a.cfg.ArbitrationWindow, func() {
+			a.decide(groupID)
+		})
+		a.timers[groupID] = timer
+	}
+}
+
+func (a *WakeArbitration) decide(groupID string) {
+	a.mu.Lock()
+	events := a.pending[groupID]
+	delete(a.pending, groupID)
+	delete(a.timers, groupID)
+	suppressor := a.suppressor
+	cfg := a.cfg
+	localID := a.localID
+	a.mu.Unlock()
+
+	if len(events) == 0 {
+		return
+	}
+
+	winner := a.selectWinner(events, cfg, localID)
+
+	result := WakeArbitrationResult{
+		WinnerID:   winner.DeviceID,
+		WinnerName: winner.DeviceName,
+		IsLocal:    winner.DeviceID == localID,
+		Confidence: winner.Confidence,
+		AllEvents:  events,
+		DecidedAt:  time.Now(),
+	}
+
+	a.mu.Lock()
+	a.history = append(a.history, result)
+	if len(a.history) > a.maxHistory {
+		a.history = a.history[len(a.history)-a.maxHistory:]
+	}
+	listeners := make([]ArbitrationListener, len(a.listeners))
+	copy(listeners, a.listeners)
+	a.mu.Unlock()
+
+	if suppressor != nil && !result.IsLocal {
+		suppressor.Suppress(winner.DeviceID, winner.DeviceName, cfg.ArbitrationWindow*2)
+	}
+
+	for _, listener := range listeners {
+		listener(result)
+	}
+}
+
+func (a *WakeArbitration) selectWinner(events []WakeEvent, cfg WakeArbitrationConfig, localID string) WakeEvent {
+	if len(events) == 1 {
+		return events[0]
+	}
+
+	switch cfg.ElectionMode {
+	case ElectionFirstResponse:
+		return a.electionFirstResponse(events)
+
+	case ElectionBestSignal:
+		return a.electionBestSignal(events, cfg, localID)
+
+	case ElectionHighestPriority:
+		return a.electionHighestPriority(events, cfg, localID)
+
+	default:
+		return a.electionBestSignal(events, cfg, localID)
+	}
+}
+
+func (a *WakeArbitration) electionFirstResponse(events []WakeEvent) WakeEvent {
+	best := events[0]
+	for _, e := range events[1:] {
+		if e.Timestamp.Before(best.Timestamp) {
+			best = e
+		}
+	}
+	return best
+}
+
+func (a *WakeArbitration) electionBestSignal(events []WakeEvent, cfg WakeArbitrationConfig, localID string) WakeEvent {
+	best := events[0]
+	bestScore := a.signalScore(events[0], cfg, localID)
+
+	for _, e := range events[1:] {
+		score := a.signalScore(e, cfg, localID)
+		if score > bestScore {
+			best = e
+			bestScore = score
+		}
+	}
+
+	return best
+}
+
+func (a *WakeArbitration) signalScore(event WakeEvent, cfg WakeArbitrationConfig, localID string) float64 {
+	score := event.Confidence * 0.6
+
+	if event.Energy > 0 {
+		energyNorm := event.Energy
+		if energyNorm > 1.0 {
+			energyNorm = 1.0
+		}
+		score += energyNorm * 0.3
+	}
+
+	if event.DeviceID == localID && cfg.PreferLocal {
+		score += 0.1
+	}
+
+	priorityNorm := float64(event.Priority) / 100.0
+	score += priorityNorm * 0.1
+
+	return score
+}
+
+func (a *WakeArbitration) electionHighestPriority(events []WakeEvent, cfg WakeArbitrationConfig, localID string) WakeEvent {
+	best := events[0]
+	bestPriority := a.priorityScore(events[0], cfg, localID)
+
+	for _, e := range events[1:] {
+		priority := a.priorityScore(e, cfg, localID)
+		if priority > bestPriority {
+			best = e
+			bestPriority = priority
+		}
+	}
+
+	return best
+}
+
+func (a *WakeArbitration) priorityScore(event WakeEvent, cfg WakeArbitrationConfig, localID string) int {
+	score := event.Priority
+
+	if event.DeviceID == localID && cfg.PreferLocal {
+		score += 10
+	}
+
+	score += int(event.Confidence * 50)
+
+	return score
+}
+
+func (a *WakeArbitration) groupWakeEvents(phrase string, ts time.Time) string {
+	return phrase
+}
+
+func (a *WakeArbitration) History() []WakeArbitrationResult {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	result := make([]WakeArbitrationResult, len(a.history))
+	copy(result, a.history)
+	return result
+}
+
+func (a *WakeArbitration) PendingCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	count := 0
+	for _, events := range a.pending {
+		count += len(events)
+	}
+	return count
+}
+
+func (a *WakeArbitration) Clear() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	for _, timer := range a.timers {
+		timer.Stop()
+	}
+
+	a.pending = make(map[string][]WakeEvent)
+	a.timers = make(map[string]*time.Timer)
+}
+
+func (a *WakeArbitration) SetConfig(cfg WakeArbitrationConfig) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if cfg.ArbitrationWindow > 0 {
+		a.cfg.ArbitrationWindow = cfg.ArbitrationWindow
+	}
+	if cfg.MinConfidence > 0 {
+		a.cfg.MinConfidence = cfg.MinConfidence
+	}
+	a.cfg.PreferLocal = cfg.PreferLocal
+	a.cfg.LocalPriority = cfg.LocalPriority
+	a.cfg.ElectionMode = cfg.ElectionMode
+}
+
+func (a *WakeArbitration) Config() WakeArbitrationConfig {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.cfg
+}

--- a/pkg/speech/voice_coordinator.go
+++ b/pkg/speech/voice_coordinator.go
@@ -1,0 +1,643 @@
+package speech
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"sync"
+	"time"
+)
+
+type VoiceWakeCoordinator struct {
+	mu             sync.Mutex
+	cfg            VoiceWakeCoordinatorConfig
+	discovery      *DeviceDiscovery
+	arbitration    *WakeArbitration
+	suppressor     *WakeSuppressor
+	localID        string
+	isRunning      bool
+	eventCh        chan CoordinatorEvent
+	listeners      []CoordinatorListener
+	stats          CoordinatorStats
+	startTime      time.Time
+	wakeConn       *net.UDPConn
+	wakeListenDone chan struct{}
+	wakePort       int
+}
+
+type VoiceWakeCoordinatorConfig struct {
+	DeviceID          string
+	DeviceName        string
+	DeviceType        DeviceType
+	DiscoveryConfig   DeviceDiscoveryConfig
+	ArbitrationConfig WakeArbitrationConfig
+	Enabled           bool
+	AutoStart         bool
+	BroadcastPort     int
+	WakeEventPort     int
+}
+
+func DefaultVoiceWakeCoordinatorConfig() VoiceWakeCoordinatorConfig {
+	return VoiceWakeCoordinatorConfig{
+		DeviceID:          "device-local",
+		DeviceName:        "Local Device",
+		DeviceType:        DeviceTypeDesktop,
+		DiscoveryConfig:   DefaultDeviceDiscoveryConfig(),
+		ArbitrationConfig: DefaultWakeArbitrationConfig(),
+		Enabled:           true,
+		AutoStart:         false,
+		BroadcastPort:     19876,
+		WakeEventPort:     19877,
+	}
+}
+
+type CoordinatorEventType string
+
+const (
+	CoordinatorEventDeviceDiscovered CoordinatorEventType = "device_discovered"
+	CoordinatorEventDeviceLost       CoordinatorEventType = "device_lost"
+	CoordinatorEventWakeSubmitted    CoordinatorEventType = "wake_submitted"
+	CoordinatorEventArbitrationWon   CoordinatorEventType = "arbitration_won"
+	CoordinatorEventArbitrationLost  CoordinatorEventType = "arbitration_lost"
+	CoordinatorEventSuppressed       CoordinatorEventType = "suppressed"
+	CoordinatorEventReleased         CoordinatorEventType = "released"
+)
+
+type CoordinatorEvent struct {
+	Type      CoordinatorEventType
+	Timestamp time.Time
+	Data      map[string]any
+}
+
+type CoordinatorListener func(event CoordinatorEvent)
+
+type CoordinatorStats struct {
+	DevicesDiscovered int
+	DevicesLost       int
+	WakesSubmitted    int
+	ArbitrationsWon   int
+	ArbitrationsLost  int
+	Suppressions      int
+	Releases          int
+	LastWakeTime      time.Time
+	LastArbitration   time.Time
+}
+
+func NewVoiceWakeCoordinator(cfg VoiceWakeCoordinatorConfig) *VoiceWakeCoordinator {
+	if cfg.DeviceID == "" {
+		cfg.DeviceID = "device-local"
+	}
+	if cfg.DeviceName == "" {
+		cfg.DeviceName = "Local Device"
+	}
+	if cfg.BroadcastPort == 0 {
+		cfg.BroadcastPort = 19876
+	}
+	if cfg.WakeEventPort == 0 {
+		cfg.WakeEventPort = 19877
+	}
+
+	cfg.DiscoveryConfig.DeviceID = cfg.DeviceID
+	cfg.DiscoveryConfig.DeviceName = cfg.DeviceName
+	cfg.DiscoveryConfig.DeviceType = cfg.DeviceType
+	cfg.DiscoveryConfig.BroadcastPort = cfg.BroadcastPort
+
+	cfg.ArbitrationConfig.LocalPriority = cfg.DiscoveryConfig.Priority
+
+	suppressor := NewWakeSuppressor()
+	arbitration := NewWakeArbitration(cfg.DeviceID, cfg.ArbitrationConfig)
+	arbitration.SetSuppressor(suppressor)
+
+	discovery := NewDeviceDiscovery(cfg.DiscoveryConfig)
+
+	vc := &VoiceWakeCoordinator{
+		cfg:         cfg,
+		localID:     cfg.DeviceID,
+		discovery:   discovery,
+		arbitration: arbitration,
+		suppressor:  suppressor,
+		eventCh:     make(chan CoordinatorEvent, 100),
+		wakePort:    cfg.WakeEventPort,
+	}
+
+	discovery.UpdateMetadata("wake_port", fmt.Sprintf("%d", cfg.WakeEventPort))
+
+	return vc
+}
+
+func (c *VoiceWakeCoordinator) Start(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if !c.cfg.Enabled {
+		return nil
+	}
+
+	if c.isRunning {
+		return fmt.Errorf("coordinator: already running")
+	}
+
+	if err := c.discovery.Start(); err != nil {
+		return fmt.Errorf("coordinator: failed to start discovery: %w", err)
+	}
+
+	c.discovery.RegisterListener(c.onDiscoveryEvent)
+	c.arbitration.RegisterListener(c.onArbitrationResult)
+	c.suppressor.RegisterListener(c.onSuppressionEvent)
+
+	if err := c.startWakeEventListener(); err != nil {
+		c.discovery.Stop()
+		return fmt.Errorf("coordinator: failed to start wake event listener: %w", err)
+	}
+
+	c.isRunning = true
+	c.startTime = time.Now()
+
+	go c.eventLoop(ctx)
+
+	log.Printf("coordinator: started (device: %s, discovery port: %d, wake port: %d)", c.localID, c.cfg.BroadcastPort, c.wakePort)
+
+	return nil
+}
+
+func (c *VoiceWakeCoordinator) Stop() error {
+	c.mu.Lock()
+
+	if !c.isRunning {
+		c.mu.Unlock()
+		return nil
+	}
+
+	c.isRunning = false
+
+	if err := c.discovery.Stop(); err != nil {
+		log.Printf("coordinator: error stopping discovery: %v", err)
+	}
+
+	c.mu.Unlock()
+
+	c.stopWakeEventListener()
+
+	c.mu.Lock()
+	c.arbitration.Clear()
+	c.mu.Unlock()
+
+	log.Printf("coordinator: stopped")
+
+	return nil
+}
+
+func (c *VoiceWakeCoordinator) eventLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-c.eventCh:
+			if !ok {
+				return
+			}
+
+			c.mu.Lock()
+			listeners := make([]CoordinatorListener, len(c.listeners))
+			copy(listeners, c.listeners)
+			c.mu.Unlock()
+
+			for _, listener := range listeners {
+				listener(event)
+			}
+		}
+	}
+}
+
+func (c *VoiceWakeCoordinator) onDiscoveryEvent(event DiscoveryEvent) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	switch event.Type {
+	case "device_discovered":
+		c.stats.DevicesDiscovered++
+
+	case "device_lost":
+		c.stats.DevicesLost++
+	}
+
+	c.emitEvent(CoordinatorEvent{
+		Type:      CoordinatorEventType(event.Type),
+		Timestamp: event.Timestamp,
+		Data: map[string]any{
+			"device_id":   event.Device.ID,
+			"device_name": event.Device.Name,
+			"device_type": event.Device.Type,
+			"ip_address":  event.Device.IPAddress,
+		},
+	})
+}
+
+func (c *VoiceWakeCoordinator) onArbitrationResult(result WakeArbitrationResult) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.stats.LastArbitration = result.DecidedAt
+
+	if result.IsLocal {
+		c.stats.ArbitrationsWon++
+
+		c.emitEvent(CoordinatorEvent{
+			Type:      CoordinatorEventArbitrationWon,
+			Timestamp: result.DecidedAt,
+			Data: map[string]any{
+				"winner_id":   result.WinnerID,
+				"winner_name": result.WinnerName,
+				"confidence":  result.Confidence,
+				"event_count": len(result.AllEvents),
+			},
+		})
+	} else {
+		c.stats.ArbitrationsLost++
+
+		c.emitEvent(CoordinatorEvent{
+			Type:      CoordinatorEventArbitrationLost,
+			Timestamp: result.DecidedAt,
+			Data: map[string]any{
+				"winner_id":   result.WinnerID,
+				"winner_name": result.WinnerName,
+				"confidence":  result.Confidence,
+			},
+		})
+	}
+}
+
+func (c *VoiceWakeCoordinator) onSuppressionEvent(event SuppressionEvent) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	switch event.Type {
+	case "suppressed":
+		c.stats.Suppressions++
+
+		c.emitEvent(CoordinatorEvent{
+			Type:      CoordinatorEventSuppressed,
+			Timestamp: event.Timestamp,
+			Data: map[string]any{
+				"device_id":   event.DeviceID,
+				"device_name": event.DeviceName,
+				"duration":    event.Duration,
+				"remaining":   event.Remaining,
+			},
+		})
+
+	case "released":
+		c.stats.Releases++
+
+		c.emitEvent(CoordinatorEvent{
+			Type:      CoordinatorEventReleased,
+			Timestamp: event.Timestamp,
+			Data: map[string]any{
+				"device_id":   event.DeviceID,
+				"device_name": event.DeviceName,
+			},
+		})
+	}
+}
+
+func (c *VoiceWakeCoordinator) emitEvent(event CoordinatorEvent) {
+	select {
+	case c.eventCh <- event:
+	default:
+	}
+}
+
+func (c *VoiceWakeCoordinator) SubmitWake(phrase string, confidence float64, energy float64, engine string) bool {
+	c.mu.Lock()
+	suppressor := c.suppressor
+	localID := c.localID
+	deviceName := c.cfg.DeviceName
+	priority := c.cfg.DiscoveryConfig.Priority
+	c.mu.Unlock()
+
+	if suppressor.IsSuppressed() {
+		return false
+	}
+
+	event := WakeEvent{
+		DeviceID:   localID,
+		DeviceName: deviceName,
+		Phrase:     phrase,
+		Confidence: confidence,
+		Energy:     energy,
+		Engine:     engine,
+		Priority:   priority,
+	}
+
+	c.mu.Lock()
+	c.stats.WakesSubmitted++
+	c.stats.LastWakeTime = time.Now()
+	c.mu.Unlock()
+
+	c.arbitration.SubmitLocalWake(event)
+
+	c.broadcastWakeEvent(event)
+
+	return true
+}
+
+func (c *VoiceWakeCoordinator) broadcastWakeEvent(event WakeEvent) {
+	c.mu.Lock()
+	devices := c.discovery.GetDevices()
+	c.mu.Unlock()
+
+	for _, device := range devices {
+		if device.ID == c.localID {
+			continue
+		}
+
+		c.sendWakeToPeer(device, event)
+	}
+}
+
+func (c *VoiceWakeCoordinator) ReceiveRemoteWake(event WakeEvent) {
+	c.mu.Lock()
+	suppressor := c.suppressor
+	c.mu.Unlock()
+
+	if suppressor.IsSuppressedBy(event.DeviceID) {
+		return
+	}
+
+	c.arbitration.SubmitRemoteWake(event)
+}
+
+func (c *VoiceWakeCoordinator) IsSuppressed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.suppressor.IsSuppressed()
+}
+
+func (c *VoiceWakeCoordinator) SuppressionRemaining() time.Duration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.suppressor.RemainingTime()
+}
+
+func (c *VoiceWakeCoordinator) RegisterListener(listener CoordinatorListener) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.listeners = append(c.listeners, listener)
+}
+
+func (c *VoiceWakeCoordinator) GetDevices() []DeviceInfo {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.discovery.GetDevices()
+}
+
+func (c *VoiceWakeCoordinator) GetDeviceCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.discovery.GetDeviceCount()
+}
+
+func (c *VoiceWakeCoordinator) LocalDevice() DeviceInfo {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.discovery.LocalDevice()
+}
+
+func (c *VoiceWakeCoordinator) Stats() CoordinatorStats {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.stats
+}
+
+func (c *VoiceWakeCoordinator) IsRunning() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.isRunning
+}
+
+func (c *VoiceWakeCoordinator) Arbitration() *WakeArbitration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.arbitration
+}
+
+func (c *VoiceWakeCoordinator) Suppressor() *WakeSuppressor {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.suppressor
+}
+
+func (c *VoiceWakeCoordinator) Discovery() *DeviceDiscovery {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.discovery
+}
+
+func (c *VoiceWakeCoordinator) SetPriority(priority int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cfg.DiscoveryConfig.Priority = priority
+	c.cfg.ArbitrationConfig.LocalPriority = priority
+
+	if c.discovery != nil {
+		c.discovery.SetPriority(priority)
+	}
+}
+
+func (c *VoiceWakeCoordinator) SetElectionMode(mode ElectionMode) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cfg.ArbitrationConfig.ElectionMode = mode
+	if c.arbitration != nil {
+		c.arbitration.SetConfig(c.cfg.ArbitrationConfig)
+	}
+}
+
+func (c *VoiceWakeCoordinator) SetPreferLocal(prefer bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cfg.ArbitrationConfig.PreferLocal = prefer
+	if c.arbitration != nil {
+		c.arbitration.SetConfig(c.cfg.ArbitrationConfig)
+	}
+}
+
+func (c *VoiceWakeCoordinator) SetArbitrationWindow(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cfg.ArbitrationConfig.ArbitrationWindow = d
+	if c.arbitration != nil {
+		c.arbitration.SetConfig(c.cfg.ArbitrationConfig)
+	}
+}
+
+func (c *VoiceWakeCoordinator) ProbeDevices() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.discovery != nil {
+		c.discovery.Probe()
+	}
+}
+
+func (c *VoiceWakeCoordinator) startWakeEventListener() error {
+	port := c.cfg.WakeEventPort
+	if port == 0 {
+		port = 19877
+	}
+
+	addr := &net.UDPAddr{
+		IP:   net.IPv4zero,
+		Port: port,
+	}
+
+	conn, err := net.ListenUDP("udp4", addr)
+	if err != nil {
+		return fmt.Errorf("failed to bind wake event port %d: %w", port, err)
+	}
+
+	c.wakeConn = conn
+	c.wakePort = port
+	c.wakeListenDone = make(chan struct{})
+
+	go c.wakeEventListenLoop()
+
+	return nil
+}
+
+func (c *VoiceWakeCoordinator) stopWakeEventListener() {
+	if c.wakeConn != nil {
+		c.wakeConn.Close()
+		c.wakeConn = nil
+	}
+
+	if c.wakeListenDone != nil {
+		<-c.wakeListenDone
+		c.wakeListenDone = nil
+	}
+}
+
+func (c *VoiceWakeCoordinator) wakeEventListenLoop() {
+	defer close(c.wakeListenDone)
+
+	buf := make([]byte, 8192)
+
+	for {
+		c.mu.Lock()
+		conn := c.wakeConn
+		isRunning := c.isRunning
+		c.mu.Unlock()
+
+		if !isRunning || conn == nil {
+			return
+		}
+
+		n, remoteAddr, err := conn.ReadFromUDP(buf)
+		if err != nil {
+			return
+		}
+
+		if n == 0 {
+			continue
+		}
+
+		var msg wakeEventMessage
+		if err := json.Unmarshal(buf[:n], &msg); err != nil {
+			continue
+		}
+
+		if msg.Type != "wake_event" {
+			continue
+		}
+
+		if msg.DeviceID == c.localID {
+			continue
+		}
+
+		remoteEvent := WakeEvent{
+			DeviceID:   msg.DeviceID,
+			DeviceName: msg.DeviceName,
+			Phrase:     msg.Phrase,
+			Confidence: msg.Confidence,
+			Energy:     msg.Energy,
+			Timestamp:  msg.Timestamp,
+			Engine:     msg.Engine,
+			Priority:   msg.Priority,
+		}
+
+		log.Printf("coordinator: received remote wake from %s (%s) phrase=%q confidence=%.2f",
+			remoteEvent.DeviceName, remoteAddr.IP.String(), remoteEvent.Phrase, remoteEvent.Confidence)
+
+		c.ReceiveRemoteWake(remoteEvent)
+	}
+}
+
+type wakeEventMessage struct {
+	Type       string    `json:"type"`
+	DeviceID   string    `json:"device_id"`
+	DeviceName string    `json:"device_name"`
+	Phrase     string    `json:"phrase"`
+	Confidence float64   `json:"confidence"`
+	Energy     float64   `json:"energy"`
+	Timestamp  time.Time `json:"timestamp"`
+	Engine     string    `json:"engine"`
+	Priority   int       `json:"priority"`
+}
+
+func (c *VoiceWakeCoordinator) sendWakeToPeer(device DeviceInfo, event WakeEvent) {
+	c.mu.Lock()
+	conn := c.wakeConn
+	c.mu.Unlock()
+
+	if conn == nil {
+		return
+	}
+
+	msg := wakeEventMessage{
+		Type:       "wake_event",
+		DeviceID:   event.DeviceID,
+		DeviceName: event.DeviceName,
+		Phrase:     event.Phrase,
+		Confidence: event.Confidence,
+		Energy:     event.Energy,
+		Timestamp:  event.Timestamp,
+		Engine:     event.Engine,
+		Priority:   event.Priority,
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		log.Printf("coordinator: failed to marshal wake event: %v", err)
+		return
+	}
+
+	targetPort := device.Metadata["wake_port"]
+	if targetPort == "" {
+		targetPort = "19877"
+	}
+
+	port := 19877
+	if p, ok := device.Metadata["wake_port"]; ok {
+		fmt.Sscanf(p, "%d", &port)
+	}
+
+	targetAddr := &net.UDPAddr{
+		IP:   net.ParseIP(device.IPAddress),
+		Port: port,
+	}
+
+	conn.SetWriteDeadline(time.Now().Add(200 * time.Millisecond))
+	_, err = conn.WriteToUDP(data, targetAddr)
+	if err != nil {
+		log.Printf("coordinator: failed to send wake to peer %s (%s): %v", device.Name, device.IPAddress, err)
+		return
+	}
+
+	log.Printf("coordinator: sent wake event to peer %s (%s)", device.Name, device.IPAddress)
+}

--- a/pkg/speech/voice_coordinator.go
+++ b/pkg/speech/voice_coordinator.go
@@ -171,18 +171,21 @@ func (c *VoiceWakeCoordinator) Stop() error {
 	}
 
 	c.isRunning = false
-
-	if err := c.discovery.Stop(); err != nil {
-		log.Printf("coordinator: error stopping discovery: %v", err)
-	}
-
+	discovery := c.discovery
+	arbitration := c.arbitration
 	c.mu.Unlock()
+
+	if discovery != nil {
+		if err := discovery.Stop(); err != nil {
+			log.Printf("coordinator: error stopping discovery: %v", err)
+		}
+	}
 
 	c.stopWakeEventListener()
 
-	c.mu.Lock()
-	c.arbitration.Clear()
-	c.mu.Unlock()
+	if arbitration != nil {
+		arbitration.Clear()
+	}
 
 	log.Printf("coordinator: stopped")
 
@@ -512,14 +515,19 @@ func (c *VoiceWakeCoordinator) startWakeEventListener() error {
 }
 
 func (c *VoiceWakeCoordinator) stopWakeEventListener() {
-	if c.wakeConn != nil {
-		c.wakeConn.Close()
-		c.wakeConn = nil
+	c.mu.Lock()
+	conn := c.wakeConn
+	done := c.wakeListenDone
+	c.wakeConn = nil
+	c.wakeListenDone = nil
+	c.mu.Unlock()
+
+	if conn != nil {
+		_ = conn.Close()
 	}
 
-	if c.wakeListenDone != nil {
-		<-c.wakeListenDone
-		c.wakeListenDone = nil
+	if done != nil {
+		<-done
 	}
 }
 

--- a/pkg/speech/voice_coordinator.go
+++ b/pkg/speech/voice_coordinator.go
@@ -147,7 +147,8 @@ func (c *VoiceWakeCoordinator) Start(ctx context.Context) error {
 	c.arbitration.RegisterListener(c.onArbitrationResult)
 	c.suppressor.RegisterListener(c.onSuppressionEvent)
 
-	if err := c.startWakeEventListener(); err != nil {
+	conn, done, err := c.startWakeEventListener()
+	if err != nil {
 		c.discovery.Stop()
 		return fmt.Errorf("coordinator: failed to start wake event listener: %w", err)
 	}
@@ -155,6 +156,7 @@ func (c *VoiceWakeCoordinator) Start(ctx context.Context) error {
 	c.isRunning = true
 	c.startTime = time.Now()
 
+	go c.wakeEventListenLoop(conn, done)
 	go c.eventLoop(ctx)
 
 	log.Printf("coordinator: started (device: %s, discovery port: %d, wake port: %d)", c.localID, c.cfg.BroadcastPort, c.wakePort)
@@ -489,7 +491,7 @@ func (c *VoiceWakeCoordinator) ProbeDevices() {
 	}
 }
 
-func (c *VoiceWakeCoordinator) startWakeEventListener() error {
+func (c *VoiceWakeCoordinator) startWakeEventListener() (*net.UDPConn, chan struct{}, error) {
 	port := c.cfg.WakeEventPort
 	if port == 0 {
 		port = 19877
@@ -502,24 +504,21 @@ func (c *VoiceWakeCoordinator) startWakeEventListener() error {
 
 	conn, err := net.ListenUDP("udp4", addr)
 	if err != nil {
-		return fmt.Errorf("failed to bind wake event port %d: %w", port, err)
+		return nil, nil, fmt.Errorf("failed to bind wake event port %d: %w", port, err)
 	}
 
 	c.wakeConn = conn
 	c.wakePort = port
-	c.wakeListenDone = make(chan struct{})
+	done := make(chan struct{})
+	c.wakeListenDone = done
 
-	go c.wakeEventListenLoop()
-
-	return nil
+	return conn, done, nil
 }
 
 func (c *VoiceWakeCoordinator) stopWakeEventListener() {
 	c.mu.Lock()
 	conn := c.wakeConn
 	done := c.wakeListenDone
-	c.wakeConn = nil
-	c.wakeListenDone = nil
 	c.mu.Unlock()
 
 	if conn != nil {
@@ -529,16 +528,24 @@ func (c *VoiceWakeCoordinator) stopWakeEventListener() {
 	if done != nil {
 		<-done
 	}
+
+	c.mu.Lock()
+	if c.wakeConn == conn {
+		c.wakeConn = nil
+	}
+	if c.wakeListenDone == done {
+		c.wakeListenDone = nil
+	}
+	c.mu.Unlock()
 }
 
-func (c *VoiceWakeCoordinator) wakeEventListenLoop() {
-	defer close(c.wakeListenDone)
+func (c *VoiceWakeCoordinator) wakeEventListenLoop(conn *net.UDPConn, done chan struct{}) {
+	defer close(done)
 
 	buf := make([]byte, 8192)
 
 	for {
 		c.mu.Lock()
-		conn := c.wakeConn
 		isRunning := c.isRunning
 		c.mu.Unlock()
 

--- a/pkg/speech/voice_coordinator_test.go
+++ b/pkg/speech/voice_coordinator_test.go
@@ -365,6 +365,37 @@ func TestVoiceWakeCoordinator_StopClearsWakeListenerState(t *testing.T) {
 	}
 }
 
+func TestVoiceWakeCoordinator_StartKeepsWakeListenerRunning(t *testing.T) {
+	cfg := DefaultVoiceWakeCoordinatorConfig()
+	cfg.DeviceID = "test-device"
+	cfg.DeviceName = "Test Device"
+	cfg.Enabled = true
+	cfg.BroadcastPort = 19922
+	cfg.WakeEventPort = 19923
+
+	coord := NewVoiceWakeCoordinator(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := coord.Start(ctx); err != nil {
+		t.Fatalf("failed to start coordinator: %v", err)
+	}
+	defer coord.Stop()
+
+	if coord.wakeListenDone == nil {
+		t.Fatal("expected wake listener done channel after start")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	select {
+	case <-coord.wakeListenDone:
+		t.Fatal("wake listener exited unexpectedly while coordinator is running")
+	default:
+	}
+}
+
 func TestVoiceWakeCoordinator_SubmitWake(t *testing.T) {
 	cfg := DefaultVoiceWakeCoordinatorConfig()
 	cfg.DeviceID = "test-device"

--- a/pkg/speech/voice_coordinator_test.go
+++ b/pkg/speech/voice_coordinator_test.go
@@ -1,0 +1,729 @@
+package speech
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWakeArbitration_FirstResponse(t *testing.T) {
+	cfg := DefaultWakeArbitrationConfig()
+	cfg.ElectionMode = ElectionFirstResponse
+
+	arb := NewWakeArbitration("device-1", cfg)
+
+	done := make(chan WakeArbitrationResult, 1)
+	arb.RegisterListener(func(result WakeArbitrationResult) {
+		done <- result
+	})
+
+	arb.SubmitLocalWake(WakeEvent{
+		DeviceID:   "device-1",
+		DeviceName: "Device 1",
+		Phrase:     "hey assistant",
+		Confidence: 0.8,
+		Energy:     0.6,
+		Priority:   50,
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	arb.SubmitRemoteWake(WakeEvent{
+		DeviceID:   "device-2",
+		DeviceName: "Device 2",
+		Phrase:     "hey assistant",
+		Confidence: 0.9,
+		Energy:     0.8,
+		Priority:   60,
+		Timestamp:  time.Now().Add(10 * time.Millisecond),
+	})
+
+	select {
+	case result := <-done:
+		if result.WinnerID != "device-1" {
+			t.Errorf("expected device-1 to win (first response), got %s", result.WinnerID)
+		}
+		if !result.IsLocal {
+			t.Error("expected local device to win")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for arbitration result")
+	}
+}
+
+func TestWakeArbitration_BestSignal(t *testing.T) {
+	cfg := DefaultWakeArbitrationConfig()
+	cfg.ElectionMode = ElectionBestSignal
+
+	arb := NewWakeArbitration("device-1", cfg)
+
+	done := make(chan WakeArbitrationResult, 1)
+	arb.RegisterListener(func(result WakeArbitrationResult) {
+		done <- result
+	})
+
+	arb.SubmitLocalWake(WakeEvent{
+		DeviceID:   "device-1",
+		DeviceName: "Device 1",
+		Phrase:     "hey assistant",
+		Confidence: 0.5,
+		Energy:     0.3,
+		Priority:   50,
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	arb.SubmitRemoteWake(WakeEvent{
+		DeviceID:   "device-2",
+		DeviceName: "Device 2",
+		Phrase:     "hey assistant",
+		Confidence: 0.95,
+		Energy:     0.9,
+		Priority:   70,
+		Timestamp:  time.Now().Add(10 * time.Millisecond),
+	})
+
+	select {
+	case result := <-done:
+		if result.WinnerID != "device-2" {
+			t.Errorf("expected device-2 to win (best signal), got %s", result.WinnerID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for arbitration result")
+	}
+}
+
+func TestWakeArbitration_HighestPriority(t *testing.T) {
+	cfg := DefaultWakeArbitrationConfig()
+	cfg.ElectionMode = ElectionHighestPriority
+
+	arb := NewWakeArbitration("device-1", cfg)
+
+	done := make(chan WakeArbitrationResult, 1)
+	arb.RegisterListener(func(result WakeArbitrationResult) {
+		done <- result
+	})
+
+	arb.SubmitLocalWake(WakeEvent{
+		DeviceID:   "device-1",
+		DeviceName: "Device 1",
+		Phrase:     "hey assistant",
+		Confidence: 0.8,
+		Priority:   30,
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	arb.SubmitRemoteWake(WakeEvent{
+		DeviceID:   "device-2",
+		DeviceName: "Device 2",
+		Phrase:     "hey assistant",
+		Confidence: 0.7,
+		Priority:   90,
+		Timestamp:  time.Now().Add(10 * time.Millisecond),
+	})
+
+	select {
+	case result := <-done:
+		if result.WinnerID != "device-2" {
+			t.Errorf("expected device-2 to win (highest priority), got %s", result.WinnerID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for arbitration result")
+	}
+}
+
+func TestWakeArbitration_Suppression(t *testing.T) {
+	cfg := DefaultWakeArbitrationConfig()
+	cfg.ArbitrationWindow = 100 * time.Millisecond
+
+	arb := NewWakeArbitration("device-1", cfg)
+	suppressor := NewWakeSuppressor()
+	arb.SetSuppressor(suppressor)
+
+	done := make(chan WakeArbitrationResult, 1)
+	arb.RegisterListener(func(result WakeArbitrationResult) {
+		done <- result
+	})
+
+	arb.SubmitLocalWake(WakeEvent{
+		DeviceID:   "device-1",
+		DeviceName: "Device 1",
+		Phrase:     "hey assistant",
+		Confidence: 0.5,
+		Priority:   30,
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	arb.SubmitRemoteWake(WakeEvent{
+		DeviceID:   "device-2",
+		DeviceName: "Device 2",
+		Phrase:     "hey assistant",
+		Confidence: 0.9,
+		Priority:   80,
+		Timestamp:  time.Now().Add(10 * time.Millisecond),
+	})
+
+	select {
+	case result := <-done:
+		if result.WinnerID != "device-2" {
+			t.Errorf("expected device-2 to win, got %s", result.WinnerID)
+		}
+
+		time.Sleep(10 * time.Millisecond)
+
+		if !suppressor.IsSuppressed() {
+			t.Error("expected suppressor to be active after losing arbitration")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for arbitration result")
+	}
+}
+
+func TestWakeArbitration_MinConfidence(t *testing.T) {
+	cfg := DefaultWakeArbitrationConfig()
+	cfg.MinConfidence = 0.5
+
+	arb := NewWakeArbitration("device-1", cfg)
+
+	done := make(chan WakeArbitrationResult, 1)
+	arb.RegisterListener(func(result WakeArbitrationResult) {
+		done <- result
+	})
+
+	arb.SubmitLocalWake(WakeEvent{
+		DeviceID:   "device-1",
+		DeviceName: "Device 1",
+		Phrase:     "hey assistant",
+		Confidence: 0.3,
+		Priority:   50,
+	})
+
+	select {
+	case <-done:
+		t.Error("should not have triggered arbitration for low confidence wake")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestWakeSuppressor_Basic(t *testing.T) {
+	s := NewWakeSuppressor()
+
+	if s.IsSuppressed() {
+		t.Error("should not be suppressed initially")
+	}
+
+	s.Suppress("device-2", "Device 2", 500*time.Millisecond)
+
+	if !s.IsSuppressed() {
+		t.Error("should be suppressed after Suppress() call")
+	}
+
+	byID, byName := s.SuppressedBy()
+	if byID != "device-2" {
+		t.Errorf("expected suppressed by device-2, got %s", byID)
+	}
+	if byName != "Device 2" {
+		t.Errorf("expected suppressed by Device 2, got %s", byName)
+	}
+
+	time.Sleep(600 * time.Millisecond)
+
+	if s.IsSuppressed() {
+		t.Error("should not be suppressed after duration expired")
+	}
+}
+
+func TestWakeSuppressor_IsSuppressedBy(t *testing.T) {
+	s := NewWakeSuppressor()
+
+	s.Suppress("device-2", "Device 2", 500*time.Millisecond)
+
+	if !s.IsSuppressedBy("device-2") {
+		t.Error("should be suppressed by device-2")
+	}
+
+	if s.IsSuppressedBy("device-3") {
+		t.Error("should not be suppressed by device-3")
+	}
+}
+
+func TestWakeSuppressor_Release(t *testing.T) {
+	s := NewWakeSuppressor()
+
+	done := make(chan SuppressionEvent, 2)
+	s.RegisterListener(func(event SuppressionEvent) {
+		done <- event
+	})
+
+	s.Suppress("device-2", "Device 2", 10*time.Second)
+
+	select {
+	case event := <-done:
+		if event.Type != "suppressed" {
+			t.Errorf("expected suppressed event, got %s", event.Type)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for suppression event")
+	}
+
+	s.Release()
+
+	select {
+	case event := <-done:
+		if event.Type != "released" {
+			t.Errorf("expected released event, got %s", event.Type)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for release event")
+	}
+
+	if s.IsSuppressed() {
+		t.Error("should not be suppressed after manual release")
+	}
+}
+
+func TestWakeSuppressor_History(t *testing.T) {
+	s := NewWakeSuppressor()
+
+	s.Suppress("device-2", "Device 2", 100*time.Millisecond)
+	s.Release()
+	s.Suppress("device-3", "Device 3", 100*time.Millisecond)
+
+	history := s.History()
+	if len(history) != 3 {
+		t.Errorf("expected 3 history entries, got %d", len(history))
+	}
+}
+
+func TestVoiceWakeCoordinator_StartStop(t *testing.T) {
+	cfg := DefaultVoiceWakeCoordinatorConfig()
+	cfg.DeviceID = "test-device"
+	cfg.DeviceName = "Test Device"
+	cfg.Enabled = true
+	cfg.BroadcastPort = 19900
+	cfg.WakeEventPort = 19901
+
+	coord := NewVoiceWakeCoordinator(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := coord.Start(ctx); err != nil {
+		t.Fatalf("failed to start coordinator: %v", err)
+	}
+
+	if !coord.IsRunning() {
+		t.Error("coordinator should be running")
+	}
+
+	if err := coord.Stop(); err != nil {
+		t.Fatalf("failed to stop coordinator: %v", err)
+	}
+
+	if coord.IsRunning() {
+		t.Error("coordinator should not be running after stop")
+	}
+}
+
+func TestVoiceWakeCoordinator_SubmitWake(t *testing.T) {
+	cfg := DefaultVoiceWakeCoordinatorConfig()
+	cfg.DeviceID = "test-device"
+	cfg.DeviceName = "Test Device"
+	cfg.Enabled = true
+	cfg.BroadcastPort = 19902
+	cfg.WakeEventPort = 19903
+	cfg.ArbitrationConfig.ArbitrationWindow = 100 * time.Millisecond
+
+	coord := NewVoiceWakeCoordinator(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := coord.Start(ctx); err != nil {
+		t.Fatalf("failed to start coordinator: %v", err)
+	}
+	defer coord.Stop()
+
+	allowed := coord.SubmitWake("hey assistant", 0.8, 0.6, "builtin")
+	if !allowed {
+		t.Error("expected wake submission to be allowed")
+	}
+
+	stats := coord.Stats()
+	if stats.WakesSubmitted != 1 {
+		t.Errorf("expected 1 wake submitted, got %d", stats.WakesSubmitted)
+	}
+}
+
+func TestVoiceWakeCoordinator_SuppressionBlocksWake(t *testing.T) {
+	cfg := DefaultVoiceWakeCoordinatorConfig()
+	cfg.DeviceID = "test-device"
+	cfg.DeviceName = "Test Device"
+	cfg.Enabled = true
+	cfg.BroadcastPort = 19904
+	cfg.WakeEventPort = 19905
+
+	coord := NewVoiceWakeCoordinator(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := coord.Start(ctx); err != nil {
+		t.Fatalf("failed to start coordinator: %v", err)
+	}
+	defer coord.Stop()
+
+	coord.Suppressor().Suppress("device-2", "Device 2", 5*time.Second)
+
+	allowed := coord.SubmitWake("hey assistant", 0.8, 0.6, "builtin")
+	if allowed {
+		t.Error("expected wake submission to be blocked when suppressed")
+	}
+}
+
+func TestVoiceWakeCoordinator_ReceiveRemoteWake(t *testing.T) {
+	cfg := DefaultVoiceWakeCoordinatorConfig()
+	cfg.DeviceID = "test-device"
+	cfg.DeviceName = "Test Device"
+	cfg.Enabled = true
+	cfg.BroadcastPort = 19906
+	cfg.WakeEventPort = 19907
+	cfg.ArbitrationConfig.ArbitrationWindow = 100 * time.Millisecond
+
+	coord := NewVoiceWakeCoordinator(cfg)
+
+	done := make(chan WakeArbitrationResult, 1)
+	coord.Arbitration().RegisterListener(func(result WakeArbitrationResult) {
+		done <- result
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := coord.Start(ctx); err != nil {
+		t.Fatalf("failed to start coordinator: %v", err)
+	}
+	defer coord.Stop()
+
+	coord.ReceiveRemoteWake(WakeEvent{
+		DeviceID:   "device-2",
+		DeviceName: "Device 2",
+		Phrase:     "hey assistant",
+		Confidence: 0.9,
+		Energy:     0.7,
+		Priority:   60,
+	})
+
+	select {
+	case result := <-done:
+		if result.WinnerID != "device-2" {
+			t.Errorf("expected device-2 to win, got %s", result.WinnerID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for arbitration result")
+	}
+}
+
+func TestVoiceWakeCoordinator_EventListeners(t *testing.T) {
+	cfg := DefaultVoiceWakeCoordinatorConfig()
+	cfg.DeviceID = "test-device"
+	cfg.DeviceName = "Test Device"
+	cfg.Enabled = true
+	cfg.BroadcastPort = 19908
+	cfg.WakeEventPort = 19909
+
+	coord := NewVoiceWakeCoordinator(cfg)
+
+	events := make(chan CoordinatorEvent, 10)
+	coord.RegisterListener(func(event CoordinatorEvent) {
+		events <- event
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := coord.Start(ctx); err != nil {
+		t.Fatalf("failed to start coordinator: %v", err)
+	}
+	defer coord.Stop()
+
+	coord.SubmitWake("hey assistant", 0.8, 0.6, "builtin")
+
+	select {
+	case event := <-events:
+		if event.Type != CoordinatorEventWakeSubmitted {
+			t.Errorf("expected wake_submitted event, got %s", event.Type)
+		}
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
+func TestVoiceWakeCoordinator_ArbitrationResult(t *testing.T) {
+	cfg := DefaultVoiceWakeCoordinatorConfig()
+	cfg.DeviceID = "test-device"
+	cfg.DeviceName = "Test Device"
+	cfg.Enabled = true
+	cfg.BroadcastPort = 19910
+	cfg.WakeEventPort = 19911
+	cfg.ArbitrationConfig.ArbitrationWindow = 100 * time.Millisecond
+
+	coord := NewVoiceWakeCoordinator(cfg)
+
+	var mu sync.Mutex
+	var won bool
+	coord.RegisterListener(func(event CoordinatorEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		if event.Type == CoordinatorEventArbitrationWon {
+			won = true
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := coord.Start(ctx); err != nil {
+		t.Fatalf("failed to start coordinator: %v", err)
+	}
+	defer coord.Stop()
+
+	coord.SubmitWake("hey assistant", 0.9, 0.8, "builtin")
+
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	if !won {
+		t.Error("expected arbitration won event for local device with high confidence")
+	}
+	mu.Unlock()
+}
+
+func TestVoiceWakeCoordinator_Configuration(t *testing.T) {
+	cfg := DefaultVoiceWakeCoordinatorConfig()
+	cfg.DeviceID = "test-device"
+	cfg.DeviceName = "Test Device"
+	cfg.Enabled = true
+	cfg.BroadcastPort = 19912
+	cfg.WakeEventPort = 19913
+
+	coord := NewVoiceWakeCoordinator(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := coord.Start(ctx); err != nil {
+		t.Fatalf("failed to start coordinator: %v", err)
+	}
+	defer coord.Stop()
+
+	coord.SetPriority(75)
+	coord.SetElectionMode(ElectionHighestPriority)
+	coord.SetPreferLocal(false)
+	coord.SetArbitrationWindow(300 * time.Millisecond)
+
+	arbCfg := coord.Arbitration().Config()
+	if arbCfg.ElectionMode != ElectionHighestPriority {
+		t.Errorf("expected election mode highest-priority, got %s", arbCfg.ElectionMode)
+	}
+	if arbCfg.PreferLocal {
+		t.Error("expected prefer local to be false")
+	}
+	if arbCfg.ArbitrationWindow != 300*time.Millisecond {
+		t.Errorf("expected 300ms arbitration window, got %v", arbCfg.ArbitrationWindow)
+	}
+}
+
+func TestVoiceWakeCoordinator_LocalDevice(t *testing.T) {
+	cfg := DefaultVoiceWakeCoordinatorConfig()
+	cfg.DeviceID = "my-device"
+	cfg.DeviceName = "My Device"
+	cfg.DeviceType = DeviceTypeSpeaker
+	cfg.Enabled = true
+	cfg.BroadcastPort = 19914
+	cfg.WakeEventPort = 19915
+
+	coord := NewVoiceWakeCoordinator(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := coord.Start(ctx); err != nil {
+		t.Fatalf("failed to start coordinator: %v", err)
+	}
+	defer coord.Stop()
+
+	local := coord.LocalDevice()
+	if local.ID != "my-device" {
+		t.Errorf("expected device ID my-device, got %s", local.ID)
+	}
+	if local.Name != "My Device" {
+		t.Errorf("expected device name My Device, got %s", local.Name)
+	}
+	if local.Type != DeviceTypeSpeaker {
+		t.Errorf("expected device type speaker, got %s", local.Type)
+	}
+}
+
+func TestWakeArbitration_Clear(t *testing.T) {
+	cfg := DefaultWakeArbitrationConfig()
+	cfg.ArbitrationWindow = 5 * time.Second
+
+	arb := NewWakeArbitration("device-1", cfg)
+
+	arb.SubmitLocalWake(WakeEvent{
+		DeviceID:   "device-1",
+		DeviceName: "Device 1",
+		Phrase:     "hey assistant",
+		Confidence: 0.8,
+		Priority:   50,
+	})
+
+	if arb.PendingCount() == 0 {
+		t.Error("expected pending count > 0")
+	}
+
+	arb.Clear()
+
+	if arb.PendingCount() != 0 {
+		t.Errorf("expected pending count 0 after clear, got %d", arb.PendingCount())
+	}
+}
+
+func TestWakeArbitration_History(t *testing.T) {
+	cfg := DefaultWakeArbitrationConfig()
+	cfg.ArbitrationWindow = 50 * time.Millisecond
+
+	arb := NewWakeArbitration("device-1", cfg)
+
+	done := make(chan WakeArbitrationResult, 5)
+	arb.RegisterListener(func(result WakeArbitrationResult) {
+		done <- result
+	})
+
+	for i := 0; i < 3; i++ {
+		arb.SubmitLocalWake(WakeEvent{
+			DeviceID:   "device-1",
+			DeviceName: "Device 1",
+			Phrase:     "hey assistant",
+			Confidence: 0.8,
+			Priority:   50,
+		})
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	history := arb.History()
+	if len(history) != 3 {
+		t.Errorf("expected 3 history entries, got %d", len(history))
+	}
+}
+
+func TestWakeArbitration_DifferentPhrases(t *testing.T) {
+	cfg := DefaultWakeArbitrationConfig()
+	cfg.ArbitrationWindow = 100 * time.Millisecond
+
+	arb := NewWakeArbitration("device-1", cfg)
+
+	results := make(chan WakeArbitrationResult, 2)
+	arb.RegisterListener(func(result WakeArbitrationResult) {
+		results <- result
+	})
+
+	arb.SubmitLocalWake(WakeEvent{
+		DeviceID:   "device-1",
+		DeviceName: "Device 1",
+		Phrase:     "hey assistant",
+		Confidence: 0.8,
+		Priority:   50,
+	})
+
+	arb.SubmitLocalWake(WakeEvent{
+		DeviceID:   "device-1",
+		DeviceName: "Device 1",
+		Phrase:     "ok computer",
+		Confidence: 0.7,
+		Priority:   50,
+	})
+
+	count := 0
+	for i := 0; i < 2; i++ {
+		select {
+		case <-results:
+			count++
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+
+	if count != 2 {
+		t.Errorf("expected 2 separate arbitration results for different phrases, got %d", count)
+	}
+}
+
+func TestVoiceWakeCoordinator_Disabled(t *testing.T) {
+	cfg := DefaultVoiceWakeCoordinatorConfig()
+	cfg.Enabled = false
+
+	coord := NewVoiceWakeCoordinator(cfg)
+
+	ctx := context.Background()
+
+	if err := coord.Start(ctx); err != nil {
+		t.Fatalf("start should return nil when disabled: %v", err)
+	}
+
+	if coord.IsRunning() {
+		t.Error("coordinator should not be running when disabled")
+	}
+}
+
+func TestVoiceWakeCoordinator_DoubleStart(t *testing.T) {
+	cfg := DefaultVoiceWakeCoordinatorConfig()
+	cfg.DeviceID = "test-device"
+	cfg.Enabled = true
+	cfg.BroadcastPort = 19916
+	cfg.WakeEventPort = 19917
+
+	coord := NewVoiceWakeCoordinator(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := coord.Start(ctx); err != nil {
+		t.Fatalf("first start failed: %v", err)
+	}
+
+	if err := coord.Start(ctx); err == nil {
+		t.Error("second start should fail with already running error")
+	}
+
+	coord.Stop()
+}
+
+func TestVoiceWakeCoordinator_Stats(t *testing.T) {
+	cfg := DefaultVoiceWakeCoordinatorConfig()
+	cfg.DeviceID = "test-device"
+	cfg.DeviceName = "Test Device"
+	cfg.Enabled = true
+	cfg.BroadcastPort = 19918
+	cfg.WakeEventPort = 19919
+
+	coord := NewVoiceWakeCoordinator(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := coord.Start(ctx); err != nil {
+		t.Fatalf("failed to start coordinator: %v", err)
+	}
+	defer coord.Stop()
+
+	coord.SubmitWake("hey assistant", 0.8, 0.6, "builtin")
+	coord.SubmitWake("hey assistant", 0.7, 0.5, "builtin")
+
+	stats := coord.Stats()
+	if stats.WakesSubmitted != 2 {
+		t.Errorf("expected 2 wakes submitted, got %d", stats.WakesSubmitted)
+	}
+}

--- a/pkg/speech/voice_coordinator_test.go
+++ b/pkg/speech/voice_coordinator_test.go
@@ -328,6 +328,43 @@ func TestVoiceWakeCoordinator_StartStop(t *testing.T) {
 	}
 }
 
+func TestVoiceWakeCoordinator_StopClearsWakeListenerState(t *testing.T) {
+	cfg := DefaultVoiceWakeCoordinatorConfig()
+	cfg.DeviceID = "test-device"
+	cfg.DeviceName = "Test Device"
+	cfg.Enabled = true
+	cfg.BroadcastPort = 19920
+	cfg.WakeEventPort = 19921
+
+	coord := NewVoiceWakeCoordinator(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := coord.Start(ctx); err != nil {
+		t.Fatalf("failed to start coordinator: %v", err)
+	}
+
+	if coord.wakeConn == nil || coord.wakeListenDone == nil {
+		t.Fatal("expected wake listener state to be initialized after start")
+	}
+
+	if err := coord.Stop(); err != nil {
+		t.Fatalf("failed to stop coordinator: %v", err)
+	}
+
+	if coord.wakeConn != nil {
+		t.Error("expected wake connection to be cleared after stop")
+	}
+	if coord.wakeListenDone != nil {
+		t.Error("expected wake listener done channel to be cleared after stop")
+	}
+
+	if err := coord.Stop(); err != nil {
+		t.Fatalf("second stop should be a no-op: %v", err)
+	}
+}
+
 func TestVoiceWakeCoordinator_SubmitWake(t *testing.T) {
 	cfg := DefaultVoiceWakeCoordinatorConfig()
 	cfg.DeviceID = "test-device"

--- a/pkg/speech/voice_discovery.go
+++ b/pkg/speech/voice_discovery.go
@@ -1,0 +1,522 @@
+package speech
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+type DeviceType string
+
+const (
+	DeviceTypeUnknown DeviceType = "unknown"
+	DeviceTypeDesktop DeviceType = "desktop"
+	DeviceTypeLaptop  DeviceType = "laptop"
+	DeviceTypePhone   DeviceType = "phone"
+	DeviceTypeTablet  DeviceType = "tablet"
+	DeviceTypeSpeaker DeviceType = "speaker"
+	DeviceTypePi      DeviceType = "raspberry-pi"
+)
+
+type DeviceInfo struct {
+	ID           string
+	Name         string
+	Type         DeviceType
+	Hostname     string
+	IPAddress    string
+	Port         int
+	Capabilities []string
+	Priority     int
+	LastSeen     time.Time
+	Metadata     map[string]string
+}
+
+type DiscoveryEvent struct {
+	Type      string
+	Device    DeviceInfo
+	Timestamp time.Time
+}
+
+type DiscoveryListener func(event DiscoveryEvent)
+
+type DeviceDiscoveryConfig struct {
+	DeviceID         string
+	DeviceName       string
+	DeviceType       DeviceType
+	BindPort         int
+	BroadcastPort    int
+	BroadcastAddr    string
+	AnnounceInterval time.Duration
+	DiscoveryTimeout time.Duration
+	Capabilities     []string
+	Priority         int
+}
+
+func DefaultDeviceDiscoveryConfig() DeviceDiscoveryConfig {
+	return DeviceDiscoveryConfig{
+		BindPort:         0,
+		BroadcastPort:    19876,
+		BroadcastAddr:    "255.255.255.255",
+		AnnounceInterval: 5 * time.Second,
+		DiscoveryTimeout: 15 * time.Second,
+		Capabilities:     []string{"voice-wake", "stt", "tts"},
+		Priority:         50,
+	}
+}
+
+type DeviceDiscovery struct {
+	mu        sync.Mutex
+	cfg       DeviceDiscoveryConfig
+	devices   map[string]*DeviceInfo
+	conn      *net.UDPConn
+	listeners []DiscoveryListener
+	isRunning bool
+	doneCh    chan struct{}
+	localInfo DeviceInfo
+}
+
+const (
+	discoveryMsgAnnounce = "announce"
+	discoveryMsgProbe    = "probe"
+	discoveryMsgResponse = "response"
+)
+
+type discoveryMessage struct {
+	Type     string     `json:"type"`
+	Device   DeviceInfo `json:"device"`
+	Sequence int64      `json:"seq"`
+}
+
+func NewDeviceDiscovery(cfg DeviceDiscoveryConfig) *DeviceDiscovery {
+	if cfg.BroadcastPort == 0 {
+		cfg.BroadcastPort = 19876
+	}
+	if cfg.BroadcastAddr == "" {
+		cfg.BroadcastAddr = "255.255.255.255"
+	}
+	if cfg.AnnounceInterval == 0 {
+		cfg.AnnounceInterval = 5 * time.Second
+	}
+	if cfg.DiscoveryTimeout == 0 {
+		cfg.DiscoveryTimeout = 15 * time.Second
+	}
+	if cfg.Priority == 0 {
+		cfg.Priority = 50
+	}
+	if len(cfg.Capabilities) == 0 {
+		cfg.Capabilities = []string{"voice-wake", "stt", "tts"}
+	}
+
+	return &DeviceDiscovery{
+		cfg:     cfg,
+		devices: make(map[string]*DeviceInfo),
+		doneCh:  make(chan struct{}),
+	}
+}
+
+func (d *DeviceDiscovery) Start() error {
+	d.mu.Lock()
+
+	if d.isRunning {
+		d.mu.Unlock()
+		return fmt.Errorf("discovery: already running")
+	}
+
+	addr := &net.UDPAddr{
+		IP:   net.IPv4zero,
+		Port: d.cfg.BroadcastPort,
+	}
+
+	conn, err := net.ListenUDP("udp4", addr)
+	if err != nil {
+		d.mu.Unlock()
+		return fmt.Errorf("discovery: failed to bind UDP port: %w", err)
+	}
+
+	d.conn = conn
+	d.isRunning = true
+
+	d.localInfo = DeviceInfo{
+		ID:           d.cfg.DeviceID,
+		Name:         d.cfg.DeviceName,
+		Type:         d.cfg.DeviceType,
+		Port:         d.cfg.BroadcastPort,
+		Capabilities: d.cfg.Capabilities,
+		Priority:     d.cfg.Priority,
+		LastSeen:     time.Now(),
+		Metadata:     make(map[string]string),
+	}
+
+	go d.listenLoop()
+	go d.announceLoop()
+
+	d.mu.Unlock()
+
+	d.broadcastMessage(discoveryMsgAnnounce)
+
+	return nil
+}
+
+func (d *DeviceDiscovery) Stop() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if !d.isRunning {
+		return nil
+	}
+
+	d.isRunning = false
+	close(d.doneCh)
+	d.doneCh = make(chan struct{})
+
+	if d.conn != nil {
+		d.conn.Close()
+		d.conn = nil
+	}
+
+	return nil
+}
+
+func (d *DeviceDiscovery) listenLoop() {
+	buf := make([]byte, 4096)
+
+	for {
+		d.mu.Lock()
+		conn := d.conn
+		isRunning := d.isRunning
+		d.mu.Unlock()
+
+		if !isRunning || conn == nil {
+			return
+		}
+
+		n, remoteAddr, err := conn.ReadFromUDP(buf)
+		if err != nil {
+			select {
+			case <-d.doneCh:
+				return
+			default:
+				continue
+			}
+		}
+
+		if n == 0 {
+			continue
+		}
+
+		var msg discoveryMessage
+		if err := json.Unmarshal(buf[:n], &msg); err != nil {
+			continue
+		}
+
+		if msg.Device.ID == d.cfg.DeviceID {
+			continue
+		}
+
+		d.mu.Lock()
+		existing, known := d.devices[msg.Device.ID]
+		if known {
+			existing.LastSeen = time.Now()
+			existing.IPAddress = remoteAddr.IP.String()
+		} else {
+			info := msg.Device
+			info.IPAddress = remoteAddr.IP.String()
+			info.LastSeen = time.Now()
+			d.devices[info.ID] = &info
+		}
+		d.mu.Unlock()
+
+		switch msg.Type {
+		case discoveryMsgAnnounce:
+			d.notifyListeners(DiscoveryEvent{
+				Type:      "device_discovered",
+				Device:    msg.Device,
+				Timestamp: time.Now(),
+			})
+
+			d.broadcastMessage(discoveryMsgResponse)
+
+		case discoveryMsgProbe:
+			d.broadcastMessage(discoveryMsgResponse)
+
+		case discoveryMsgResponse:
+			d.notifyListeners(DiscoveryEvent{
+				Type:      "device_responded",
+				Device:    msg.Device,
+				Timestamp: time.Now(),
+			})
+		}
+	}
+}
+
+func (d *DeviceDiscovery) announceLoop() {
+	ticker := time.NewTicker(d.cfg.AnnounceInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			d.mu.Lock()
+			isRunning := d.isRunning
+			d.mu.Unlock()
+
+			if !isRunning {
+				return
+			}
+
+			d.broadcastMessage(discoveryMsgAnnounce)
+			d.pruneStaleDevices()
+
+		case <-d.doneCh:
+			return
+		}
+	}
+}
+
+func (d *DeviceDiscovery) broadcastMessage(msgType string) {
+	d.mu.Lock()
+	conn := d.conn
+	localInfo := d.localInfo
+	d.mu.Unlock()
+
+	if conn == nil {
+		return
+	}
+
+	localInfo.LastSeen = time.Now()
+
+	msg := discoveryMessage{
+		Type:     msgType,
+		Device:   localInfo,
+		Sequence: time.Now().UnixNano(),
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return
+	}
+
+	broadcastAddr := &net.UDPAddr{
+		IP:   net.ParseIP(d.cfg.BroadcastAddr),
+		Port: d.cfg.BroadcastPort,
+	}
+
+	conn.SetWriteDeadline(time.Now().Add(100 * time.Millisecond))
+	_, _ = conn.WriteToUDP(data, broadcastAddr)
+}
+
+func (d *DeviceDiscovery) pruneStaleDevices() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	now := time.Now()
+	for id, device := range d.devices {
+		if now.Sub(device.LastSeen) > d.cfg.DiscoveryTimeout {
+			delete(d.devices, id)
+			d.notifyListeners(DiscoveryEvent{
+				Type:      "device_lost",
+				Device:    *device,
+				Timestamp: now,
+			})
+		}
+	}
+}
+
+func (d *DeviceDiscovery) RegisterListener(listener DiscoveryListener) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.listeners = append(d.listeners, listener)
+}
+
+func (d *DeviceDiscovery) notifyListeners(event DiscoveryEvent) {
+	d.mu.Lock()
+	listeners := make([]DiscoveryListener, len(d.listeners))
+	copy(listeners, d.listeners)
+	d.mu.Unlock()
+
+	for _, listener := range listeners {
+		listener(event)
+	}
+}
+
+func (d *DeviceDiscovery) GetDevice(id string) (*DeviceInfo, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	device, ok := d.devices[id]
+	if !ok {
+		return nil, false
+	}
+
+	return device, true
+}
+
+func (d *DeviceDiscovery) GetDevices() []DeviceInfo {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	devices := make([]DeviceInfo, 0, len(d.devices))
+	for _, device := range d.devices {
+		devices = append(devices, *device)
+	}
+
+	return devices
+}
+
+func (d *DeviceDiscovery) GetDeviceCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.devices)
+}
+
+func (d *DeviceDiscovery) LocalDevice() DeviceInfo {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.localInfo
+}
+
+func (d *DeviceDiscovery) HasCapability(deviceID, capability string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	device, ok := d.devices[deviceID]
+	if !ok {
+		return false
+	}
+
+	for _, cap := range device.Capabilities {
+		if cap == capability {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (d *DeviceDiscovery) GetDevicesWithCapability(capability string) []DeviceInfo {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	var result []DeviceInfo
+	for _, device := range d.devices {
+		for _, cap := range device.Capabilities {
+			if cap == capability {
+				result = append(result, *device)
+				break
+			}
+		}
+	}
+
+	return result
+}
+
+func (d *DeviceDiscovery) Probe() {
+	d.broadcastMessage(discoveryMsgProbe)
+}
+
+func (d *DeviceDiscovery) SetPriority(priority int) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.localInfo.Priority = priority
+	d.cfg.Priority = priority
+}
+
+func (d *DeviceDiscovery) SetDeviceName(name string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.localInfo.Name = name
+	d.cfg.DeviceName = name
+}
+
+func (d *DeviceDiscovery) UpdateMetadata(key, value string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.localInfo.Metadata == nil {
+		d.localInfo.Metadata = make(map[string]string)
+	}
+	d.localInfo.Metadata[key] = value
+}
+
+type MockDeviceDiscovery struct {
+	mu        sync.Mutex
+	devices   map[string]*DeviceInfo
+	local     DeviceInfo
+	listeners []DiscoveryListener
+}
+
+func NewMockDeviceDiscovery(deviceID, deviceName string, priority int) *MockDeviceDiscovery {
+	return &MockDeviceDiscovery{
+		devices: make(map[string]*DeviceInfo),
+		local: DeviceInfo{
+			ID:           deviceID,
+			Name:         deviceName,
+			Type:         DeviceTypeDesktop,
+			Priority:     priority,
+			Capabilities: []string{"voice-wake", "stt", "tts"},
+			LastSeen:     time.Now(),
+		},
+	}
+}
+
+func (m *MockDeviceDiscovery) AddDevice(info DeviceInfo) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	info.LastSeen = time.Now()
+	m.devices[info.ID] = &info
+
+	for _, listener := range m.listeners {
+		listener(DiscoveryEvent{
+			Type:      "device_discovered",
+			Device:    info,
+			Timestamp: time.Now(),
+		})
+	}
+}
+
+func (m *MockDeviceDiscovery) RemoveDevice(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if device, ok := m.devices[id]; ok {
+		delete(m.devices, id)
+		for _, listener := range m.listeners {
+			listener(DiscoveryEvent{
+				Type:      "device_lost",
+				Device:    *device,
+				Timestamp: time.Now(),
+			})
+		}
+	}
+}
+
+func (m *MockDeviceDiscovery) GetDevices() []DeviceInfo {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	devices := make([]DeviceInfo, 0, len(m.devices))
+	for _, device := range m.devices {
+		devices = append(devices, *device)
+	}
+	return devices
+}
+
+func (m *MockDeviceDiscovery) GetDeviceCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.devices)
+}
+
+func (m *MockDeviceDiscovery) LocalDevice() DeviceInfo {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.local
+}
+
+func (m *MockDeviceDiscovery) RegisterListener(listener DiscoveryListener) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.listeners = append(m.listeners, listener)
+}

--- a/pkg/speech/voice_discovery.go
+++ b/pkg/speech/voice_discovery.go
@@ -68,6 +68,7 @@ func DefaultDeviceDiscoveryConfig() DeviceDiscoveryConfig {
 
 type DeviceDiscovery struct {
 	mu        sync.Mutex
+	wg        sync.WaitGroup
 	cfg       DeviceDiscoveryConfig
 	devices   map[string]*DeviceInfo
 	conn      *net.UDPConn
@@ -112,7 +113,6 @@ func NewDeviceDiscovery(cfg DeviceDiscoveryConfig) *DeviceDiscovery {
 	return &DeviceDiscovery{
 		cfg:     cfg,
 		devices: make(map[string]*DeviceInfo),
-		doneCh:  make(chan struct{}),
 	}
 }
 
@@ -136,6 +136,8 @@ func (d *DeviceDiscovery) Start() error {
 	}
 
 	d.conn = conn
+	done := make(chan struct{})
+	d.doneCh = done
 	d.isRunning = true
 
 	d.localInfo = DeviceInfo{
@@ -149,8 +151,9 @@ func (d *DeviceDiscovery) Start() error {
 		Metadata:     make(map[string]string),
 	}
 
-	go d.listenLoop()
-	go d.announceLoop()
+	d.wg.Add(2)
+	go d.listenLoop(conn, done)
+	go d.announceLoop(done)
 
 	d.mu.Unlock()
 
@@ -161,41 +164,51 @@ func (d *DeviceDiscovery) Start() error {
 
 func (d *DeviceDiscovery) Stop() error {
 	d.mu.Lock()
-	defer d.mu.Unlock()
 
 	if !d.isRunning {
+		d.mu.Unlock()
 		return nil
 	}
 
 	d.isRunning = false
-	close(d.doneCh)
-	d.doneCh = make(chan struct{})
+	conn := d.conn
+	done := d.doneCh
+	d.conn = nil
+	d.mu.Unlock()
 
-	if d.conn != nil {
-		d.conn.Close()
-		d.conn = nil
+	if conn != nil {
+		_ = conn.Close()
 	}
+
+	if done != nil {
+		close(done)
+	}
+
+	d.wg.Wait()
+
+	d.mu.Lock()
+	if d.doneCh == done {
+		d.doneCh = nil
+	}
+	d.mu.Unlock()
 
 	return nil
 }
 
-func (d *DeviceDiscovery) listenLoop() {
+func (d *DeviceDiscovery) listenLoop(conn *net.UDPConn, done <-chan struct{}) {
+	defer d.wg.Done()
+
 	buf := make([]byte, 4096)
 
 	for {
-		d.mu.Lock()
-		conn := d.conn
-		isRunning := d.isRunning
-		d.mu.Unlock()
-
-		if !isRunning || conn == nil {
+		if conn == nil {
 			return
 		}
 
 		n, remoteAddr, err := conn.ReadFromUDP(buf)
 		if err != nil {
 			select {
-			case <-d.doneCh:
+			case <-done:
 				return
 			default:
 				continue
@@ -251,25 +264,19 @@ func (d *DeviceDiscovery) listenLoop() {
 	}
 }
 
-func (d *DeviceDiscovery) announceLoop() {
+func (d *DeviceDiscovery) announceLoop(done <-chan struct{}) {
+	defer d.wg.Done()
+
 	ticker := time.NewTicker(d.cfg.AnnounceInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ticker.C:
-			d.mu.Lock()
-			isRunning := d.isRunning
-			d.mu.Unlock()
-
-			if !isRunning {
-				return
-			}
-
 			d.broadcastMessage(discoveryMsgAnnounce)
 			d.pruneStaleDevices()
 
-		case <-d.doneCh:
+		case <-done:
 			return
 		}
 	}

--- a/pkg/speech/voice_suppression.go
+++ b/pkg/speech/voice_suppression.go
@@ -1,0 +1,217 @@
+package speech
+
+import (
+	"sync"
+	"time"
+)
+
+type WakeSuppressor struct {
+	mu             sync.Mutex
+	isSuppressed   bool
+	suppressedBy   string
+	suppressorName string
+	suppressUntil  time.Time
+	duration       time.Duration
+	listeners      []SuppressionListener
+	history        []SuppressionEvent
+	maxHistory     int
+}
+
+type SuppressionEvent struct {
+	Type       string
+	DeviceID   string
+	DeviceName string
+	Duration   time.Duration
+	Timestamp  time.Time
+	Remaining  time.Duration
+}
+
+type SuppressionListener func(event SuppressionEvent)
+
+func NewWakeSuppressor() *WakeSuppressor {
+	return &WakeSuppressor{
+		maxHistory: 50,
+	}
+}
+
+func (s *WakeSuppressor) Suppress(deviceID, deviceName string, duration time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.isSuppressed = true
+	s.suppressedBy = deviceID
+	s.suppressorName = deviceName
+	s.suppressUntil = time.Now().Add(duration)
+	s.duration = duration
+
+	event := SuppressionEvent{
+		Type:       "suppressed",
+		DeviceID:   deviceID,
+		DeviceName: deviceName,
+		Duration:   duration,
+		Timestamp:  time.Now(),
+		Remaining:  duration,
+	}
+
+	s.history = append(s.history, event)
+	if len(s.history) > s.maxHistory {
+		s.history = s.history[len(s.history)-s.maxHistory:]
+	}
+
+	listeners := make([]SuppressionListener, len(s.listeners))
+	copy(listeners, s.listeners)
+
+	go func() {
+		for _, listener := range listeners {
+			listener(event)
+		}
+	}()
+}
+
+func (s *WakeSuppressor) IsSuppressed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.isSuppressed {
+		return false
+	}
+
+	if time.Now().After(s.suppressUntil) {
+		s.isSuppressed = false
+		s.suppressedBy = ""
+		s.suppressorName = ""
+		return false
+	}
+
+	return true
+}
+
+func (s *WakeSuppressor) SuppressUntil() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.suppressUntil
+}
+
+func (s *WakeSuppressor) RemainingTime() time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.isSuppressed {
+		return 0
+	}
+
+	remaining := time.Until(s.suppressUntil)
+	if remaining < 0 {
+		s.isSuppressed = false
+		return 0
+	}
+
+	return remaining
+}
+
+func (s *WakeSuppressor) SuppressedBy() (string, string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.isSuppressed {
+		return "", ""
+	}
+
+	if time.Now().After(s.suppressUntil) {
+		s.isSuppressed = false
+		return "", ""
+	}
+
+	return s.suppressedBy, s.suppressorName
+}
+
+func (s *WakeSuppressor) Release() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.isSuppressed {
+		s.isSuppressed = false
+
+		event := SuppressionEvent{
+			Type:       "released",
+			DeviceID:   s.suppressedBy,
+			DeviceName: s.suppressorName,
+			Timestamp:  time.Now(),
+			Remaining:  0,
+		}
+
+		s.history = append(s.history, event)
+
+		listeners := make([]SuppressionListener, len(s.listeners))
+		copy(listeners, s.listeners)
+
+		go func() {
+			for _, listener := range listeners {
+				listener(event)
+			}
+		}()
+
+		s.suppressedBy = ""
+		s.suppressorName = ""
+	}
+}
+
+func (s *WakeSuppressor) RegisterListener(listener SuppressionListener) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.listeners = append(s.listeners, listener)
+}
+
+func (s *WakeSuppressor) History() []SuppressionEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	result := make([]SuppressionEvent, len(s.history))
+	copy(result, s.history)
+	return result
+}
+
+func (s *WakeSuppressor) IsSuppressedBy(deviceID string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.isSuppressed {
+		return false
+	}
+
+	return s.suppressedBy == deviceID && time.Now().Before(s.suppressUntil)
+}
+
+func (s *WakeSuppressor) Status() map[string]any {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	status := map[string]any{
+		"is_suppressed": s.isSuppressed,
+	}
+
+	if s.isSuppressed {
+		remaining := time.Until(s.suppressUntil)
+		if remaining < 0 {
+			remaining = 0
+			s.isSuppressed = false
+		}
+
+		status["suppressed_by"] = s.suppressedBy
+		status["suppressor_name"] = s.suppressorName
+		status["remaining"] = remaining
+		status["duration"] = s.duration
+	}
+
+	return status
+}
+
+func (s *WakeSuppressor) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.isSuppressed = false
+	s.suppressedBy = ""
+	s.suppressorName = ""
+	s.history = nil
+}

--- a/pkg/speech/voicewake.go
+++ b/pkg/speech/voicewake.go
@@ -1,0 +1,620 @@
+package speech
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+)
+
+type VoiceWakeState string
+
+const (
+	VoiceWakeStateIdle       VoiceWakeState = "idle"
+	VoiceWakeStateListening  VoiceWakeState = "listening"
+	VoiceWakeStateRecording  VoiceWakeState = "recording"
+	VoiceWakeStateProcessing VoiceWakeState = "processing"
+	VoiceWakeStateTriggered  VoiceWakeState = "triggered"
+)
+
+type VoiceWakeEventType string
+
+const (
+	VoiceWakeEventStateChanged VoiceWakeEventType = "state_changed"
+	VoiceWakeEventWakeDetected VoiceWakeEventType = "wake_detected"
+	VoiceWakeEventSpeechStart  VoiceWakeEventType = "speech_start"
+	VoiceWakeEventSpeechEnd    VoiceWakeEventType = "speech_end"
+	VoiceWakeEventError        VoiceWakeEventType = "error"
+)
+
+type VoiceWakeEvent struct {
+	Type      VoiceWakeEventType
+	State     VoiceWakeState
+	Timestamp time.Time
+	Data      map[string]any
+}
+
+type VoiceWakeListener func(event VoiceWakeEvent)
+
+type AudioSource interface {
+	Start(ctx context.Context) error
+	Stop() error
+	Read(samples []int16) (int, error)
+	SampleRate() int
+	Channels() int
+}
+
+type VoiceWakeConfig struct {
+	VADConfig        VADConfig
+	WakeWordConfig   WakeWordConfig
+	EngineConfig     WakeWordEngineConfig
+	SampleRate       int
+	Channels         int
+	FrameSize        int
+	MaxRecordingTime time.Duration
+	CooldownTime     time.Duration
+	AudioSource      AudioSource
+	STTPipeline      *STTPipeline
+	AutoTranscribe   bool
+	WakeWordEngine   WakeWordEngineType
+}
+
+func DefaultVoiceWakeConfig() VoiceWakeConfig {
+	return VoiceWakeConfig{
+		VADConfig:        DefaultVADConfig(),
+		WakeWordConfig:   DefaultWakeWordConfig(),
+		SampleRate:       16000,
+		Channels:         1,
+		FrameSize:        320,
+		MaxRecordingTime: 30 * time.Second,
+		CooldownTime:     2 * time.Second,
+		AutoTranscribe:   true,
+	}
+}
+
+type VoiceWake struct {
+	mu              sync.Mutex
+	cfg             VoiceWakeConfig
+	state           VoiceWakeState
+	vad             *VAD
+	wakeDetector    *WakeWordDetector
+	engineRouter    *WakeWordEngineRouter
+	engineAdapter   *WakeWordEngineAdapter
+	listeners       []VoiceWakeListener
+	audioBuffer     []int16
+	recordingBuffer []int16
+	isRecording     bool
+	recordingStart  time.Time
+	cooldownUntil   time.Time
+	ctx             context.Context
+	cancel          context.CancelFunc
+	wg              sync.WaitGroup
+	transcriber     *STTPipeline
+	lastTranscript  string
+	lastWakeMatch   string
+	lastConfidence  float64
+	lastEnergy      float64
+}
+
+func NewVoiceWake(cfg VoiceWakeConfig) *VoiceWake {
+	if cfg.SampleRate == 0 {
+		cfg.SampleRate = 16000
+	}
+	if cfg.Channels == 0 {
+		cfg.Channels = 1
+	}
+	if cfg.FrameSize == 0 {
+		cfg.FrameSize = 320
+	}
+	if cfg.MaxRecordingTime == 0 {
+		cfg.MaxRecordingTime = 30 * time.Second
+	}
+	if cfg.CooldownTime == 0 {
+		cfg.CooldownTime = 2 * time.Second
+	}
+
+	cfg.VADConfig.SampleRate = cfg.SampleRate
+	cfg.VADConfig.FrameSize = cfg.FrameSize
+
+	cfg.EngineConfig.SampleRate = cfg.SampleRate
+	cfg.EngineConfig.FrameSize = cfg.FrameSize
+
+	vad := NewVAD(cfg.VADConfig)
+	wakeDetector := NewWakeWordDetector(cfg.WakeWordConfig)
+
+	router := NewWakeWordEngineRouter(cfg.EngineConfig)
+	adapter := NewWakeWordEngineAdapter(router, wakeDetector)
+
+	vw := &VoiceWake{
+		cfg:           cfg,
+		state:         VoiceWakeStateIdle,
+		vad:           vad,
+		wakeDetector:  wakeDetector,
+		engineRouter:  router,
+		engineAdapter: adapter,
+		transcriber:   cfg.STTPipeline,
+	}
+
+	vad.RegisterListener(vw.onVADStateChanged)
+
+	return vw
+}
+
+func (vw *VoiceWake) RegisterListener(listener VoiceWakeListener) {
+	vw.mu.Lock()
+	defer vw.mu.Unlock()
+	vw.listeners = append(vw.listeners, listener)
+}
+
+func (vw *VoiceWake) Start(ctx context.Context) error {
+	vw.mu.Lock()
+	if vw.state != VoiceWakeStateIdle {
+		vw.mu.Unlock()
+		return fmt.Errorf("voicewake: already in state %s", vw.state)
+	}
+	vw.state = VoiceWakeStateListening
+	vw.mu.Unlock()
+
+	vw.ctx, vw.cancel = context.WithCancel(ctx)
+
+	if vw.cfg.AudioSource != nil {
+		if err := vw.cfg.AudioSource.Start(vw.ctx); err != nil {
+			vw.mu.Lock()
+			vw.state = VoiceWakeStateIdle
+			vw.mu.Unlock()
+			return fmt.Errorf("voicewake: failed to start audio source: %w", err)
+		}
+	}
+
+	vw.wg.Add(1)
+	go vw.listenLoop()
+
+	vw.notifyListeners(VoiceWakeEvent{
+		Type:      VoiceWakeEventStateChanged,
+		State:     VoiceWakeStateListening,
+		Timestamp: time.Now(),
+		Data:      map[string]any{"message": "Voice wake listener started"},
+	})
+
+	return nil
+}
+
+func (vw *VoiceWake) Stop() error {
+	vw.mu.Lock()
+	if vw.state == VoiceWakeStateIdle {
+		vw.mu.Unlock()
+		return nil
+	}
+
+	if vw.cancel != nil {
+		vw.cancel()
+	}
+	vw.state = VoiceWakeStateIdle
+	vw.mu.Unlock()
+
+	if vw.cfg.AudioSource != nil {
+		_ = vw.cfg.AudioSource.Stop()
+	}
+
+	vw.wg.Wait()
+
+	vw.notifyListeners(VoiceWakeEvent{
+		Type:      VoiceWakeEventStateChanged,
+		State:     VoiceWakeStateIdle,
+		Timestamp: time.Now(),
+		Data:      map[string]any{"message": "Voice wake listener stopped"},
+	})
+
+	return nil
+}
+
+func (vw *VoiceWake) listenLoop() {
+	defer vw.wg.Done()
+
+	samples := make([]int16, vw.cfg.FrameSize)
+
+	for {
+		select {
+		case <-vw.ctx.Done():
+			return
+		default:
+		}
+
+		var n int
+		var err error
+
+		if vw.cfg.AudioSource != nil {
+			n, err = vw.cfg.AudioSource.Read(samples)
+			if err != nil {
+				log.Printf("voicewake: error reading audio: %v", err)
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
+		} else {
+			time.Sleep(time.Duration(vw.cfg.FrameSize) * time.Second / time.Duration(vw.cfg.SampleRate))
+			continue
+		}
+
+		if n == 0 {
+			continue
+		}
+
+		vw.mu.Lock()
+		inCooldown := time.Now().Before(vw.cooldownUntil)
+		vw.mu.Unlock()
+
+		if inCooldown {
+			continue
+		}
+
+		if vw.engineAdapter != nil && vw.engineAdapter.UseEngine() {
+			result, detected := vw.engineAdapter.ProcessFrame(samples[:n])
+			if detected && result != nil {
+				vw.mu.Lock()
+				vw.lastWakeMatch = result.Keyword
+				vw.lastConfidence = result.Confidence
+				vw.cooldownUntil = time.Now().Add(vw.cfg.CooldownTime)
+				vw.mu.Unlock()
+
+				vw.notifyListeners(VoiceWakeEvent{
+					Type:      VoiceWakeEventWakeDetected,
+					State:     VoiceWakeStateTriggered,
+					Timestamp: time.Now(),
+					Data: map[string]any{
+						"phrase":     result.Keyword,
+						"confidence": result.Confidence,
+						"engine":     string(result.Engine),
+						"energy":     0.0,
+					},
+				})
+
+				vw.mu.Lock()
+				vw.setState(VoiceWakeStateTriggered)
+				vw.mu.Unlock()
+
+				time.Sleep(vw.cfg.CooldownTime)
+
+				vw.mu.Lock()
+				vw.setState(VoiceWakeStateListening)
+				vw.mu.Unlock()
+
+				continue
+			}
+		}
+
+		vw.processAudio(samples[:n])
+	}
+}
+
+func (vw *VoiceWake) processAudio(samples []int16) {
+	vw.mu.Lock()
+	vw.audioBuffer = append(vw.audioBuffer, samples...)
+	vw.mu.Unlock()
+
+	state := vw.vad.ProcessFrame(samples)
+
+	switch state {
+	case VADStateSpeech:
+		vw.mu.Lock()
+		if !vw.isRecording {
+			vw.isRecording = true
+			vw.recordingStart = time.Now()
+			vw.recordingBuffer = make([]int16, 0, vw.cfg.SampleRate*int(vw.cfg.MaxRecordingTime.Seconds()))
+			vw.setState(VoiceWakeStateRecording)
+		}
+		vw.recordingBuffer = append(vw.recordingBuffer, samples...)
+		vw.mu.Unlock()
+
+	case VADStateSilence:
+		vw.mu.Lock()
+		if vw.isRecording {
+			vw.isRecording = false
+			recording := make([]int16, len(vw.recordingBuffer))
+			copy(recording, vw.recordingBuffer)
+			vw.recordingBuffer = nil
+			vw.mu.Unlock()
+
+			vw.processRecording(recording)
+		} else {
+			vw.mu.Unlock()
+		}
+	}
+}
+
+func (vw *VoiceWake) processRecording(samples []int16) {
+	if len(samples) == 0 {
+		return
+	}
+
+	vw.mu.Lock()
+	vw.setState(VoiceWakeStateProcessing)
+	vw.mu.Unlock()
+
+	if vw.cfg.AutoTranscribe && vw.transcriber != nil {
+		audioData := Int16ToWAV(samples, vw.cfg.SampleRate, vw.cfg.Channels)
+
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			result, err := vw.transcriber.TranscribeDirect(ctx, audioData, WithSTTInputFormat(InputWAV))
+			if err != nil {
+				log.Printf("voicewake: transcription error: %v", err)
+				vw.notifyListeners(VoiceWakeEvent{
+					Type:      VoiceWakeEventError,
+					State:     VoiceWakeStateProcessing,
+					Timestamp: time.Now(),
+					Data:      map[string]any{"error": err.Error()},
+				})
+				vw.mu.Lock()
+				vw.setState(VoiceWakeStateListening)
+				vw.mu.Unlock()
+				return
+			}
+
+			vw.mu.Lock()
+			vw.lastTranscript = result.Text
+			vw.mu.Unlock()
+
+			vw.checkWakeWord(result.Text)
+		}()
+	} else {
+		vw.mu.Lock()
+		vw.setState(VoiceWakeStateListening)
+		vw.mu.Unlock()
+	}
+}
+
+func (vw *VoiceWake) checkWakeWord(transcript string) {
+	if transcript == "" {
+		vw.mu.Lock()
+		vw.setState(VoiceWakeStateListening)
+		vw.mu.Unlock()
+		return
+	}
+
+	phrase, confidence, matched := vw.wakeDetector.Detect(transcript)
+
+	vw.mu.Lock()
+	vw.lastTranscript = transcript
+	vw.lastWakeMatch = phrase
+	vw.lastConfidence = confidence
+	vw.mu.Unlock()
+
+	if matched {
+		vw.mu.Lock()
+		vw.setState(VoiceWakeStateTriggered)
+		vw.cooldownUntil = time.Now().Add(vw.cfg.CooldownTime)
+		energy := vw.lastEnergy
+		vw.mu.Unlock()
+
+		vw.notifyListeners(VoiceWakeEvent{
+			Type:      VoiceWakeEventWakeDetected,
+			State:     VoiceWakeStateTriggered,
+			Timestamp: time.Now(),
+			Data: map[string]any{
+				"phrase":     phrase,
+				"confidence": confidence,
+				"transcript": transcript,
+				"energy":     energy,
+			},
+		})
+
+		time.Sleep(vw.cfg.CooldownTime)
+
+		vw.mu.Lock()
+		vw.setState(VoiceWakeStateListening)
+		vw.mu.Unlock()
+	} else {
+		vw.mu.Lock()
+		vw.setState(VoiceWakeStateListening)
+		vw.mu.Unlock()
+	}
+}
+
+func (vw *VoiceWake) onVADStateChanged(state VADState, energy float64, zcr float64) {
+	vw.mu.Lock()
+	vw.lastEnergy = energy
+	vw.mu.Unlock()
+
+	switch state {
+	case VADStateSpeech:
+		vw.notifyListeners(VoiceWakeEvent{
+			Type:      VoiceWakeEventSpeechStart,
+			State:     vw.State(),
+			Timestamp: time.Now(),
+			Data: map[string]any{
+				"energy": energy,
+				"zcr":    zcr,
+			},
+		})
+
+	case VADStateSilence:
+		vw.notifyListeners(VoiceWakeEvent{
+			Type:      VoiceWakeEventSpeechEnd,
+			State:     vw.State(),
+			Timestamp: time.Now(),
+			Data: map[string]any{
+				"energy": energy,
+				"zcr":    zcr,
+			},
+		})
+	}
+}
+
+func (vw *VoiceWake) setState(state VoiceWakeState) {
+	oldState := vw.state
+	vw.state = state
+
+	if oldState != state {
+		vw.notifyListeners(VoiceWakeEvent{
+			Type:      VoiceWakeEventStateChanged,
+			State:     state,
+			Timestamp: time.Now(),
+			Data: map[string]any{
+				"previous_state": oldState,
+				"new_state":      state,
+			},
+		})
+	}
+}
+
+func (vw *VoiceWake) State() VoiceWakeState {
+	vw.mu.Lock()
+	defer vw.mu.Unlock()
+	return vw.state
+}
+
+func (vw *VoiceWake) notifyListeners(event VoiceWakeEvent) {
+	vw.mu.Lock()
+	listeners := make([]VoiceWakeListener, len(vw.listeners))
+	copy(listeners, vw.listeners)
+	vw.mu.Unlock()
+
+	for _, listener := range listeners {
+		listener(event)
+	}
+}
+
+func (vw *VoiceWake) LastTranscript() string {
+	vw.mu.Lock()
+	defer vw.mu.Unlock()
+	return vw.lastTranscript
+}
+
+func (vw *VoiceWake) LastWakeMatch() (string, float64) {
+	vw.mu.Lock()
+	defer vw.mu.Unlock()
+	return vw.lastWakeMatch, vw.lastConfidence
+}
+
+func (vw *VoiceWake) VAD() *VAD {
+	return vw.vad
+}
+
+func (vw *VoiceWake) WakeDetector() *WakeWordDetector {
+	return vw.wakeDetector
+}
+
+func (vw *VoiceWake) UpdateConfig(cfg VoiceWakeConfig) {
+	vw.mu.Lock()
+	defer vw.mu.Unlock()
+
+	if cfg.SampleRate > 0 {
+		vw.cfg.SampleRate = cfg.SampleRate
+	}
+	if cfg.Channels > 0 {
+		vw.cfg.Channels = cfg.Channels
+	}
+	if cfg.FrameSize > 0 {
+		vw.cfg.FrameSize = cfg.FrameSize
+	}
+	if cfg.MaxRecordingTime > 0 {
+		vw.cfg.MaxRecordingTime = cfg.MaxRecordingTime
+	}
+	if cfg.CooldownTime > 0 {
+		vw.cfg.CooldownTime = cfg.CooldownTime
+	}
+
+	vw.cfg.AutoTranscribe = cfg.AutoTranscribe
+}
+
+func (vw *VoiceWake) Config() VoiceWakeConfig {
+	vw.mu.Lock()
+	defer vw.mu.Unlock()
+	return vw.cfg
+}
+
+func (vw *VoiceWake) SetTranscriber(pipeline *STTPipeline) {
+	vw.mu.Lock()
+	defer vw.mu.Unlock()
+	vw.transcriber = pipeline
+}
+
+func (vw *VoiceWake) RegisterEngine(engineType WakeWordEngineType, cfg WakeWordEngineConfig) error {
+	vw.mu.Lock()
+	router := vw.engineRouter
+	vw.mu.Unlock()
+
+	if router == nil {
+		return fmt.Errorf("voicewake: no engine router available")
+	}
+
+	if err := router.CreateEngine(engineType, cfg); err != nil {
+		return err
+	}
+
+	vw.engineAdapter.SetUseEngine(true)
+	return nil
+}
+
+func (vw *VoiceWake) SetActiveEngine(name string) error {
+	vw.mu.Lock()
+	router := vw.engineRouter
+	vw.mu.Unlock()
+
+	if router == nil {
+		return fmt.Errorf("voicewake: no engine router available")
+	}
+
+	return router.SetActive(name)
+}
+
+func (vw *VoiceWake) UseWakeWordEngine(use bool) {
+	vw.mu.Lock()
+	defer vw.mu.Unlock()
+	if vw.engineAdapter != nil {
+		vw.engineAdapter.SetUseEngine(use)
+	}
+}
+
+func (vw *VoiceWake) IsUsingWakeWordEngine() bool {
+	vw.mu.Lock()
+	defer vw.mu.Unlock()
+	if vw.engineAdapter == nil {
+		return false
+	}
+	return vw.engineAdapter.UseEngine()
+}
+
+func (vw *VoiceWake) AvailableEngines() []string {
+	vw.mu.Lock()
+	defer vw.mu.Unlock()
+	if vw.engineRouter == nil {
+		return nil
+	}
+	return vw.engineRouter.Engines()
+}
+
+func (vw *VoiceWake) ActiveEngine() string {
+	vw.mu.Lock()
+	defer vw.mu.Unlock()
+	if vw.engineRouter == nil {
+		return ""
+	}
+	return vw.engineRouter.ActiveEngine()
+}
+
+func (vw *VoiceWake) EngineRouter() *WakeWordEngineRouter {
+	return vw.engineRouter
+}
+
+func (vw *VoiceWake) EngineAdapter() *WakeWordEngineAdapter {
+	return vw.engineAdapter
+}
+
+func (vw *VoiceWake) Close() error {
+	if err := vw.Stop(); err != nil {
+		return err
+	}
+
+	vw.mu.Lock()
+	router := vw.engineRouter
+	vw.mu.Unlock()
+
+	if router != nil {
+		return router.Close()
+	}
+	return nil
+}

--- a/pkg/speech/voicewake_integration.go
+++ b/pkg/speech/voicewake_integration.go
@@ -1,0 +1,577 @@
+package speech
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/capability/agents/prompt"
+)
+
+type VoiceWakeIntegration struct {
+	mu             sync.Mutex
+	cfg            VoiceWakeIntegrationConfig
+	voiceWake      *VoiceWake
+	processor      *VoiceWakeProcessor
+	sessionMgr     *VoiceWakeSessionManager
+	sessionTracker *VoiceWakeSessionTracker
+	audioPlayer    AudioPlayer
+	coordinator    *VoiceWakeCoordinator
+	isRunning      bool
+	startTime      time.Time
+	stats          VoiceWakeIntegrationStats
+}
+
+type VoiceWakeIntegrationConfig struct {
+	VoiceWakeConfig    VoiceWakeConfig
+	ProcessorConfig    VoiceWakeProcessorConfig
+	SessionConfig      VoiceWakeSessionManagerConfig
+	AudioPlayerConfig  LocalAudioPlayerConfig
+	CoordinatorConfig  VoiceWakeCoordinatorConfig
+	AutoStart          bool
+	SessionID          string
+	EnableSessionTrack bool
+	EnableCoordination bool
+}
+
+func DefaultVoiceWakeIntegrationConfig() VoiceWakeIntegrationConfig {
+	return VoiceWakeIntegrationConfig{
+		VoiceWakeConfig:    DefaultVoiceWakeConfig(),
+		ProcessorConfig:    DefaultVoiceWakeProcessorConfig(),
+		SessionConfig:      DefaultVoiceWakeSessionManagerConfig(),
+		AudioPlayerConfig:  DefaultLocalAudioPlayerConfig(),
+		CoordinatorConfig:  DefaultVoiceWakeCoordinatorConfig(),
+		AutoStart:          false,
+		SessionID:          "voicewake-default",
+		EnableSessionTrack: true,
+		EnableCoordination: false,
+	}
+}
+
+type VoiceWakeIntegrationStats struct {
+	WakeCount        int
+	TranscriptCount  int
+	ResponseCount    int
+	AudioPlayedCount int
+	ErrorCount       int
+	TotalListenTime  time.Duration
+	TotalSpeakTime   time.Duration
+	LastWakeTime     time.Time
+	LastResponseTime time.Time
+}
+
+func NewVoiceWakeIntegration(cfg VoiceWakeIntegrationConfig) *VoiceWakeIntegration {
+	if cfg.SessionID == "" {
+		cfg.SessionID = "voicewake-default"
+	}
+
+	return &VoiceWakeIntegration{
+		cfg:   cfg,
+		stats: VoiceWakeIntegrationStats{},
+	}
+}
+
+func (i *VoiceWakeIntegration) Init(agent AgentRunner, ttsProcessor TTSProcessor) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if i.isRunning {
+		return fmt.Errorf("voicewake-integration: already initialized")
+	}
+
+	i.sessionMgr = NewVoiceWakeSessionManager(i.cfg.SessionConfig)
+	i.sessionTracker = NewVoiceWakeSessionTracker(i.sessionMgr)
+
+	i.audioPlayer = NewLocalAudioPlayer(i.cfg.AudioPlayerConfig)
+
+	i.cfg.ProcessorConfig.SessionID = i.cfg.SessionID
+	i.cfg.ProcessorConfig.AutoSpeak = true
+
+	i.voiceWake = NewVoiceWake(i.cfg.VoiceWakeConfig)
+
+	i.cfg.ProcessorConfig.VoiceWake = i.voiceWake
+	i.processor = NewVoiceWakeProcessor(i.cfg.ProcessorConfig)
+	i.processor.SetAgent(agent)
+	i.processor.SetTTSProcessor(ttsProcessor)
+	i.processor.SetAudioPlayer(i.audioPlayer)
+
+	i.processor.cfg.OnResponse = func(text string) {
+		i.mu.Lock()
+		i.stats.ResponseCount++
+		i.stats.LastResponseTime = time.Now()
+		i.mu.Unlock()
+
+		i.recordResponse(text)
+	}
+
+	i.processor.cfg.OnAudioComplete = func(dur time.Duration) {
+		i.mu.Lock()
+		i.stats.AudioPlayedCount++
+		i.stats.TotalSpeakTime += dur
+		i.mu.Unlock()
+	}
+
+	i.processor.cfg.OnError = func(err error) {
+		i.mu.Lock()
+		i.stats.ErrorCount++
+		i.mu.Unlock()
+
+		log.Printf("voicewake-integration: processor error: %v", err)
+	}
+
+	i.voiceWake.RegisterListener(i.onVoiceWakeEvent)
+
+	if i.cfg.EnableCoordination {
+		i.coordinator = NewVoiceWakeCoordinator(i.cfg.CoordinatorConfig)
+		i.coordinator.RegisterListener(i.onCoordinatorEvent)
+	}
+
+	_ = i.sessionMgr.GetOrCreateSession(i.cfg.SessionID)
+
+	return nil
+}
+
+func (i *VoiceWakeIntegration) Start(ctx context.Context) error {
+	i.mu.Lock()
+	if i.isRunning {
+		i.mu.Unlock()
+		return fmt.Errorf("voicewake-integration: already running")
+	}
+	i.isRunning = true
+	i.startTime = time.Now()
+	coordinator := i.coordinator
+	i.mu.Unlock()
+
+	if err := i.processor.Start(); err != nil {
+		i.mu.Lock()
+		i.isRunning = false
+		i.mu.Unlock()
+		return fmt.Errorf("voicewake-integration: failed to start processor: %w", err)
+	}
+
+	if _, err := i.sessionTracker.StartSession(i.cfg.SessionID); err != nil {
+		log.Printf("voicewake-integration: failed to start session: %v", err)
+	}
+
+	if coordinator != nil {
+		if err := coordinator.Start(ctx); err != nil {
+			log.Printf("voicewake-integration: failed to start coordinator: %v", err)
+		}
+	}
+
+	if err := i.voiceWake.Start(ctx); err != nil {
+		i.mu.Lock()
+		i.isRunning = false
+		i.mu.Unlock()
+		return fmt.Errorf("voicewake-integration: failed to start voicewake: %w", err)
+	}
+
+	log.Printf("voicewake-integration: started (session: %s, coordination: %v)", i.cfg.SessionID, i.cfg.EnableCoordination)
+
+	return nil
+}
+
+func (i *VoiceWakeIntegration) Stop() error {
+	i.mu.Lock()
+	if !i.isRunning {
+		i.mu.Unlock()
+		return nil
+	}
+	i.isRunning = false
+	coordinator := i.coordinator
+	i.mu.Unlock()
+
+	if err := i.voiceWake.Stop(); err != nil {
+		log.Printf("voicewake-integration: error stopping voicewake: %v", err)
+	}
+
+	if coordinator != nil {
+		if err := coordinator.Stop(); err != nil {
+			log.Printf("voicewake-integration: error stopping coordinator: %v", err)
+		}
+	}
+
+	if err := i.sessionTracker.EndSession(i.cfg.SessionID); err != nil {
+		log.Printf("voicewake-integration: error ending session: %v", err)
+	}
+
+	i.mu.Lock()
+	i.stats.TotalListenTime = time.Since(i.startTime)
+	i.mu.Unlock()
+
+	log.Printf("voicewake-integration: stopped (stats: %+v)", i.Stats())
+
+	return nil
+}
+
+func (i *VoiceWakeIntegration) onVoiceWakeEvent(event VoiceWakeEvent) {
+	i.mu.Lock()
+	switch event.Type {
+	case VoiceWakeEventWakeDetected:
+		i.stats.WakeCount++
+		i.stats.LastWakeTime = time.Now()
+
+	case VoiceWakeEventSpeechStart:
+		// VAD detected speech start
+
+	case VoiceWakeEventSpeechEnd:
+		// VAD detected speech end
+
+	case VoiceWakeEventError:
+		i.stats.ErrorCount++
+	}
+	i.mu.Unlock()
+
+	if event.Type == VoiceWakeEventWakeDetected {
+		i.recordWakeEvent(event)
+
+		i.mu.Lock()
+		coordinator := i.coordinator
+		i.mu.Unlock()
+
+		if coordinator != nil && !coordinator.IsSuppressed() {
+			phrase, _ := event.Data["phrase"].(string)
+			confidence, _ := event.Data["confidence"].(float64)
+			engine, _ := event.Data["engine"].(string)
+			energy, _ := event.Data["energy"].(float64)
+
+			allowed := coordinator.SubmitWake(phrase, confidence, energy, engine)
+			if !allowed {
+				log.Printf("voicewake-integration: wake suppressed by coordinator")
+				return
+			}
+		}
+	}
+}
+
+func (i *VoiceWakeIntegration) onCoordinatorEvent(event CoordinatorEvent) {
+	switch event.Type {
+	case CoordinatorEventArbitrationWon:
+		log.Printf("coordinator: local device won arbitration")
+
+	case CoordinatorEventArbitrationLost:
+		winnerName, _ := event.Data["winner_name"].(string)
+		log.Printf("coordinator: lost arbitration to %s", winnerName)
+
+	case CoordinatorEventSuppressed:
+		deviceName, _ := event.Data["device_name"].(string)
+		duration, _ := event.Data["duration"].(time.Duration)
+		log.Printf("coordinator: suppressed for %v by %s", duration, deviceName)
+
+	case CoordinatorEventDeviceDiscovered:
+		deviceName, _ := event.Data["device_name"].(string)
+		ipAddress, _ := event.Data["ip_address"].(string)
+		log.Printf("coordinator: discovered device %s at %s", deviceName, ipAddress)
+
+	case CoordinatorEventDeviceLost:
+		deviceName, _ := event.Data["device_name"].(string)
+		log.Printf("coordinator: lost device %s", deviceName)
+	}
+}
+
+func (i *VoiceWakeIntegration) recordWakeEvent(event VoiceWakeEvent) {
+	if i.sessionMgr == nil {
+		return
+	}
+
+	phrase, _ := event.Data["phrase"].(string)
+	confidence, _ := event.Data["confidence"].(float64)
+
+	entry := WakeEventEntry{
+		Phrase:     phrase,
+		Confidence: confidence,
+		Engine:     fmt.Sprintf("%v", event.Data["engine"]),
+		Timestamp:  event.Timestamp,
+	}
+
+	_ = i.sessionMgr.AddWakeEvent(i.cfg.SessionID, entry)
+}
+
+func (i *VoiceWakeIntegration) recordTranscript(text string, confidence float64, language string, duration time.Duration) {
+	if i.sessionMgr == nil {
+		return
+	}
+
+	entry := TranscriptEntry{
+		Text:       text,
+		Confidence: confidence,
+		Language:   language,
+		Duration:   duration,
+		Timestamp:  time.Now(),
+	}
+
+	i.mu.Lock()
+	i.stats.TranscriptCount++
+	i.mu.Unlock()
+
+	_ = i.sessionMgr.AddTranscript(i.cfg.SessionID, entry)
+}
+
+func (i *VoiceWakeIntegration) recordResponse(text string) {
+	if i.sessionMgr == nil {
+		return
+	}
+
+	entry := ResponseEntry{
+		Text:      text,
+		Timestamp: time.Now(),
+		IsSpoken:  i.processor.cfg.AutoSpeak,
+	}
+
+	_ = i.sessionMgr.AddResponse(i.cfg.SessionID, entry)
+}
+
+func (i *VoiceWakeIntegration) AddToHistory(role string, content string) error {
+	if i.sessionMgr == nil {
+		return nil
+	}
+
+	msg := prompt.Message{
+		Role:    role,
+		Content: content,
+	}
+
+	return i.sessionMgr.AddToHistory(i.cfg.SessionID, msg)
+}
+
+func (i *VoiceWakeIntegration) GetHistory() ([]prompt.Message, error) {
+	if i.sessionMgr == nil {
+		return nil, nil
+	}
+
+	return i.sessionMgr.GetHistory(i.cfg.SessionID)
+}
+
+func (i *VoiceWakeIntegration) SetHistory(history []prompt.Message) error {
+	if i.sessionMgr == nil {
+		return nil
+	}
+
+	return i.sessionMgr.SetHistory(i.cfg.SessionID, history)
+}
+
+func (i *VoiceWakeIntegration) Stats() VoiceWakeIntegrationStats {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	stats := i.stats
+	if i.isRunning {
+		stats.TotalListenTime += time.Since(i.startTime)
+	}
+	return stats
+}
+
+func (i *VoiceWakeIntegration) IsRunning() bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.isRunning
+}
+
+func (i *VoiceWakeIntegration) IsProcessing() bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.processor == nil {
+		return false
+	}
+	return i.processor.IsProcessing()
+}
+
+func (i *VoiceWakeIntegration) CancelConversation() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if i.processor != nil {
+		i.processor.CancelConversation()
+	}
+}
+
+func (i *VoiceWakeIntegration) VoiceWake() *VoiceWake {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.voiceWake
+}
+
+func (i *VoiceWakeIntegration) Processor() *VoiceWakeProcessor {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.processor
+}
+
+func (i *VoiceWakeIntegration) SessionManager() *VoiceWakeSessionManager {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.sessionMgr
+}
+
+func (i *VoiceWakeIntegration) AudioPlayer() AudioPlayer {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.audioPlayer
+}
+
+func (i *VoiceWakeIntegration) SetAgent(agent AgentRunner) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.processor != nil {
+		i.processor.SetAgent(agent)
+	}
+}
+
+func (i *VoiceWakeIntegration) SetTTSProcessor(processor TTSProcessor) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.processor != nil {
+		i.processor.SetTTSProcessor(processor)
+	}
+}
+
+func (i *VoiceWakeIntegration) SetSessionID(id string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.cfg.SessionID = id
+	if i.processor != nil {
+		i.processor.cfg.SessionID = id
+	}
+}
+
+func (i *VoiceWakeIntegration) SetAutoSpeak(enabled bool) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.processor != nil {
+		i.processor.cfg.AutoSpeak = enabled
+	}
+}
+
+func (i *VoiceWakeIntegration) SetSensitivity(s float64) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.voiceWake != nil {
+		if wd := i.voiceWake.WakeDetector(); wd != nil {
+			wd.SetSensitivity(s)
+		}
+	}
+}
+
+func (i *VoiceWakeIntegration) RegisterEngine(engineType WakeWordEngineType, cfg WakeWordEngineConfig) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if i.voiceWake == nil {
+		return fmt.Errorf("voicewake-integration: not initialized")
+	}
+
+	return i.voiceWake.RegisterEngine(engineType, cfg)
+}
+
+func (i *VoiceWakeIntegration) RecentTranscripts(n int) ([]TranscriptEntry, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if i.sessionMgr == nil {
+		return nil, nil
+	}
+
+	return i.sessionMgr.RecentTranscripts(i.cfg.SessionID, n)
+}
+
+func (i *VoiceWakeIntegration) RecentResponses(n int) ([]ResponseEntry, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if i.sessionMgr == nil {
+		return nil, nil
+	}
+
+	return i.sessionMgr.RecentResponses(i.cfg.SessionID, n)
+}
+
+func (i *VoiceWakeIntegration) SessionStats() (map[string]any, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if i.sessionMgr == nil {
+		return nil, nil
+	}
+
+	return i.sessionMgr.SessionStats(i.cfg.SessionID)
+}
+
+func (i *VoiceWakeIntegration) Coordinator() *VoiceWakeCoordinator {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.coordinator
+}
+
+func (i *VoiceWakeIntegration) EnableCoordination(enabled bool) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.cfg.EnableCoordination = enabled
+}
+
+func (i *VoiceWakeIntegration) IsCoordinationEnabled() bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.cfg.EnableCoordination
+}
+
+func (i *VoiceWakeIntegration) CoordinatorStats() CoordinatorStats {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.coordinator == nil {
+		return CoordinatorStats{}
+	}
+	return i.coordinator.Stats()
+}
+
+func (i *VoiceWakeIntegration) SetDevicePriority(priority int) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.coordinator != nil {
+		i.coordinator.SetPriority(priority)
+	}
+}
+
+func (i *VoiceWakeIntegration) SetElectionMode(mode ElectionMode) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.coordinator != nil {
+		i.coordinator.SetElectionMode(mode)
+	}
+}
+
+func (i *VoiceWakeIntegration) SetPreferLocal(prefer bool) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.coordinator != nil {
+		i.coordinator.SetPreferLocal(prefer)
+	}
+}
+
+func (i *VoiceWakeIntegration) DiscoveredDevices() []DeviceInfo {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.coordinator == nil {
+		return nil
+	}
+	return i.coordinator.GetDevices()
+}
+
+func (i *VoiceWakeIntegration) IsSuppressed() bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.coordinator == nil {
+		return false
+	}
+	return i.coordinator.IsSuppressed()
+}
+
+func (i *VoiceWakeIntegration) SuppressionRemaining() time.Duration {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.coordinator == nil {
+		return 0
+	}
+	return i.coordinator.SuppressionRemaining()
+}

--- a/pkg/speech/voicewake_pipeline_test.go
+++ b/pkg/speech/voicewake_pipeline_test.go
@@ -1,0 +1,1086 @@
+package speech
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/capability/agents/prompt"
+)
+
+type mockAgent struct {
+	mu        sync.Mutex
+	responses []string
+	inputs    []string
+	delay     time.Duration
+	err       error
+}
+
+func (m *mockAgent) Run(ctx context.Context, userInput string) (string, error) {
+	m.mu.Lock()
+	m.inputs = append(m.inputs, userInput)
+	resp := "default response"
+	if len(m.responses) > 0 {
+		resp = m.responses[0]
+		m.responses = m.responses[1:]
+	}
+	m.mu.Unlock()
+
+	if m.delay > 0 {
+		select {
+		case <-time.After(m.delay):
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+
+	if m.err != nil {
+		return "", m.err
+	}
+
+	return resp, nil
+}
+
+func (m *mockAgent) LastInput() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.inputs) == 0 {
+		return ""
+	}
+	return m.inputs[len(m.inputs)-1]
+}
+
+func (m *mockAgent) InputCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.inputs)
+}
+
+type mockTTSProcessor struct {
+	mu        sync.Mutex
+	audio     []byte
+	format    AudioFormat
+	duration  time.Duration
+	err       error
+	callCount int
+}
+
+func (m *mockTTSProcessor) Synthesize(ctx context.Context, text string, opts ...SynthesizeOption) (*AudioResult, error) {
+	m.mu.Lock()
+	m.callCount++
+	m.mu.Unlock()
+
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return &AudioResult{
+		Data:     m.audio,
+		Format:   m.format,
+		Duration: m.duration,
+	}, nil
+}
+
+func (m *mockTTSProcessor) CallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.callCount
+}
+
+type mockAudioPlayer struct {
+	mu         sync.Mutex
+	isPlaying  bool
+	played     [][]byte
+	formats    []AudioFormat
+	playDelay  time.Duration
+	stopCalled bool
+}
+
+func (m *mockAudioPlayer) Play(ctx context.Context, audio []byte, format AudioFormat) error {
+	m.mu.Lock()
+	m.isPlaying = true
+	m.played = append(m.played, append([]byte(nil), audio...))
+	m.formats = append(m.formats, format)
+	m.mu.Unlock()
+
+	if m.playDelay > 0 {
+		select {
+		case <-time.After(m.playDelay):
+		case <-ctx.Done():
+			m.mu.Lock()
+			m.isPlaying = false
+			m.mu.Unlock()
+			return ctx.Err()
+		}
+	}
+
+	m.mu.Lock()
+	m.isPlaying = false
+	m.mu.Unlock()
+
+	return nil
+}
+
+func (m *mockAudioPlayer) Stop() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.isPlaying = false
+	m.stopCalled = true
+	return nil
+}
+
+func (m *mockAudioPlayer) IsPlaying() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.isPlaying
+}
+
+func (m *mockAudioPlayer) PlayCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.played)
+}
+
+func (m *mockAudioPlayer) LastAudio() []byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.played) == 0 {
+		return nil
+	}
+	return m.played[len(m.played)-1]
+}
+
+func TestVoiceWakeProcessorCreation(t *testing.T) {
+	cfg := DefaultVoiceWakeProcessorConfig()
+	processor := NewVoiceWakeProcessor(cfg)
+
+	if processor == nil {
+		t.Fatal("expected processor instance")
+	}
+
+	if processor.IsProcessing() {
+		t.Error("expected not processing initially")
+	}
+}
+
+func TestVoiceWakeProcessorStart(t *testing.T) {
+	vw := NewVoiceWake(DefaultVoiceWakeConfig())
+	agent := &mockAgent{responses: []string{"hello"}}
+
+	cfg := DefaultVoiceWakeProcessorConfig()
+	cfg.VoiceWake = vw
+	cfg.Agent = agent
+
+	processor := NewVoiceWakeProcessor(cfg)
+
+	err := processor.Start()
+	if err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+}
+
+func TestVoiceWakeProcessorStartMissingAgent(t *testing.T) {
+	vw := NewVoiceWake(DefaultVoiceWakeConfig())
+
+	cfg := DefaultVoiceWakeProcessorConfig()
+	cfg.VoiceWake = vw
+	cfg.Agent = nil
+
+	processor := NewVoiceWakeProcessor(cfg)
+
+	err := processor.Start()
+	if err == nil {
+		t.Error("expected error for missing agent")
+	}
+}
+
+func TestVoiceWakeProcessorStartMissingVoiceWake(t *testing.T) {
+	agent := &mockAgent{}
+
+	cfg := DefaultVoiceWakeProcessorConfig()
+	cfg.Agent = agent
+	cfg.VoiceWake = nil
+
+	processor := NewVoiceWakeProcessor(cfg)
+
+	err := processor.Start()
+	if err == nil {
+		t.Error("expected error for missing voicewake")
+	}
+}
+
+func TestVoiceWakeProcessorHandleWakeDetected(t *testing.T) {
+	vw := NewVoiceWake(DefaultVoiceWakeConfig())
+	agent := &mockAgent{responses: []string{"Hello! How can I help?"}}
+
+	cfg := DefaultVoiceWakeProcessorConfig()
+	cfg.VoiceWake = vw
+	cfg.Agent = agent
+	cfg.AutoSpeak = false
+
+	processor := NewVoiceWakeProcessor(cfg)
+	_ = processor.Start()
+
+	event := VoiceWakeEvent{
+		Type:      VoiceWakeEventWakeDetected,
+		State:     VoiceWakeStateTriggered,
+		Timestamp: time.Now(),
+		Data: map[string]any{
+			"transcript": "hey anyclaw what is the weather",
+			"phrase":     "hey anyclaw",
+			"confidence": 0.95,
+		},
+	}
+
+	processor.onVoiceWakeEvent(event)
+
+	time.Sleep(50 * time.Millisecond)
+
+	if agent.InputCount() != 1 {
+		t.Errorf("expected 1 agent call, got %d", agent.InputCount())
+	}
+
+	input := agent.LastInput()
+	if input != "hey anyclaw what is the weather" {
+		t.Errorf("expected input 'hey anyclaw what is the weather', got %q", input)
+	}
+
+	if processor.LastResponse() != "Hello! How can I help?" {
+		t.Errorf("expected response 'Hello! How can I help?', got %q", processor.LastResponse())
+	}
+}
+
+func TestVoiceWakeProcessorWithTTS(t *testing.T) {
+	vw := NewVoiceWake(DefaultVoiceWakeConfig())
+	agent := &mockAgent{responses: []string{"The weather is sunny"}}
+	tts := &mockTTSProcessor{
+		audio:    []byte("fake-audio-data"),
+		format:   FormatWAV,
+		duration: 2 * time.Second,
+	}
+	player := &mockAudioPlayer{}
+
+	cfg := DefaultVoiceWakeProcessorConfig()
+	cfg.VoiceWake = vw
+	cfg.Agent = agent
+	cfg.TTSProcessor = tts
+	cfg.AudioPlayer = player
+	cfg.AutoSpeak = true
+
+	processor := NewVoiceWakeProcessor(cfg)
+	_ = processor.Start()
+
+	event := VoiceWakeEvent{
+		Type:      VoiceWakeEventWakeDetected,
+		State:     VoiceWakeStateTriggered,
+		Timestamp: time.Now(),
+		Data: map[string]any{
+			"transcript": "hey anyclaw what is the weather",
+		},
+	}
+
+	processor.onVoiceWakeEvent(event)
+
+	time.Sleep(50 * time.Millisecond)
+
+	if tts.CallCount() != 1 {
+		t.Errorf("expected 1 TTS call, got %d", tts.CallCount())
+	}
+
+	if player.PlayCount() != 1 {
+		t.Errorf("expected 1 playback, got %d", player.PlayCount())
+	}
+
+	if processor.LastAudioDuration() != 2*time.Second {
+		t.Errorf("expected duration 2s, got %v", processor.LastAudioDuration())
+	}
+}
+
+func TestVoiceWakeProcessorConcurrency(t *testing.T) {
+	vw := NewVoiceWake(DefaultVoiceWakeConfig())
+	agent := &mockAgent{responses: []string{"response1", "response2"}}
+
+	cfg := DefaultVoiceWakeProcessorConfig()
+	cfg.VoiceWake = vw
+	cfg.Agent = agent
+	cfg.AutoSpeak = false
+
+	processor := NewVoiceWakeProcessor(cfg)
+	_ = processor.Start()
+
+	event1 := VoiceWakeEvent{
+		Type:      VoiceWakeEventWakeDetected,
+		Timestamp: time.Now(),
+		Data:      map[string]any{"transcript": "first message"},
+	}
+	event2 := VoiceWakeEvent{
+		Type:      VoiceWakeEventWakeDetected,
+		Timestamp: time.Now(),
+		Data:      map[string]any{"transcript": "second message"},
+	}
+
+	processor.onVoiceWakeEvent(event1)
+	processor.onVoiceWakeEvent(event2)
+
+	time.Sleep(50 * time.Millisecond)
+
+	if agent.InputCount() != 1 {
+		t.Errorf("expected only 1 agent call (second skipped due to processing), got %d", agent.InputCount())
+	}
+}
+
+func TestVoiceWakeProcessorCancel(t *testing.T) {
+	vw := NewVoiceWake(DefaultVoiceWakeConfig())
+	agent := &mockAgent{
+		responses: []string{"slow response"},
+		delay:     500 * time.Millisecond,
+	}
+
+	cfg := DefaultVoiceWakeProcessorConfig()
+	cfg.VoiceWake = vw
+	cfg.Agent = agent
+	cfg.AutoSpeak = false
+
+	processor := NewVoiceWakeProcessor(cfg)
+	_ = processor.Start()
+
+	event := VoiceWakeEvent{
+		Type:      VoiceWakeEventWakeDetected,
+		Timestamp: time.Now(),
+		Data:      map[string]any{"transcript": "cancel me"},
+	}
+
+	processor.onVoiceWakeEvent(event)
+
+	time.Sleep(10 * time.Millisecond)
+
+	if !processor.IsProcessing() {
+		t.Error("expected processing to be active")
+	}
+
+	processor.CancelConversation()
+
+	if processor.IsProcessing() {
+		t.Error("expected processing to be cancelled")
+	}
+}
+
+func TestVoiceWakeProcessorCallbacks(t *testing.T) {
+	vw := NewVoiceWake(DefaultVoiceWakeConfig())
+	agent := &mockAgent{responses: []string{"response"}}
+	tts := &mockTTSProcessor{
+		audio:    []byte("audio"),
+		format:   FormatWAV,
+		duration: 1 * time.Second,
+	}
+	player := &mockAudioPlayer{}
+
+	responseCalled := make(chan string, 1)
+	audioCalled := make(chan time.Duration, 1)
+
+	cfg := DefaultVoiceWakeProcessorConfig()
+	cfg.VoiceWake = vw
+	cfg.Agent = agent
+	cfg.TTSProcessor = tts
+	cfg.AudioPlayer = player
+	cfg.AutoSpeak = true
+	cfg.OnResponse = func(text string) {
+		responseCalled <- text
+	}
+	cfg.OnAudioComplete = func(dur time.Duration) {
+		audioCalled <- dur
+	}
+
+	processor := NewVoiceWakeProcessor(cfg)
+	_ = processor.Start()
+
+	event := VoiceWakeEvent{
+		Type:      VoiceWakeEventWakeDetected,
+		Timestamp: time.Now(),
+		Data:      map[string]any{"transcript": "test"},
+	}
+
+	processor.onVoiceWakeEvent(event)
+
+	select {
+	case resp := <-responseCalled:
+		if resp != "response" {
+			t.Errorf("expected response 'response', got %q", resp)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("expected OnResponse callback")
+	}
+
+	select {
+	case dur := <-audioCalled:
+		if dur != 1*time.Second {
+			t.Errorf("expected duration 1s, got %v", dur)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("expected OnAudioComplete callback")
+	}
+}
+
+func TestVoiceWakeProcessorUpdateConfig(t *testing.T) {
+	vw := NewVoiceWake(DefaultVoiceWakeConfig())
+	agent := &mockAgent{}
+
+	cfg := DefaultVoiceWakeProcessorConfig()
+	cfg.VoiceWake = vw
+	cfg.Agent = agent
+
+	processor := NewVoiceWakeProcessor(cfg)
+
+	newAgent := &mockAgent{}
+	processor.SetAgent(newAgent)
+
+	if processor.cfg.Agent != newAgent {
+		t.Error("expected agent to be updated")
+	}
+}
+
+func TestLocalAudioPlayerCreation(t *testing.T) {
+	cfg := DefaultLocalAudioPlayerConfig()
+	player := NewLocalAudioPlayer(cfg)
+
+	if player == nil {
+		t.Fatal("expected player instance")
+	}
+
+	if player.IsPlaying() {
+		t.Error("expected not playing initially")
+	}
+}
+
+func TestLocalAudioPlayerAvailablePlayers(t *testing.T) {
+	cfg := DefaultLocalAudioPlayerConfig()
+	player := NewLocalAudioPlayer(cfg)
+
+	players := player.AvailablePlayers()
+	// At minimum, should return empty or available players
+	if players == nil {
+		t.Error("expected non-nil player list")
+	}
+}
+
+func TestLocalAudioPlayerSetPlayer(t *testing.T) {
+	cfg := DefaultLocalAudioPlayerConfig()
+	player := NewLocalAudioPlayer(cfg)
+
+	player.SetPlayer("test-player")
+	if player.Player() != "test-player" {
+		t.Errorf("expected player 'test-player', got %s", player.Player())
+	}
+}
+
+func TestLocalAudioPlayerVolume(t *testing.T) {
+	cfg := DefaultLocalAudioPlayerConfig()
+	player := NewLocalAudioPlayer(cfg)
+
+	player.SetVolume(0.5)
+	if player.Volume() != 0.5 {
+		t.Errorf("expected volume 0.5, got %f", player.Volume())
+	}
+
+	player.SetVolume(3.0)
+	if player.Volume() != 0.5 {
+		t.Error("expected volume unchanged after invalid set")
+	}
+}
+
+func TestBufferAudioPlayer(t *testing.T) {
+	player := NewBufferAudioPlayer()
+
+	if player.IsPlaying() {
+		t.Error("expected not playing initially")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		player.Stop()
+	}()
+
+	err := player.Play(ctx, []byte("audio"), FormatWAV)
+	if err != nil {
+		t.Errorf("play failed: %v", err)
+	}
+
+	buf := player.Buffer()
+	if string(buf) != "audio" {
+		t.Errorf("expected buffer 'audio', got %s", string(buf))
+	}
+
+	if player.Format() != FormatWAV {
+		t.Errorf("expected format WAV, got %s", player.Format())
+	}
+}
+
+func TestMultiAudioPlayer(t *testing.T) {
+	player1 := &mockAudioPlayer{}
+	player2 := &mockAudioPlayer{}
+
+	multi := NewMultiAudioPlayer(player1, player2)
+
+	ctx := context.Background()
+	err := multi.Play(ctx, []byte("test"), FormatMP3)
+	if err != nil {
+		t.Errorf("play failed: %v", err)
+	}
+
+	if player1.PlayCount() != 1 {
+		t.Error("expected first player to be used")
+	}
+
+	err = multi.SetPlayer(1)
+	if err != nil {
+		t.Errorf("set player failed: %v", err)
+	}
+
+	err = multi.Play(ctx, []byte("test2"), FormatMP3)
+	if err != nil {
+		t.Errorf("play failed: %v", err)
+	}
+
+	if player2.PlayCount() != 1 {
+		t.Error("expected second player to be used after switch")
+	}
+}
+
+func TestNopAudioPlayer(t *testing.T) {
+	player := NopAudioPlayer{}
+
+	ctx := context.Background()
+	err := player.Play(ctx, []byte("test"), FormatWAV)
+	if err != nil {
+		t.Errorf("nop play failed: %v", err)
+	}
+
+	if player.IsPlaying() {
+		t.Error("nop player should never be playing")
+	}
+
+	err = player.Stop()
+	if err != nil {
+		t.Errorf("nop stop failed: %v", err)
+	}
+}
+
+func TestVoiceWakeSessionManagerCreation(t *testing.T) {
+	cfg := DefaultVoiceWakeSessionManagerConfig()
+	mgr := NewVoiceWakeSessionManager(cfg)
+
+	if mgr == nil {
+		t.Fatal("expected session manager")
+	}
+
+	if mgr.SessionCount() != 0 {
+		t.Errorf("expected 0 sessions, got %d", mgr.SessionCount())
+	}
+}
+
+func TestVoiceWakeSessionManagerCreateAndGet(t *testing.T) {
+	cfg := DefaultVoiceWakeSessionManagerConfig()
+	mgr := NewVoiceWakeSessionManager(cfg)
+
+	session := mgr.CreateSession("test-session")
+	if session == nil {
+		t.Fatal("expected session")
+	}
+
+	if session.ID != "test-session" {
+		t.Errorf("expected ID 'test-session', got %s", session.ID)
+	}
+
+	if mgr.SessionCount() != 1 {
+		t.Errorf("expected 1 session, got %d", mgr.SessionCount())
+	}
+
+	retrieved, ok := mgr.GetSession("test-session")
+	if !ok {
+		t.Error("expected to find session")
+	}
+	if retrieved.ID != "test-session" {
+		t.Errorf("expected ID 'test-session', got %s", retrieved.ID)
+	}
+
+	_, ok = mgr.GetSession("nonexistent")
+	if ok {
+		t.Error("expected not to find nonexistent session")
+	}
+}
+
+func TestVoiceWakeSessionManagerGetOrCreate(t *testing.T) {
+	cfg := DefaultVoiceWakeSessionManagerConfig()
+	mgr := NewVoiceWakeSessionManager(cfg)
+
+	session := mgr.GetOrCreateSession("new-session")
+	if session == nil {
+		t.Fatal("expected session")
+	}
+
+	if mgr.SessionCount() != 1 {
+		t.Errorf("expected 1 session, got %d", mgr.SessionCount())
+	}
+
+	same := mgr.GetOrCreateSession("new-session")
+	if same.ID != session.ID {
+		t.Error("expected same session")
+	}
+
+	if mgr.SessionCount() != 1 {
+		t.Errorf("expected still 1 session, got %d", mgr.SessionCount())
+	}
+}
+
+func TestVoiceWakeSessionManagerAddTranscript(t *testing.T) {
+	cfg := DefaultVoiceWakeSessionManagerConfig()
+	mgr := NewVoiceWakeSessionManager(cfg)
+	mgr.CreateSession("test")
+
+	entry := TranscriptEntry{
+		Text:       "hello world",
+		Confidence: 0.9,
+		Language:   "en",
+		Duration:   3 * time.Second,
+		Timestamp:  time.Now(),
+	}
+
+	err := mgr.AddTranscript("test", entry)
+	if err != nil {
+		t.Errorf("add transcript failed: %v", err)
+	}
+
+	transcripts, err := mgr.RecentTranscripts("test", 10)
+	if err != nil {
+		t.Errorf("recent transcripts failed: %v", err)
+	}
+
+	if len(transcripts) != 1 {
+		t.Errorf("expected 1 transcript, got %d", len(transcripts))
+	}
+	if transcripts[0].Text != "hello world" {
+		t.Errorf("expected text 'hello world', got %s", transcripts[0].Text)
+	}
+}
+
+func TestVoiceWakeSessionManagerAddResponse(t *testing.T) {
+	cfg := DefaultVoiceWakeSessionManagerConfig()
+	mgr := NewVoiceWakeSessionManager(cfg)
+	mgr.CreateSession("test")
+
+	entry := ResponseEntry{
+		Text:      "Hi there!",
+		Duration:  2 * time.Second,
+		Timestamp: time.Now(),
+		IsSpoken:  true,
+	}
+
+	err := mgr.AddResponse("test", entry)
+	if err != nil {
+		t.Errorf("add response failed: %v", err)
+	}
+
+	responses, err := mgr.RecentResponses("test", 10)
+	if err != nil {
+		t.Errorf("recent responses failed: %v", err)
+	}
+
+	if len(responses) != 1 {
+		t.Errorf("expected 1 response, got %d", len(responses))
+	}
+}
+
+func TestVoiceWakeSessionManagerAddWakeEvent(t *testing.T) {
+	cfg := DefaultVoiceWakeSessionManagerConfig()
+	mgr := NewVoiceWakeSessionManager(cfg)
+	mgr.CreateSession("test")
+
+	entry := WakeEventEntry{
+		Phrase:     "hey anyclaw",
+		Confidence: 0.95,
+		Engine:     "builtin",
+		Timestamp:  time.Now(),
+	}
+
+	err := mgr.AddWakeEvent("test", entry)
+	if err != nil {
+		t.Errorf("add wake event failed: %v", err)
+	}
+
+	session, _ := mgr.GetSession("test")
+	if len(session.WakeEvents) != 1 {
+		t.Errorf("expected 1 wake event, got %d", len(session.WakeEvents))
+	}
+}
+
+func TestVoiceWakeSessionManagerHistory(t *testing.T) {
+	cfg := DefaultVoiceWakeSessionManagerConfig()
+	mgr := NewVoiceWakeSessionManager(cfg)
+	mgr.CreateSession("test")
+
+	err := mgr.AddToHistory("test", prompt.Message{Role: "user", Content: "hello"})
+	if err != nil {
+		t.Errorf("add history failed: %v", err)
+	}
+
+	err = mgr.AddToHistory("test", prompt.Message{Role: "assistant", Content: "hi"})
+	if err != nil {
+		t.Errorf("add history failed: %v", err)
+	}
+
+	history, err := mgr.GetHistory("test")
+	if err != nil {
+		t.Errorf("get history failed: %v", err)
+	}
+
+	if len(history) != 2 {
+		t.Errorf("expected 2 history entries, got %d", len(history))
+	}
+}
+
+func TestVoiceWakeSessionManagerDelete(t *testing.T) {
+	cfg := DefaultVoiceWakeSessionManagerConfig()
+	mgr := NewVoiceWakeSessionManager(cfg)
+	mgr.CreateSession("s1")
+	mgr.CreateSession("s2")
+
+	err := mgr.DeleteSession("s1")
+	if err != nil {
+		t.Errorf("delete session failed: %v", err)
+	}
+
+	if mgr.SessionCount() != 1 {
+		t.Errorf("expected 1 session after delete, got %d", mgr.SessionCount())
+	}
+}
+
+func TestVoiceWakeSessionManagerActive(t *testing.T) {
+	cfg := DefaultVoiceWakeSessionManagerConfig()
+	mgr := NewVoiceWakeSessionManager(cfg)
+	mgr.CreateSession("s1")
+	mgr.CreateSession("s2")
+
+	if mgr.ActiveSessionID() != "s2" {
+		t.Errorf("expected active session 's2', got %s", mgr.ActiveSessionID())
+	}
+
+	err := mgr.SetActive("s1")
+	if err != nil {
+		t.Errorf("set active failed: %v", err)
+	}
+
+	if mgr.ActiveSessionID() != "s1" {
+		t.Errorf("expected active session 's1', got %s", mgr.ActiveSessionID())
+	}
+}
+
+func TestVoiceWakeSessionManagerEviction(t *testing.T) {
+	cfg := VoiceWakeSessionManagerConfig{MaxSessions: 2, MaxHistory: 50}
+	mgr := NewVoiceWakeSessionManager(cfg)
+
+	mgr.CreateSession("s1")
+	time.Sleep(1 * time.Millisecond)
+	mgr.CreateSession("s2")
+	time.Sleep(1 * time.Millisecond)
+	mgr.CreateSession("s3")
+
+	if mgr.SessionCount() > 2 {
+		t.Errorf("expected max 2 sessions, got %d", mgr.SessionCount())
+	}
+}
+
+func TestVoiceWakeSessionManagerStats(t *testing.T) {
+	cfg := DefaultVoiceWakeSessionManagerConfig()
+	mgr := NewVoiceWakeSessionManager(cfg)
+	mgr.CreateSession("test")
+
+	_ = mgr.AddTranscript("test", TranscriptEntry{Text: "hi", Timestamp: time.Now()})
+	_ = mgr.AddResponse("test", ResponseEntry{Text: "hello", Timestamp: time.Now()})
+	_ = mgr.AddWakeEvent("test", WakeEventEntry{Phrase: "hey", Timestamp: time.Now()})
+
+	stats, err := mgr.SessionStats("test")
+	if err != nil {
+		t.Errorf("session stats failed: %v", err)
+	}
+
+	if stats["transcript_count"] != 1 {
+		t.Errorf("expected 1 transcript, got %v", stats["transcript_count"])
+	}
+	if stats["response_count"] != 1 {
+		t.Errorf("expected 1 response, got %v", stats["response_count"])
+	}
+	if stats["wake_event_count"] != 1 {
+		t.Errorf("expected 1 wake event, got %v", stats["wake_event_count"])
+	}
+}
+
+func TestVoiceWakeSessionTracker(t *testing.T) {
+	mgr := NewVoiceWakeSessionManager(DefaultVoiceWakeSessionManagerConfig())
+	tracker := NewVoiceWakeSessionTracker(mgr)
+
+	sc, err := tracker.StartSession("test")
+	if err != nil {
+		t.Fatalf("start session failed: %v", err)
+	}
+
+	if sc.Session.ID != "test" {
+		t.Errorf("expected session ID 'test', got %s", sc.Session.ID)
+	}
+
+	if tracker.ActiveSessionID() != "test" {
+		t.Errorf("expected active session 'test', got %s", tracker.ActiveSessionID())
+	}
+
+	err = tracker.EndSession("test")
+	if err != nil {
+		t.Errorf("end session failed: %v", err)
+	}
+
+	if tracker.ActiveSession() != nil {
+		t.Error("expected no active session after end")
+	}
+}
+
+func TestVoiceWakeIntegrationCreation(t *testing.T) {
+	cfg := DefaultVoiceWakeIntegrationConfig()
+	integration := NewVoiceWakeIntegration(cfg)
+
+	if integration == nil {
+		t.Fatal("expected integration instance")
+	}
+
+	if integration.IsRunning() {
+		t.Error("expected not running initially")
+	}
+}
+
+func TestVoiceWakeIntegrationInit(t *testing.T) {
+	cfg := DefaultVoiceWakeIntegrationConfig()
+	integration := NewVoiceWakeIntegration(cfg)
+
+	agent := &mockAgent{}
+	tts := &mockTTSProcessor{}
+
+	err := integration.Init(agent, tts)
+	if err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	if integration.VoiceWake() == nil {
+		t.Error("expected VoiceWake after init")
+	}
+	if integration.Processor() == nil {
+		t.Error("expected Processor after init")
+	}
+	if integration.SessionManager() == nil {
+		t.Error("expected SessionManager after init")
+	}
+	if integration.AudioPlayer() == nil {
+		t.Error("expected AudioPlayer after init")
+	}
+}
+
+func TestVoiceWakeIntegrationStartStop(t *testing.T) {
+	cfg := DefaultVoiceWakeIntegrationConfig()
+	integration := NewVoiceWakeIntegration(cfg)
+
+	agent := &mockAgent{}
+	tts := &mockTTSProcessor{}
+
+	_ = integration.Init(agent, tts)
+
+	ctx := context.Background()
+	err := integration.Start(ctx)
+	if err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+
+	if !integration.IsRunning() {
+		t.Error("expected running after start")
+	}
+
+	err = integration.Stop()
+	if err != nil {
+		t.Fatalf("stop failed: %v", err)
+	}
+
+	if integration.IsRunning() {
+		t.Error("expected not running after stop")
+	}
+}
+
+func TestVoiceWakeIntegrationStats(t *testing.T) {
+	cfg := DefaultVoiceWakeIntegrationConfig()
+	integration := NewVoiceWakeIntegration(cfg)
+
+	agent := &mockAgent{}
+	tts := &mockTTSProcessor{}
+
+	_ = integration.Init(agent, tts)
+
+	stats := integration.Stats()
+	if stats.WakeCount != 0 {
+		t.Errorf("expected 0 wake count, got %d", stats.WakeCount)
+	}
+}
+
+func TestVoiceWakeIntegrationSetters(t *testing.T) {
+	cfg := DefaultVoiceWakeIntegrationConfig()
+	integration := NewVoiceWakeIntegration(cfg)
+
+	agent := &mockAgent{}
+	tts := &mockTTSProcessor{}
+
+	_ = integration.Init(agent, tts)
+
+	newAgent := &mockAgent{}
+	integration.SetAgent(newAgent)
+
+	integration.SetAutoSpeak(false)
+	if integration.processor.cfg.AutoSpeak {
+		t.Error("expected auto-speak disabled")
+	}
+
+	integration.SetSensitivity(0.8)
+	if integration.voiceWake.WakeDetector().Sensitivity() != 0.8 {
+		t.Errorf("expected sensitivity 0.8, got %f", integration.voiceWake.WakeDetector().Sensitivity())
+	}
+}
+
+func TestVoiceWakeIntegrationCancel(t *testing.T) {
+	cfg := DefaultVoiceWakeIntegrationConfig()
+	integration := NewVoiceWakeIntegration(cfg)
+
+	agent := &mockAgent{}
+	tts := &mockTTSProcessor{}
+
+	_ = integration.Init(agent, tts)
+
+	integration.CancelConversation()
+	if integration.IsProcessing() {
+		t.Error("expected not processing after cancel")
+	}
+}
+
+func TestVoiceWakeIntegrationHistory(t *testing.T) {
+	cfg := DefaultVoiceWakeIntegrationConfig()
+	integration := NewVoiceWakeIntegration(cfg)
+
+	agent := &mockAgent{}
+	tts := &mockTTSProcessor{}
+
+	_ = integration.Init(agent, tts)
+
+	_ = integration.AddToHistory("user", "hello")
+	_ = integration.AddToHistory("assistant", "hi")
+
+	history, err := integration.GetHistory()
+	if err != nil {
+		t.Errorf("get history failed: %v", err)
+	}
+
+	if len(history) != 2 {
+		t.Errorf("expected 2 history entries, got %d", len(history))
+	}
+}
+
+func TestVoiceWakeIntegrationNoAgentError(t *testing.T) {
+	vw := NewVoiceWake(DefaultVoiceWakeConfig())
+
+	cfg := DefaultVoiceWakeProcessorConfig()
+	cfg.VoiceWake = vw
+	cfg.Agent = nil
+
+	processor := NewVoiceWakeProcessor(cfg)
+	_ = processor.Start()
+
+	event := VoiceWakeEvent{
+		Type:      VoiceWakeEventWakeDetected,
+		Timestamp: time.Now(),
+		Data:      map[string]any{"transcript": "test"},
+	}
+
+	processor.onVoiceWakeEvent(event)
+
+	time.Sleep(50 * time.Millisecond)
+
+	if processor.LastResponse() != "" {
+		t.Error("expected empty response when no agent")
+	}
+}
+
+func TestVoiceWakeProcessorEmptyTranscript(t *testing.T) {
+	vw := NewVoiceWake(DefaultVoiceWakeConfig())
+	agent := &mockAgent{}
+
+	cfg := DefaultVoiceWakeProcessorConfig()
+	cfg.VoiceWake = vw
+	cfg.Agent = agent
+	cfg.AutoSpeak = false
+
+	processor := NewVoiceWakeProcessor(cfg)
+	_ = processor.Start()
+
+	event := VoiceWakeEvent{
+		Type:      VoiceWakeEventWakeDetected,
+		Timestamp: time.Now(),
+		Data:      map[string]any{"transcript": ""},
+	}
+
+	processor.onVoiceWakeEvent(event)
+
+	time.Sleep(50 * time.Millisecond)
+
+	if agent.InputCount() != 0 {
+		t.Errorf("expected no agent call for empty transcript, got %d", agent.InputCount())
+	}
+}
+
+func TestVoiceWakeProcessorErrorCallback(t *testing.T) {
+	vw := NewVoiceWake(DefaultVoiceWakeConfig())
+	agent := &mockAgent{
+		responses: []string{"ok"},
+		delay:     10 * time.Millisecond,
+	}
+	tts := &mockTTSProcessor{
+		err: errors.New("TTS failed"),
+	}
+	player := &mockAudioPlayer{}
+
+	errCh := make(chan error, 1)
+
+	cfg := DefaultVoiceWakeProcessorConfig()
+	cfg.VoiceWake = vw
+	cfg.Agent = agent
+	cfg.TTSProcessor = tts
+	cfg.AudioPlayer = player
+	cfg.AutoSpeak = true
+	cfg.OnError = func(err error) {
+		errCh <- err
+	}
+
+	processor := NewVoiceWakeProcessor(cfg)
+	_ = processor.Start()
+
+	event := VoiceWakeEvent{
+		Type:      VoiceWakeEventWakeDetected,
+		Timestamp: time.Now(),
+		Data:      map[string]any{"transcript": "test"},
+	}
+
+	processor.onVoiceWakeEvent(event)
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Error("expected error in callback")
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Error("expected OnError callback")
+	}
+}

--- a/pkg/speech/voicewake_processor.go
+++ b/pkg/speech/voicewake_processor.go
@@ -1,0 +1,311 @@
+package speech
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+)
+
+type AgentRunner interface {
+	Run(ctx context.Context, userInput string) (string, error)
+}
+
+type TTSProcessor interface {
+	Synthesize(ctx context.Context, text string, opts ...SynthesizeOption) (*AudioResult, error)
+}
+
+type VoiceWakeProcessorConfig struct {
+	Agent           AgentRunner
+	TTSProcessor    TTSProcessor
+	AudioPlayer     AudioPlayer
+	VoiceWake       *VoiceWake
+	SessionID       string
+	Channel         string
+	Sender          string
+	AutoSpeak       bool
+	AutoTranscribe  bool
+	MaxResponseTime time.Duration
+	MaxAudioTime    time.Duration
+	OnResponse      func(text string)
+	OnAudioComplete func(duration time.Duration)
+	OnError         func(err error)
+}
+
+func DefaultVoiceWakeProcessorConfig() VoiceWakeProcessorConfig {
+	return VoiceWakeProcessorConfig{
+		SessionID:       "voicewake-local",
+		Channel:         "voicewake",
+		Sender:          "local-mic",
+		AutoSpeak:       true,
+		AutoTranscribe:  true,
+		MaxResponseTime: 60 * time.Second,
+		MaxAudioTime:    5 * time.Minute,
+	}
+}
+
+type VoiceWakeProcessor struct {
+	mu                 sync.Mutex
+	cfg                VoiceWakeProcessorConfig
+	isProcessing       bool
+	lastResponse       string
+	lastAudioDur       time.Duration
+	conversationCtx    context.Context
+	conversationCancel context.CancelFunc
+}
+
+func NewVoiceWakeProcessor(cfg VoiceWakeProcessorConfig) *VoiceWakeProcessor {
+	if cfg.SessionID == "" {
+		cfg.SessionID = "voicewake-local"
+	}
+	if cfg.Channel == "" {
+		cfg.Channel = "voicewake"
+	}
+	if cfg.Sender == "" {
+		cfg.Sender = "local-mic"
+	}
+	if cfg.MaxResponseTime == 0 {
+		cfg.MaxResponseTime = 60 * time.Second
+	}
+	if cfg.MaxAudioTime == 0 {
+		cfg.MaxAudioTime = 5 * time.Minute
+	}
+
+	return &VoiceWakeProcessor{
+		cfg: cfg,
+	}
+}
+
+func (p *VoiceWakeProcessor) Start() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.cfg.VoiceWake == nil {
+		return fmt.Errorf("voicewake-processor: VoiceWake is required")
+	}
+	if p.cfg.Agent == nil {
+		return fmt.Errorf("voicewake-processor: Agent is required")
+	}
+
+	p.cfg.VoiceWake.RegisterListener(p.onVoiceWakeEvent)
+
+	return nil
+}
+
+func (p *VoiceWakeProcessor) onVoiceWakeEvent(event VoiceWakeEvent) {
+	switch event.Type {
+	case VoiceWakeEventWakeDetected:
+		p.mu.Lock()
+		if p.isProcessing {
+			p.mu.Unlock()
+			log.Printf("voicewake-processor: already processing, skipping wake event")
+			return
+		}
+		p.isProcessing = true
+		p.mu.Unlock()
+		go p.handleWakeDetected(event)
+
+	case VoiceWakeEventError:
+		if p.cfg.OnError != nil {
+			if errStr, ok := event.Data["error"].(string); ok {
+				p.cfg.OnError(fmt.Errorf("voicewake: %s", errStr))
+			}
+		}
+	}
+}
+
+func (p *VoiceWakeProcessor) handleWakeDetected(event VoiceWakeEvent) {
+	defer func() {
+		p.mu.Lock()
+		p.isProcessing = false
+		p.conversationCtx = nil
+		p.conversationCancel = nil
+		p.mu.Unlock()
+	}()
+
+	transcript, _ := event.Data["transcript"].(string)
+	if transcript == "" {
+		transcript = p.cfg.VoiceWake.LastTranscript()
+	}
+
+	if transcript == "" {
+		log.Printf("voicewake-processor: no transcript available")
+		return
+	}
+
+	log.Printf("voicewake-processor: wake detected, transcript: %q", transcript)
+
+	ctx, cancel := context.WithTimeout(context.Background(), p.cfg.MaxResponseTime)
+	defer cancel()
+
+	p.mu.Lock()
+	p.conversationCtx = ctx
+	p.conversationCancel = cancel
+	p.mu.Unlock()
+
+	response, err := p.runAgent(ctx, transcript)
+	if err != nil {
+		log.Printf("voicewake-processor: agent error: %v", err)
+		if p.cfg.OnError != nil {
+			p.cfg.OnError(err)
+		}
+		return
+	}
+
+	p.mu.Lock()
+	p.lastResponse = response
+	p.mu.Unlock()
+
+	if p.cfg.OnResponse != nil {
+		p.cfg.OnResponse(response)
+	}
+
+	if p.cfg.AutoSpeak && p.cfg.TTSProcessor != nil && p.cfg.AudioPlayer != nil {
+		if err := p.speakResponse(ctx, response); err != nil {
+			log.Printf("voicewake-processor: TTS error: %v", err)
+			if p.cfg.OnError != nil {
+				p.cfg.OnError(err)
+			}
+		}
+	}
+}
+
+func (p *VoiceWakeProcessor) runAgent(ctx context.Context, transcript string) (string, error) {
+	if p.cfg.Agent == nil {
+		return "", fmt.Errorf("voicewake-processor: no agent configured")
+	}
+
+	return p.cfg.Agent.Run(ctx, transcript)
+}
+
+func (p *VoiceWakeProcessor) speakResponse(ctx context.Context, text string) error {
+	if p.cfg.TTSProcessor == nil {
+		return fmt.Errorf("voicewake-processor: no TTS processor configured")
+	}
+	if p.cfg.AudioPlayer == nil {
+		return fmt.Errorf("voicewake-processor: no audio player configured")
+	}
+
+	if p.cfg.AudioPlayer.IsPlaying() {
+		p.cfg.AudioPlayer.Stop()
+	}
+
+	ttsCtx, cancel := context.WithTimeout(ctx, p.cfg.MaxAudioTime)
+	defer cancel()
+
+	var opts []SynthesizeOption
+	opts = append(opts, WithFormat(FormatWAV))
+
+	result, err := p.cfg.TTSProcessor.Synthesize(ttsCtx, text, opts...)
+	if err != nil {
+		return fmt.Errorf("voicewake-processor: TTS failed: %w", err)
+	}
+
+	if len(result.Data) == 0 {
+		return fmt.Errorf("voicewake-processor: TTS returned empty audio")
+	}
+
+	if err := p.cfg.AudioPlayer.Play(ttsCtx, result.Data, result.Format); err != nil {
+		return fmt.Errorf("voicewake-processor: playback failed: %w", err)
+	}
+
+	p.mu.Lock()
+	p.lastAudioDur = result.Duration
+	p.mu.Unlock()
+
+	if p.cfg.OnAudioComplete != nil {
+		p.cfg.OnAudioComplete(result.Duration)
+	}
+
+	return nil
+}
+
+func (p *VoiceWakeProcessor) IsProcessing() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.isProcessing
+}
+
+func (p *VoiceWakeProcessor) LastResponse() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.lastResponse
+}
+
+func (p *VoiceWakeProcessor) LastAudioDuration() time.Duration {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.lastAudioDur
+}
+
+func (p *VoiceWakeProcessor) CancelConversation() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.conversationCancel != nil {
+		p.conversationCancel()
+		p.conversationCancel = nil
+		p.conversationCtx = nil
+	}
+
+	if p.cfg.AudioPlayer != nil && p.cfg.AudioPlayer.IsPlaying() {
+		p.cfg.AudioPlayer.Stop()
+	}
+
+	p.isProcessing = false
+}
+
+func (p *VoiceWakeProcessor) UpdateConfig(cfg VoiceWakeProcessorConfig) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if cfg.Agent != nil {
+		p.cfg.Agent = cfg.Agent
+	}
+	if cfg.TTSProcessor != nil {
+		p.cfg.TTSProcessor = cfg.TTSProcessor
+	}
+	if cfg.AudioPlayer != nil {
+		p.cfg.AudioPlayer = cfg.AudioPlayer
+	}
+	if cfg.SessionID != "" {
+		p.cfg.SessionID = cfg.SessionID
+	}
+	if cfg.MaxResponseTime > 0 {
+		p.cfg.MaxResponseTime = cfg.MaxResponseTime
+	}
+	if cfg.MaxAudioTime > 0 {
+		p.cfg.MaxAudioTime = cfg.MaxAudioTime
+	}
+
+	p.cfg.AutoSpeak = cfg.AutoSpeak
+	p.cfg.AutoTranscribe = cfg.AutoTranscribe
+	p.cfg.OnResponse = cfg.OnResponse
+	p.cfg.OnAudioComplete = cfg.OnAudioComplete
+	p.cfg.OnError = cfg.OnError
+}
+
+func (p *VoiceWakeProcessor) Config() VoiceWakeProcessorConfig {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.cfg
+}
+
+func (p *VoiceWakeProcessor) SetAgent(agent AgentRunner) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cfg.Agent = agent
+}
+
+func (p *VoiceWakeProcessor) SetTTSProcessor(processor TTSProcessor) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cfg.TTSProcessor = processor
+}
+
+func (p *VoiceWakeProcessor) SetAudioPlayer(player AudioPlayer) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cfg.AudioPlayer = player
+}

--- a/pkg/speech/voicewake_session.go
+++ b/pkg/speech/voicewake_session.go
@@ -1,0 +1,504 @@
+package speech
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/capability/agents/prompt"
+)
+
+type VoiceWakeSession struct {
+	ID             string
+	CreatedAt      time.Time
+	LastActive     time.Time
+	History        []prompt.Message
+	Transcripts    []TranscriptEntry
+	Responses      []ResponseEntry
+	WakeEvents     []WakeEventEntry
+	IsConversation bool
+	ConversationID string
+}
+
+type TranscriptEntry struct {
+	Text       string
+	Confidence float64
+	Language   string
+	Duration   time.Duration
+	Timestamp  time.Time
+}
+
+type ResponseEntry struct {
+	Text      string
+	Duration  time.Duration
+	Timestamp time.Time
+	IsSpoken  bool
+}
+
+type WakeEventEntry struct {
+	Phrase     string
+	Confidence float64
+	Engine     string
+	Timestamp  time.Time
+}
+
+type VoiceWakeSessionManager struct {
+	mu          sync.RWMutex
+	sessions    map[string]*VoiceWakeSession
+	active      string
+	maxSessions int
+	maxHistory  int
+}
+
+type VoiceWakeSessionManagerConfig struct {
+	MaxSessions int
+	MaxHistory  int
+}
+
+func DefaultVoiceWakeSessionManagerConfig() VoiceWakeSessionManagerConfig {
+	return VoiceWakeSessionManagerConfig{
+		MaxSessions: 10,
+		MaxHistory:  50,
+	}
+}
+
+func NewVoiceWakeSessionManager(cfg VoiceWakeSessionManagerConfig) *VoiceWakeSessionManager {
+	if cfg.MaxSessions <= 0 {
+		cfg.MaxSessions = 10
+	}
+	if cfg.MaxHistory <= 0 {
+		cfg.MaxHistory = 50
+	}
+
+	return &VoiceWakeSessionManager{
+		sessions:    make(map[string]*VoiceWakeSession),
+		maxSessions: cfg.MaxSessions,
+		maxHistory:  cfg.MaxHistory,
+	}
+}
+
+func (m *VoiceWakeSessionManager) CreateSession(id string) *VoiceWakeSession {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(m.sessions) >= m.maxSessions {
+		m.evictOldest()
+	}
+
+	session := &VoiceWakeSession{
+		ID:         id,
+		CreatedAt:  time.Now(),
+		LastActive: time.Now(),
+		History:    make([]prompt.Message, 0),
+	}
+
+	m.sessions[id] = session
+	m.active = id
+
+	return session
+}
+
+func (m *VoiceWakeSessionManager) GetSession(id string) (*VoiceWakeSession, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	session, ok := m.sessions[id]
+	return session, ok
+}
+
+func (m *VoiceWakeSessionManager) GetOrCreateSession(id string) *VoiceWakeSession {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	session, ok := m.sessions[id]
+	if ok {
+		session.LastActive = time.Now()
+		return session
+	}
+
+	if len(m.sessions) >= m.maxSessions {
+		m.evictOldestLocked()
+	}
+
+	session = &VoiceWakeSession{
+		ID:         id,
+		CreatedAt:  time.Now(),
+		LastActive: time.Now(),
+		History:    make([]prompt.Message, 0),
+	}
+
+	m.sessions[id] = session
+	m.active = id
+
+	return session
+}
+
+func (m *VoiceWakeSessionManager) AddTranscript(sessionID string, entry TranscriptEntry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	session, ok := m.sessions[sessionID]
+	if !ok {
+		return fmt.Errorf("voicewake-session: session %s not found", sessionID)
+	}
+
+	session.Transcripts = append(session.Transcripts, entry)
+	session.LastActive = time.Now()
+
+	return nil
+}
+
+func (m *VoiceWakeSessionManager) AddResponse(sessionID string, entry ResponseEntry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	session, ok := m.sessions[sessionID]
+	if !ok {
+		return fmt.Errorf("voicewake-session: session %s not found", sessionID)
+	}
+
+	session.Responses = append(session.Responses, entry)
+	session.LastActive = time.Now()
+
+	return nil
+}
+
+func (m *VoiceWakeSessionManager) AddWakeEvent(sessionID string, entry WakeEventEntry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	session, ok := m.sessions[sessionID]
+	if !ok {
+		return fmt.Errorf("voicewake-session: session %s not found", sessionID)
+	}
+
+	session.WakeEvents = append(session.WakeEvents, entry)
+	session.LastActive = time.Now()
+
+	return nil
+}
+
+func (m *VoiceWakeSessionManager) AddToHistory(sessionID string, msg prompt.Message) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	session, ok := m.sessions[sessionID]
+	if !ok {
+		return fmt.Errorf("voicewake-session: session %s not found", sessionID)
+	}
+
+	session.History = append(session.History, msg)
+
+	if len(session.History) > m.maxHistory {
+		session.History = session.History[len(session.History)-m.maxHistory:]
+	}
+
+	session.LastActive = time.Now()
+
+	return nil
+}
+
+func (m *VoiceWakeSessionManager) GetHistory(sessionID string) ([]prompt.Message, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	session, ok := m.sessions[sessionID]
+	if !ok {
+		return nil, fmt.Errorf("voicewake-session: session %s not found", sessionID)
+	}
+
+	history := make([]prompt.Message, len(session.History))
+	copy(history, session.History)
+
+	return history, nil
+}
+
+func (m *VoiceWakeSessionManager) SetHistory(sessionID string, history []prompt.Message) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	session, ok := m.sessions[sessionID]
+	if !ok {
+		return fmt.Errorf("voicewake-session: session %s not found", sessionID)
+	}
+
+	session.History = history
+	session.LastActive = time.Now()
+
+	return nil
+}
+
+func (m *VoiceWakeSessionManager) SetActive(sessionID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.sessions[sessionID]; !ok {
+		return fmt.Errorf("voicewake-session: session %s not found", sessionID)
+	}
+
+	m.active = sessionID
+	return nil
+}
+
+func (m *VoiceWakeSessionManager) ActiveSession() *VoiceWakeSession {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	session, ok := m.sessions[m.active]
+	if !ok {
+		return nil
+	}
+	return session
+}
+
+func (m *VoiceWakeSessionManager) ActiveSessionID() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.active
+}
+
+func (m *VoiceWakeSessionManager) DeleteSession(sessionID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.sessions[sessionID]; !ok {
+		return fmt.Errorf("voicewake-session: session %s not found", sessionID)
+	}
+
+	delete(m.sessions, sessionID)
+
+	if m.active == sessionID {
+		m.active = ""
+		for id := range m.sessions {
+			m.active = id
+			break
+		}
+	}
+
+	return nil
+}
+
+func (m *VoiceWakeSessionManager) SessionCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.sessions)
+}
+
+func (m *VoiceWakeSessionManager) Sessions() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	ids := make([]string, 0, len(m.sessions))
+	for id := range m.sessions {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func (m *VoiceWakeSessionManager) evictOldest() {
+	var oldestID string
+	var oldestTime time.Time
+
+	for id, session := range m.sessions {
+		if oldestID == "" || session.LastActive.Before(oldestTime) {
+			oldestID = id
+			oldestTime = session.LastActive
+		}
+	}
+
+	if oldestID != "" {
+		delete(m.sessions, oldestID)
+	}
+}
+
+func (m *VoiceWakeSessionManager) evictOldestLocked() {
+	var oldestID string
+	var oldestTime time.Time
+
+	for id, session := range m.sessions {
+		if oldestID == "" || session.LastActive.Before(oldestTime) {
+			oldestID = id
+			oldestTime = session.LastActive
+		}
+	}
+
+	if oldestID != "" {
+		delete(m.sessions, oldestID)
+	}
+}
+
+func (m *VoiceWakeSessionManager) Clear() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.sessions = make(map[string]*VoiceWakeSession)
+	m.active = ""
+}
+
+func (m *VoiceWakeSessionManager) SessionStats(sessionID string) (map[string]any, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	session, ok := m.sessions[sessionID]
+	if !ok {
+		return nil, fmt.Errorf("voicewake-session: session %s not found", sessionID)
+	}
+
+	return map[string]any{
+		"id":               session.ID,
+		"created_at":       session.CreatedAt,
+		"last_active":      session.LastActive,
+		"history_length":   len(session.History),
+		"transcript_count": len(session.Transcripts),
+		"response_count":   len(session.Responses),
+		"wake_event_count": len(session.WakeEvents),
+		"is_conversation":  session.IsConversation,
+	}, nil
+}
+
+func (m *VoiceWakeSessionManager) RecentTranscripts(sessionID string, n int) ([]TranscriptEntry, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	session, ok := m.sessions[sessionID]
+	if !ok {
+		return nil, fmt.Errorf("voicewake-session: session %s not found", sessionID)
+	}
+
+	transcripts := session.Transcripts
+	if len(transcripts) > n {
+		transcripts = transcripts[len(transcripts)-n:]
+	}
+
+	result := make([]TranscriptEntry, len(transcripts))
+	copy(result, transcripts)
+
+	return result, nil
+}
+
+func (m *VoiceWakeSessionManager) RecentResponses(sessionID string, n int) ([]ResponseEntry, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	session, ok := m.sessions[sessionID]
+	if !ok {
+		return nil, fmt.Errorf("voicewake-session: session %s not found", sessionID)
+	}
+
+	responses := session.Responses
+	if len(responses) > n {
+		responses = responses[len(responses)-n:]
+	}
+
+	result := make([]ResponseEntry, len(responses))
+	copy(result, responses)
+
+	return result, nil
+}
+
+type VoiceWakeSessionContext struct {
+	Session *VoiceWakeSession
+	Cancel  context.CancelFunc
+	Started time.Time
+}
+
+type VoiceWakeSessionTracker struct {
+	mu       sync.Mutex
+	sessions map[string]*VoiceWakeSessionContext
+	active   string
+	manager  *VoiceWakeSessionManager
+}
+
+func NewVoiceWakeSessionTracker(manager *VoiceWakeSessionManager) *VoiceWakeSessionTracker {
+	return &VoiceWakeSessionTracker{
+		sessions: make(map[string]*VoiceWakeSessionContext),
+		manager:  manager,
+	}
+}
+
+func (t *VoiceWakeSessionTracker) StartSession(sessionID string) (*VoiceWakeSessionContext, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if existing, ok := t.sessions[sessionID]; ok {
+		return existing, nil
+	}
+
+	session := t.manager.GetOrCreateSession(sessionID)
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = ctx
+
+	sc := &VoiceWakeSessionContext{
+		Session: session,
+		Cancel:  cancel,
+		Started: time.Now(),
+	}
+
+	t.sessions[sessionID] = sc
+	t.active = sessionID
+
+	return sc, nil
+}
+
+func (t *VoiceWakeSessionTracker) EndSession(sessionID string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	sc, ok := t.sessions[sessionID]
+	if !ok {
+		return fmt.Errorf("voicewake-tracker: session %s not found", sessionID)
+	}
+
+	if sc.Cancel != nil {
+		sc.Cancel()
+	}
+
+	delete(t.sessions, sessionID)
+
+	if t.active == sessionID {
+		t.active = ""
+		for id := range t.sessions {
+			t.active = id
+			break
+		}
+	}
+
+	return nil
+}
+
+func (t *VoiceWakeSessionTracker) ActiveSession() *VoiceWakeSessionContext {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	sc, ok := t.sessions[t.active]
+	if !ok {
+		return nil
+	}
+	return sc
+}
+
+func (t *VoiceWakeSessionTracker) ActiveSessionID() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.active
+}
+
+func (t *VoiceWakeSessionTracker) GetSession(sessionID string) (*VoiceWakeSessionContext, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	sc, ok := t.sessions[sessionID]
+	return sc, ok
+}
+
+func (t *VoiceWakeSessionTracker) CancelActive() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if sc, ok := t.sessions[t.active]; ok {
+		if sc.Cancel != nil {
+			sc.Cancel()
+		}
+	}
+}

--- a/pkg/speech/voicewake_test.go
+++ b/pkg/speech/voicewake_test.go
@@ -1,0 +1,1015 @@
+package speech
+
+import (
+	"testing"
+	"time"
+)
+
+func TestVADCreation(t *testing.T) {
+	cfg := DefaultVADConfig()
+	vad := NewVAD(cfg)
+
+	if vad == nil {
+		t.Fatal("expected VAD instance, got nil")
+	}
+
+	if vad.State() != VADStateSilence {
+		t.Errorf("expected initial state to be silence, got %s", vad.State())
+	}
+}
+
+func TestVADDefaultConfig(t *testing.T) {
+	cfg := DefaultVADConfig()
+
+	if cfg.SampleRate != 16000 {
+		t.Errorf("expected default sample rate 16000, got %d", cfg.SampleRate)
+	}
+	if cfg.FrameSize != 320 {
+		t.Errorf("expected default frame size 320, got %d", cfg.FrameSize)
+	}
+	if cfg.EnergyThreshold != 0.01 {
+		t.Errorf("expected default energy threshold 0.01, got %f", cfg.EnergyThreshold)
+	}
+}
+
+func TestVADProcessSilence(t *testing.T) {
+	cfg := DefaultVADConfig()
+	vad := NewVAD(cfg)
+
+	silence := make([]int16, 320)
+	state := vad.ProcessFrame(silence)
+
+	if state != VADStateSilence {
+		t.Errorf("expected silence state for zero samples, got %s", state)
+	}
+}
+
+func TestVADProcessSpeech(t *testing.T) {
+	cfg := DefaultVADConfig()
+	cfg.SpeechMinFrames = 3
+	vad := NewVAD(cfg)
+
+	speech := make([]int16, 320)
+	for i := range speech {
+		speech[i] = 10000
+	}
+
+	for i := 0; i < 5; i++ {
+		vad.ProcessFrame(speech)
+	}
+
+	state := vad.State()
+	if state != VADStateSpeech {
+		t.Errorf("expected speech state after consecutive speech frames, got %s", state)
+	}
+}
+
+func TestVADStateTransition(t *testing.T) {
+	cfg := DefaultVADConfig()
+	cfg.SpeechMinFrames = 3
+	cfg.HangoverFrames = 5
+	vad := NewVAD(cfg)
+
+	silence := make([]int16, 320)
+	speech := make([]int16, 320)
+	for i := range speech {
+		speech[i] = 10000
+	}
+
+	if vad.State() != VADStateSilence {
+		t.Error("expected initial silence")
+	}
+
+	for i := 0; i < 5; i++ {
+		vad.ProcessFrame(speech)
+	}
+
+	if vad.State() != VADStateSpeech {
+		t.Errorf("expected speech after speech frames, got %s", vad.State())
+	}
+
+	for i := 0; i < 10; i++ {
+		vad.ProcessFrame(silence)
+	}
+
+	if vad.State() != VADStateSilence {
+		t.Errorf("expected silence after silence frames, got %s", vad.State())
+	}
+}
+
+func TestVADReset(t *testing.T) {
+	cfg := DefaultVADConfig()
+	cfg.SpeechMinFrames = 3
+	vad := NewVAD(cfg)
+
+	speech := make([]int16, 320)
+	for i := range speech {
+		speech[i] = 10000
+	}
+
+	for i := 0; i < 5; i++ {
+		vad.ProcessFrame(speech)
+	}
+
+	if vad.State() != VADStateSpeech {
+		t.Error("expected speech state before reset")
+	}
+
+	vad.Reset()
+
+	if vad.State() != VADStateSilence {
+		t.Errorf("expected silence after reset, got %s", vad.State())
+	}
+}
+
+func TestVADListener(t *testing.T) {
+	cfg := DefaultVADConfig()
+	cfg.SpeechMinFrames = 3
+	cfg.HangoverFrames = 5
+	vad := NewVAD(cfg)
+
+	stateChanges := make(chan VADState, 10)
+	vad.RegisterListener(func(state VADState, energy float64, zcr float64) {
+		stateChanges <- state
+	})
+
+	speech := make([]int16, 320)
+	for i := range speech {
+		speech[i] = 10000
+	}
+
+	for i := 0; i < 5; i++ {
+		vad.ProcessFrame(speech)
+	}
+
+	select {
+	case state := <-stateChanges:
+		if state != VADStateSpeech {
+			t.Errorf("expected speech state in listener, got %s", state)
+		}
+	default:
+		t.Error("expected listener callback for speech state")
+	}
+}
+
+func TestVADFloatFrame(t *testing.T) {
+	cfg := DefaultVADConfig()
+	vad := NewVAD(cfg)
+
+	silence := make([]float32, 320)
+	state := vad.ProcessFloatFrame(silence)
+
+	if state != VADStateSilence {
+		t.Errorf("expected silence for float silence samples, got %s", state)
+	}
+}
+
+func TestVADUpdateConfig(t *testing.T) {
+	cfg := DefaultVADConfig()
+	vad := NewVAD(cfg)
+
+	newCfg := VADConfig{
+		EnergyThreshold: 0.05,
+	}
+	vad.UpdateConfig(newCfg)
+
+	updated := vad.Config()
+	if updated.EnergyThreshold != 0.05 {
+		t.Errorf("expected energy threshold 0.05, got %f", updated.EnergyThreshold)
+	}
+}
+
+func TestNormalizeAudio(t *testing.T) {
+	samples := []int16{-32768, 0, 32767}
+	normalized := NormalizeAudio(samples)
+
+	if len(normalized) != 3 {
+		t.Errorf("expected 3 samples, got %d", len(normalized))
+	}
+
+	if normalized[0] != -1.0 {
+		t.Errorf("expected -1.0, got %f", normalized[0])
+	}
+	if normalized[1] != 0.0 {
+		t.Errorf("expected 0.0, got %f", normalized[1])
+	}
+}
+
+func TestFloat32ToInt16(t *testing.T) {
+	samples := []float32{-1.0, 0.0, 1.0}
+	converted := Float32ToInt16(samples)
+
+	if converted[0] != -32767 {
+		t.Errorf("expected -32767, got %d", converted[0])
+	}
+	if converted[1] != 0 {
+		t.Errorf("expected 0, got %d", converted[1])
+	}
+	if converted[2] != 32767 {
+		t.Errorf("expected 32767, got %d", converted[2])
+	}
+}
+
+func TestInt16ToWAV(t *testing.T) {
+	samples := []int16{0, 1000, -1000, 0}
+	wav := Int16ToWAV(samples, 16000, 1)
+
+	if len(wav) != 44+8 {
+		t.Errorf("expected WAV size 52 bytes (44 header + 8 data), got %d", len(wav))
+	}
+
+	if string(wav[0:4]) != "RIFF" {
+		t.Errorf("expected RIFF header, got %s", string(wav[0:4]))
+	}
+
+	if string(wav[8:12]) != "WAVE" {
+		t.Errorf("expected WAVE format, got %s", string(wav[8:12]))
+	}
+}
+
+func TestInt16ToWAVEmpty(t *testing.T) {
+	wav := Int16ToWAV(nil, 16000, 1)
+	if wav != nil {
+		t.Error("expected nil for empty samples")
+	}
+}
+
+func TestWakeWordDetectorCreation(t *testing.T) {
+	cfg := DefaultWakeWordConfig()
+	detector := NewWakeWordDetector(cfg)
+
+	if detector == nil {
+		t.Fatal("expected detector instance, got nil")
+	}
+
+	words := detector.WakeWords()
+	if len(words) != 3 {
+		t.Errorf("expected 3 wake words, got %d", len(words))
+	}
+}
+
+func TestWakeWordExactMatch(t *testing.T) {
+	cfg := WakeWordConfig{
+		WakeWords: []string{"hey anyclaw"},
+	}
+	detector := NewWakeWordDetector(cfg)
+
+	phrase, confidence, matched := detector.Detect("hey anyclaw")
+
+	if !matched {
+		t.Error("expected exact match for 'hey anyclaw'")
+	}
+	if phrase != "hey anyclaw" {
+		t.Errorf("expected phrase 'hey anyclaw', got %s", phrase)
+	}
+	if confidence != 1.0 {
+		t.Errorf("expected confidence 1.0, got %f", confidence)
+	}
+}
+
+func TestWakeWordSubstringMatch(t *testing.T) {
+	cfg := WakeWordConfig{
+		WakeWords: []string{"hey anyclaw"},
+	}
+	detector := NewWakeWordDetector(cfg)
+
+	_, confidence, matched := detector.Detect("hello hey anyclaw how are you")
+
+	if !matched {
+		t.Error("expected substring match")
+	}
+	if confidence < 0.8 {
+		t.Errorf("expected high confidence for substring match, got %f", confidence)
+	}
+}
+
+func TestWakeWordCaseInsensitive(t *testing.T) {
+	cfg := WakeWordConfig{
+		WakeWords: []string{"hey anyclaw"},
+	}
+	detector := NewWakeWordDetector(cfg)
+
+	_, _, matched := detector.Detect("HEY ANYCLAW")
+
+	if !matched {
+		t.Error("expected case-insensitive match")
+	}
+}
+
+func TestWakeWordNoMatch(t *testing.T) {
+	cfg := WakeWordConfig{
+		WakeWords: []string{"hey anyclaw"},
+	}
+	detector := NewWakeWordDetector(cfg)
+
+	_, _, matched := detector.Detect("hello world")
+
+	if matched {
+		t.Error("expected no match for unrelated text")
+	}
+}
+
+func TestWakeWordEmptyInput(t *testing.T) {
+	cfg := WakeWordConfig{
+		WakeWords: []string{"hey anyclaw"},
+	}
+	detector := NewWakeWordDetector(cfg)
+
+	_, _, matched := detector.Detect("")
+
+	if matched {
+		t.Error("expected no match for empty input")
+	}
+}
+
+func TestWakeWordAddRemove(t *testing.T) {
+	cfg := WakeWordConfig{}
+	detector := NewWakeWordDetector(cfg)
+
+	detector.AddWakeWord(WakeWord{Phrase: "test word"})
+	words := detector.WakeWords()
+	if len(words) != 1 {
+		t.Errorf("expected 1 wake word after add, got %d", len(words))
+	}
+
+	detector.RemoveWakeWord("test word")
+	words = detector.WakeWords()
+	if len(words) != 0 {
+		t.Errorf("expected 0 wake words after remove, got %d", len(words))
+	}
+}
+
+func TestWakeWordListener(t *testing.T) {
+	cfg := WakeWordConfig{
+		WakeWords: []string{"hey anyclaw"},
+	}
+	detector := NewWakeWordDetector(cfg)
+
+	matched := make(chan string, 1)
+	detector.RegisterListener(func(phrase string, confidence float64) {
+		matched <- phrase
+	})
+
+	detector.Detect("hey anyclaw")
+
+	select {
+	case phrase := <-matched:
+		if phrase != "hey anyclaw" {
+			t.Errorf("expected 'hey anyclaw', got %s", phrase)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("expected listener callback")
+	}
+}
+
+func TestWakeWordAliases(t *testing.T) {
+	cfg := WakeWordConfig{}
+	detector := NewWakeWordDetector(cfg)
+
+	detector.AddWakeWord(WakeWord{
+		Phrase:  "hey anyclaw",
+		Aliases: []string{"hi anyclaw", "hello anyclaw"},
+	})
+
+	_, _, matched := detector.Detect("hi anyclaw")
+	if !matched {
+		t.Error("expected match for alias 'hi anyclaw'")
+	}
+}
+
+func TestWakeWordCallback(t *testing.T) {
+	cfg := WakeWordConfig{}
+	detector := NewWakeWordDetector(cfg)
+
+	called := make(chan string, 1)
+	detector.AddWakeWord(WakeWord{
+		Phrase: "hey anyclaw",
+		Callback: func(phrase string) {
+			called <- phrase
+		},
+	})
+
+	detector.Detect("hey anyclaw")
+
+	select {
+	case phrase := <-called:
+		if phrase != "hey anyclaw" {
+			t.Errorf("expected callback with 'hey anyclaw', got %s", phrase)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("expected wake word callback")
+	}
+}
+
+func TestWakeWordSensitivity(t *testing.T) {
+	cfg := WakeWordConfig{
+		WakeWords:   []string{"hey anyclaw"},
+		Sensitivity: 0.5,
+	}
+	detector := NewWakeWordDetector(cfg)
+
+	_, _, matched := detector.Detect("hey anycl")
+	if !matched {
+		t.Error("expected match with low sensitivity for close phrase")
+	}
+
+	detector.SetSensitivity(0.95)
+	_, _, matched = detector.Detect("hey anycl")
+	if matched {
+		t.Error("expected no match with high sensitivity for close phrase")
+	}
+}
+
+func TestLevenshteinDistance(t *testing.T) {
+	tests := []struct {
+		s1, s2   string
+		expected int
+	}{
+		{"", "", 0},
+		{"abc", "", 3},
+		{"", "abc", 3},
+		{"abc", "abc", 0},
+		{"kitten", "sitting", 3},
+		{"hey", "hay", 1},
+	}
+
+	for _, tt := range tests {
+		dist := levenshteinDistance(tt.s1, tt.s2)
+		if dist != tt.expected {
+			t.Errorf("levenshtein(%q, %q) = %d, expected %d", tt.s1, tt.s2, dist, tt.expected)
+		}
+	}
+}
+
+func TestNormalizeText(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"Hello World", "hello world"},
+		{"HEY ANYCLAW!", "hey anyclaw"},
+		{"  spaces  ", "spaces"},
+		{"Hey, AnyClaw!", "hey anyclaw"},
+	}
+
+	for _, tt := range tests {
+		result := normalizeText(tt.input)
+		if result != tt.expected {
+			t.Errorf("normalizeText(%q) = %q, expected %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestMatchPhrase(t *testing.T) {
+	tests := []struct {
+		input   string
+		phrase  string
+		minConf float64
+	}{
+		{"hey anyclaw", "hey anyclaw", 1.0},
+		{"hello hey anyclaw how are you", "hey anyclaw", 0.8},
+		{"hey anycl", "hey anyclaw", 0.7},
+	}
+
+	for _, tt := range tests {
+		conf := matchPhrase(tt.input, tt.phrase)
+		if conf < tt.minConf {
+			t.Errorf("matchPhrase(%q, %q) = %f, expected >= %f", tt.input, tt.phrase, conf, tt.minConf)
+		}
+	}
+}
+
+func TestVoiceWakeCreation(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	if vw == nil {
+		t.Fatal("expected VoiceWake instance, got nil")
+	}
+
+	if vw.State() != VoiceWakeStateIdle {
+		t.Errorf("expected idle state, got %s", vw.State())
+	}
+}
+
+func TestVoiceWakeDefaultConfig(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+
+	if cfg.SampleRate != 16000 {
+		t.Errorf("expected sample rate 16000, got %d", cfg.SampleRate)
+	}
+	if cfg.Channels != 1 {
+		t.Errorf("expected 1 channel, got %d", cfg.Channels)
+	}
+	if cfg.AutoTranscribe != true {
+		t.Error("expected auto-transcribe to be enabled by default")
+	}
+}
+
+func TestVoiceWakeStartStop(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	ctx := t.Context()
+	err := vw.Start(ctx)
+	if err != nil {
+		t.Errorf("expected successful start, got error: %v", err)
+	}
+
+	if vw.State() != VoiceWakeStateListening {
+		t.Errorf("expected listening state after start, got %s", vw.State())
+	}
+
+	err = vw.Stop()
+	if err != nil {
+		t.Errorf("expected successful stop, got error: %v", err)
+	}
+
+	if vw.State() != VoiceWakeStateIdle {
+		t.Errorf("expected idle state after stop, got %s", vw.State())
+	}
+}
+
+func TestVoiceWakeDoubleStart(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	ctx := t.Context()
+	_ = vw.Start(ctx)
+
+	err := vw.Start(ctx)
+	if err == nil {
+		t.Error("expected error on double start")
+	}
+
+	_ = vw.Stop()
+}
+
+func TestVoiceWakeListener(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	events := make(chan VoiceWakeEvent, 10)
+	vw.RegisterListener(func(event VoiceWakeEvent) {
+		events <- event
+	})
+
+	ctx := t.Context()
+	_ = vw.Start(ctx)
+
+	select {
+	case event := <-events:
+		if event.Type != VoiceWakeEventStateChanged {
+			t.Errorf("expected state_changed event, got %s", event.Type)
+		}
+		if event.State != VoiceWakeStateListening {
+			t.Errorf("expected listening state, got %s", event.State)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("expected state change event on start")
+	}
+
+	_ = vw.Stop()
+}
+
+func TestVoiceWakeComponents(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	vad := vw.VAD()
+	if vad == nil {
+		t.Error("expected VAD instance")
+	}
+
+	detector := vw.WakeDetector()
+	if detector == nil {
+		t.Error("expected WakeWordDetector instance")
+	}
+}
+
+func TestVoiceWakeUpdateConfig(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	newCfg := VoiceWakeConfig{
+		SampleRate: 44100,
+		Channels:   2,
+	}
+	vw.UpdateConfig(newCfg)
+
+	updated := vw.Config()
+	if updated.SampleRate != 44100 {
+		t.Errorf("expected sample rate 44100, got %d", updated.SampleRate)
+	}
+	if updated.Channels != 2 {
+		t.Errorf("expected 2 channels, got %d", updated.Channels)
+	}
+}
+
+func TestVoiceWakeSetTranscriber(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	manager := NewSTTManager()
+	pipeline := NewSTTPipeline(manager, DefaultSTTPipelineConfig())
+
+	vw.SetTranscriber(pipeline)
+
+	if vw.transcriber != pipeline {
+		t.Error("expected transcriber to be set")
+	}
+}
+
+func TestVoiceWakeLastTranscript(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	transcript := vw.LastTranscript()
+	if transcript != "" {
+		t.Errorf("expected empty transcript initially, got %s", transcript)
+	}
+}
+
+func TestVoiceWakeLastWakeMatch(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	phrase, confidence := vw.LastWakeMatch()
+	if phrase != "" {
+		t.Errorf("expected empty phrase initially, got %s", phrase)
+	}
+	if confidence != 0 {
+		t.Errorf("expected zero confidence initially, got %f", confidence)
+	}
+}
+
+func TestVoiceWakeEngineRouter(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	router := vw.EngineRouter()
+	if router == nil {
+		t.Fatal("expected engine router")
+	}
+
+	engines := router.Engines()
+	if len(engines) != 0 {
+		t.Errorf("expected no engines initially, got %d", len(engines))
+	}
+}
+
+func TestVoiceWakeRegisterMockEngine(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	router := vw.EngineRouter()
+	if router == nil {
+		t.Fatal("expected engine router")
+	}
+
+	router.RegisterFactory("mock", func(cfg WakeWordEngineConfig) (WakeWordEngine, error) {
+		return NewMockWakeWordEngine("test-word", 5), nil
+	})
+
+	engineCfg := WakeWordEngineConfig{
+		Type:     "mock",
+		Keywords: []string{"test-word"},
+	}
+	err := router.CreateEngine("mock", engineCfg)
+	if err != nil {
+		t.Fatalf("failed to create mock engine: %v", err)
+	}
+
+	engines := router.Engines()
+	if len(engines) != 1 {
+		t.Errorf("expected 1 engine, got %d", len(engines))
+	}
+
+	if router.ActiveEngine() == "" {
+		t.Error("expected active engine after creation")
+	}
+}
+
+func TestVoiceWakeEngineDetection(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	router := vw.EngineRouter()
+	router.RegisterFactory("mock", func(cfg WakeWordEngineConfig) (WakeWordEngine, error) {
+		return NewMockWakeWordEngine("test-word", 3), nil
+	})
+
+	_ = router.CreateEngine("mock", WakeWordEngineConfig{
+		Type:     "mock",
+		Keywords: []string{"test-word"},
+	})
+
+	silence := make([]int16, 320)
+	for i := 0; i < 2; i++ {
+		result, detected := router.ProcessFrame(silence)
+		if detected {
+			t.Errorf("expected no detection on frame %d", i)
+		}
+		_ = result
+	}
+
+	result, detected := router.ProcessFrame(silence)
+	if !detected {
+		t.Error("expected detection on frame 3")
+	}
+	if result.Keyword != "test-word" {
+		t.Errorf("expected keyword 'test-word', got %s", result.Keyword)
+	}
+	if result.Engine != "mock" {
+		t.Errorf("expected engine 'mock', got %s", result.Engine)
+	}
+}
+
+func TestVoiceWakeEngineAdapter(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	adapter := vw.EngineAdapter()
+	if adapter == nil {
+		t.Fatal("expected engine adapter")
+	}
+
+	if adapter.UseEngine() {
+		t.Error("expected engine not in use by default")
+	}
+
+	adapter.SetUseEngine(true)
+	if !adapter.UseEngine() {
+		t.Error("expected engine in use after SetUseEngine(true)")
+	}
+
+	adapter.SetUseEngine(false)
+	if adapter.UseEngine() {
+		t.Error("expected engine not in use after SetUseEngine(false)")
+	}
+}
+
+func TestVoiceWakeEngineAdapterTranscript(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	adapter := vw.EngineAdapter()
+	phrase, confidence, matched := adapter.DetectTranscript("hey anyclaw")
+	if !matched {
+		t.Error("expected transcript match with builtin detector")
+	}
+	if phrase != "hey anyclaw" {
+		t.Errorf("expected 'hey anyclaw', got %s", phrase)
+	}
+	if confidence != 1.0 {
+		t.Errorf("expected confidence 1.0, got %f", confidence)
+	}
+}
+
+func TestVoiceWakeSetActiveEngine(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	router := vw.EngineRouter()
+	router.RegisterFactory("mock1", func(cfg WakeWordEngineConfig) (WakeWordEngine, error) {
+		return NewMockWakeWordEngine("word1", 5), nil
+	})
+	router.RegisterFactory("mock2", func(cfg WakeWordEngineConfig) (WakeWordEngine, error) {
+		return NewMockWakeWordEngine("word2", 10), nil
+	})
+
+	_ = router.CreateEngine("mock1", WakeWordEngineConfig{Keywords: []string{"word1"}})
+	_ = router.CreateEngine("mock2", WakeWordEngineConfig{Keywords: []string{"word2"}})
+
+	engines := router.Engines()
+	if len(engines) != 2 {
+		t.Errorf("expected 2 engines, got %d", len(engines))
+	}
+
+	err := router.SetActive("mock-word2")
+	if err != nil {
+		t.Errorf("failed to set active engine: %v", err)
+	}
+
+	if router.ActiveEngine() != "mock-word2" {
+		t.Errorf("expected active engine 'mock-word2', got %s", router.ActiveEngine())
+	}
+
+	err = router.SetActive("nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent engine")
+	}
+}
+
+func TestVoiceWakeEngineRouterReset(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	router := vw.EngineRouter()
+	router.RegisterFactory("mock", func(cfg WakeWordEngineConfig) (WakeWordEngine, error) {
+		return NewMockWakeWordEngine("test", 3), nil
+	})
+
+	_ = router.CreateEngine("mock", WakeWordEngineConfig{Keywords: []string{"test"}})
+
+	err := router.Reset()
+	if err != nil {
+		t.Errorf("failed to reset router: %v", err)
+	}
+}
+
+func TestVoiceWakeEngineRouterClose(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	router := vw.EngineRouter()
+	router.RegisterFactory("mock", func(cfg WakeWordEngineConfig) (WakeWordEngine, error) {
+		return NewMockWakeWordEngine("test", 3), nil
+	})
+
+	_ = router.CreateEngine("mock", WakeWordEngineConfig{Keywords: []string{"test"}})
+
+	err := router.Close()
+	if err != nil {
+		t.Errorf("failed to close router: %v", err)
+	}
+
+	engines := router.Engines()
+	if len(engines) != 0 {
+		t.Errorf("expected no engines after close, got %d", len(engines))
+	}
+}
+
+func TestVoiceWakeUseWakeWordEngine(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	vw.UseWakeWordEngine(true)
+	if !vw.IsUsingWakeWordEngine() {
+		t.Error("expected engine to be in use")
+	}
+
+	vw.UseWakeWordEngine(false)
+	if vw.IsUsingWakeWordEngine() {
+		t.Error("expected engine not in use")
+	}
+}
+
+func TestVoiceWakeAvailableEngines(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	engines := vw.AvailableEngines()
+	if len(engines) != 0 {
+		t.Errorf("expected no engines initially, got %d", len(engines))
+	}
+
+	router := vw.EngineRouter()
+	router.RegisterFactory("mock", func(cfg WakeWordEngineConfig) (WakeWordEngine, error) {
+		return NewMockWakeWordEngine("test", 3), nil
+	})
+
+	_ = router.CreateEngine("mock", WakeWordEngineConfig{Keywords: []string{"test"}})
+
+	engines = vw.AvailableEngines()
+	if len(engines) != 1 {
+		t.Errorf("expected 1 engine, got %d", len(engines))
+	}
+}
+
+func TestVoiceWakeRegisterEngine(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	router := vw.EngineRouter()
+	router.RegisterFactory("mock", func(cfg WakeWordEngineConfig) (WakeWordEngine, error) {
+		return NewMockWakeWordEngine("anycalw", 3), nil
+	})
+
+	err := vw.RegisterEngine("mock", WakeWordEngineConfig{
+		Keywords: []string{"anycalw"},
+	})
+	if err != nil {
+		t.Fatalf("failed to register engine: %v", err)
+	}
+
+	if !vw.IsUsingWakeWordEngine() {
+		t.Error("expected engine to be in use after registration")
+	}
+}
+
+func TestVoiceWakeClose(t *testing.T) {
+	cfg := DefaultVoiceWakeConfig()
+	vw := NewVoiceWake(cfg)
+
+	router := vw.EngineRouter()
+	router.RegisterFactory("mock", func(cfg WakeWordEngineConfig) (WakeWordEngine, error) {
+		return NewMockWakeWordEngine("test", 3), nil
+	})
+
+	_ = router.CreateEngine("mock", WakeWordEngineConfig{Keywords: []string{"test"}})
+
+	ctx := t.Context()
+	_ = vw.Start(ctx)
+
+	err := vw.Close()
+	if err != nil {
+		t.Errorf("failed to close voicewake: %v", err)
+	}
+
+	if vw.State() != VoiceWakeStateIdle {
+		t.Errorf("expected idle state after close, got %s", vw.State())
+	}
+}
+
+func TestMockWakeWordEngine(t *testing.T) {
+	engine := NewMockWakeWordEngine("hello", 5)
+
+	if engine.Name() != "mock-hello" {
+		t.Errorf("expected name 'mock-hello', got %s", engine.Name())
+	}
+	if engine.Type() != "mock" {
+		t.Errorf("expected type 'mock', got %s", engine.Type())
+	}
+
+	if err := engine.Init(); err != nil {
+		t.Errorf("init failed: %v", err)
+	}
+
+	samples := make([]int16, 320)
+	for i := 0; i < 4; i++ {
+		result, detected := engine.ProcessFrame(samples)
+		if detected {
+			t.Errorf("expected no detection on frame %d", i)
+		}
+		_ = result
+	}
+
+	result, detected := engine.ProcessFrame(samples)
+	if !detected {
+		t.Error("expected detection on frame 5")
+	}
+	if result.Keyword != "hello" {
+		t.Errorf("expected keyword 'hello', got %s", result.Keyword)
+	}
+	if result.Confidence != 0.95 {
+		t.Errorf("expected confidence 0.95, got %f", result.Confidence)
+	}
+
+	if err := engine.Reset(); err != nil {
+		t.Errorf("reset failed: %v", err)
+	}
+
+	result, detected = engine.ProcessFrame(samples)
+	if detected {
+		t.Error("expected no detection after reset")
+	}
+	_ = result
+
+	if err := engine.Close(); err != nil {
+		t.Errorf("close failed: %v", err)
+	}
+}
+
+func TestWakeWordEngineConfig(t *testing.T) {
+	cfg := WakeWordEngineConfig{
+		Type:         EnginePorcupine,
+		Keywords:     []string{"alexa"},
+		AccessKey:    "test-key",
+		Sensitivity:  0.7,
+		SampleRate:   16000,
+		FrameSize:    512,
+		LibraryPath:  "/usr/lib/porcupine",
+		ModelPath:    "/usr/lib/porcupine/model.pv",
+		ResourcePath: "/usr/lib/porcupine/common.res",
+		Extra:        map[string]string{"debug": "true"},
+	}
+
+	if cfg.Type != EnginePorcupine {
+		t.Errorf("expected type porcupine, got %s", cfg.Type)
+	}
+	if len(cfg.Keywords) != 1 {
+		t.Errorf("expected 1 keyword, got %d", len(cfg.Keywords))
+	}
+	if cfg.Sensitivity != 0.7 {
+		t.Errorf("expected sensitivity 0.7, got %f", cfg.Sensitivity)
+	}
+}
+
+func TestWakeWordDetectionResult(t *testing.T) {
+	result := WakeWordDetectionResult{
+		Keyword:    "hey assistant",
+		Confidence: 0.85,
+		Engine:     EnginePorcupine,
+	}
+
+	if result.Keyword != "hey assistant" {
+		t.Errorf("expected keyword 'hey assistant', got %s", result.Keyword)
+	}
+	if result.Confidence != 0.85 {
+		t.Errorf("expected confidence 0.85, got %f", result.Confidence)
+	}
+	if result.Engine != EnginePorcupine {
+		t.Errorf("expected engine porcupine, got %s", result.Engine)
+	}
+}

--- a/pkg/speech/wake_word.go
+++ b/pkg/speech/wake_word.go
@@ -1,0 +1,503 @@
+package speech
+
+import (
+	"math"
+	"strings"
+	"sync"
+)
+
+type WakeWordDetector struct {
+	mu          sync.Mutex
+	wakeWords   []WakeWord
+	sensitivity float64
+	listeners   []WakeWordListener
+}
+
+type WakeWord struct {
+	Phrase   string
+	Aliases  []string
+	Enabled  bool
+	Callback func(matchedPhrase string)
+}
+
+type WakeWordListener func(phrase string, confidence float64)
+
+type WakeWordConfig struct {
+	WakeWords   []string
+	Sensitivity float64
+}
+
+func DefaultWakeWordConfig() WakeWordConfig {
+	return WakeWordConfig{
+		WakeWords:   []string{"hey anyclaw", "hi anyclaw", "ok anyclaw"},
+		Sensitivity: 0.7,
+	}
+}
+
+func NewWakeWordDetector(cfg WakeWordConfig) *WakeWordDetector {
+	detector := &WakeWordDetector{
+		sensitivity: cfg.Sensitivity,
+	}
+
+	if detector.sensitivity <= 0 {
+		detector.sensitivity = 0.7
+	}
+
+	for _, phrase := range cfg.WakeWords {
+		detector.AddWakeWord(WakeWord{
+			Phrase:  phrase,
+			Enabled: true,
+		})
+	}
+
+	return detector
+}
+
+func (d *WakeWordDetector) AddWakeWord(ww WakeWord) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if ww.Phrase == "" {
+		return
+	}
+
+	if !ww.Enabled {
+		ww.Enabled = true
+	}
+
+	d.wakeWords = append(d.wakeWords, ww)
+}
+
+func (d *WakeWordDetector) RemoveWakeWord(phrase string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	filtered := make([]WakeWord, 0, len(d.wakeWords))
+	for _, ww := range d.wakeWords {
+		if !strings.EqualFold(ww.Phrase, phrase) {
+			filtered = append(filtered, ww)
+		}
+	}
+	d.wakeWords = filtered
+}
+
+func (d *WakeWordDetector) RegisterListener(listener WakeWordListener) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.listeners = append(d.listeners, listener)
+}
+
+func (d *WakeWordDetector) Detect(transcript string) (string, float64, bool) {
+	d.mu.Lock()
+	wakeWords := make([]WakeWord, len(d.wakeWords))
+	copy(wakeWords, d.wakeWords)
+	listeners := make([]WakeWordListener, len(d.listeners))
+	copy(listeners, d.listeners)
+	sensitivity := d.sensitivity
+	d.mu.Unlock()
+
+	if transcript == "" {
+		return "", 0, false
+	}
+
+	normalized := normalizeText(transcript)
+
+	for _, ww := range wakeWords {
+		if !ww.Enabled {
+			continue
+		}
+
+		phrases := append([]string{ww.Phrase}, ww.Aliases...)
+		for _, phrase := range phrases {
+			confidence := matchPhrase(normalized, normalizeText(phrase))
+			if confidence >= sensitivity {
+				if ww.Callback != nil {
+					ww.Callback(phrase)
+				}
+
+				for _, listener := range listeners {
+					listener(phrase, confidence)
+				}
+
+				return phrase, confidence, true
+			}
+		}
+	}
+
+	return "", 0, false
+}
+
+func (d *WakeWordDetector) DetectStream(transcript string) (string, float64, bool) {
+	return d.Detect(transcript)
+}
+
+func (d *WakeWordDetector) SetSensitivity(s float64) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if s >= 0 && s <= 1 {
+		d.sensitivity = s
+	}
+}
+
+func (d *WakeWordDetector) Sensitivity() float64 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.sensitivity
+}
+
+func (d *WakeWordDetector) WakeWords() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	result := make([]string, 0, len(d.wakeWords))
+	for _, ww := range d.wakeWords {
+		if ww.Enabled {
+			result = append(result, ww.Phrase)
+		}
+	}
+	return result
+}
+
+func (d *WakeWordDetector) Reset() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for i := range d.wakeWords {
+		d.wakeWords[i].Enabled = true
+	}
+}
+
+func normalizeText(text string) string {
+	text = strings.ToLower(text)
+	text = strings.TrimSpace(text)
+
+	replacements := map[string]string{
+		"'":  "",
+		"\"": "",
+		".":  "",
+		",":  "",
+		"!":  "",
+		"?":  "",
+	}
+	for old, new := range replacements {
+		text = strings.ReplaceAll(text, old, new)
+	}
+
+	return strings.Join(strings.Fields(text), " ")
+}
+
+func matchPhrase(input, phrase string) float64 {
+	if input == phrase {
+		return 1.0
+	}
+
+	if strings.Contains(input, phrase) {
+		return 0.9
+	}
+
+	if strings.HasPrefix(input, phrase) {
+		return 0.85
+	}
+
+	if levenshteinDistance(input, phrase) <= 1 {
+		return 0.8
+	}
+
+	inputWords := strings.Fields(input)
+	phraseWords := strings.Fields(phrase)
+
+	if len(phraseWords) == 0 {
+		return 0
+	}
+
+	matchedWords := 0
+	for _, pw := range phraseWords {
+		for _, iw := range inputWords {
+			if iw == pw || levenshteinDistance(iw, pw) <= 2 {
+				matchedWords++
+				break
+			}
+		}
+	}
+
+	wordMatchRatio := float64(matchedWords) / float64(len(phraseWords))
+
+	if wordMatchRatio >= 0.5 {
+		return wordMatchRatio * 0.75
+	}
+
+	return 0
+}
+
+func levenshteinDistance(s1, s2 string) int {
+	s1Runes := []rune(s1)
+	s2Runes := []rune(s2)
+	len1 := len(s1Runes)
+	len2 := len(s2Runes)
+
+	if len1 == 0 {
+		return len2
+	}
+	if len2 == 0 {
+		return len1
+	}
+
+	matrix := make([][]int, len1+1)
+	for i := range matrix {
+		matrix[i] = make([]int, len2+1)
+		matrix[i][0] = i
+	}
+	for j := 0; j <= len2; j++ {
+		matrix[0][j] = j
+	}
+
+	for i := 1; i <= len1; i++ {
+		for j := 1; j <= len2; j++ {
+			cost := 1
+			if s1Runes[i-1] == s2Runes[j-1] {
+				cost = 0
+			}
+
+			matrix[i][j] = min3(
+				matrix[i-1][j]+1,
+				matrix[i][j-1]+1,
+				matrix[i-1][j-1]+cost,
+			)
+		}
+	}
+
+	return matrix[len1][len2]
+}
+
+func min3(a, b, c int) int {
+	if a < b {
+		if a < c {
+			return a
+		}
+		return c
+	}
+	if b < c {
+		return b
+	}
+	return c
+}
+
+func MFCC(samples []float64, sampleRate int, numCoefficients int, numFilters int) [][]float64 {
+	if len(samples) == 0 || sampleRate <= 0 || numCoefficients <= 0 || numFilters <= 0 {
+		return nil
+	}
+
+	frameSize := 256
+	hopSize := frameSize / 2
+	numFrames := (len(samples)-frameSize)/hopSize + 1
+
+	if numFrames <= 0 {
+		return nil
+	}
+
+	features := make([][]float64, numFrames)
+
+	for i := 0; i < numFrames; i++ {
+		start := i * hopSize
+		end := start + frameSize
+		if end > len(samples) {
+			break
+		}
+
+		frame := make([]float64, frameSize)
+		copy(frame, samples[start:end])
+
+		frame = applyHammingWindow(frame)
+
+		magSpectrum := computeMagnitudeSpectrum(frame)
+
+		energies := applyMelFilterBank(magSpectrum, sampleRate, numFilters)
+
+		logEnergies := make([]float64, numFilters)
+		for j, e := range energies {
+			if e > 0 {
+				logEnergies[j] = math.Log(e + 1e-10)
+			} else {
+				logEnergies[j] = 0
+			}
+		}
+
+		coefficients := computeDCT(logEnergies, numCoefficients)
+
+		if len(coefficients) > 0 {
+			coefficients[0] = 0
+		}
+
+		features[i] = coefficients
+	}
+
+	return features
+}
+
+func applyHammingWindow(frame []float64) []float64 {
+	N := len(frame)
+	result := make([]float64, N)
+	for i := 0; i < N; i++ {
+		window := 0.54 - 0.46*math.Cos(2*math.Pi*float64(i)/float64(N-1))
+		result[i] = frame[i] * window
+	}
+	return result
+}
+
+func computeMagnitudeSpectrum(frame []float64) []float64 {
+	N := len(frame)
+	halfN := N / 2
+
+	magnitude := make([]float64, halfN)
+
+	for k := 0; k < halfN; k++ {
+		var real, imag float64
+		for n := 0; n < N; n++ {
+			angle := 2 * math.Pi * float64(k) * float64(n) / float64(N)
+			real += frame[n] * math.Cos(angle)
+			imag -= frame[n] * math.Sin(angle)
+		}
+		magnitude[k] = math.Sqrt(real*real+imag*imag) / float64(N)
+	}
+
+	return magnitude
+}
+
+func hzToMel(hz float64) float64 {
+	return 2595.0 * math.Log10(1+hz/700.0)
+}
+
+func melToHz(mel float64) float64 {
+	return 700.0 * (math.Pow(10, mel/2595.0) - 1)
+}
+
+func applyMelFilterBank(magnitude []float64, sampleRate int, numFilters int) []float64 {
+	N := len(magnitude)
+	if N == 0 {
+		return nil
+	}
+
+	fMin := 0.0
+	fMax := float64(sampleRate) / 2.0
+
+	melMin := hzToMel(fMin)
+	melMax := hzToMel(fMax)
+
+	melPoints := make([]float64, numFilters+2)
+	for i := 0; i < numFilters+2; i++ {
+		mel := melMin + float64(i)*(melMax-melMin)/float64(numFilters+1)
+		melPoints[i] = melToHz(mel)
+	}
+
+	binFreqs := make([]float64, numFilters+2)
+	for i, mel := range melPoints {
+		binFreqs[i] = float64(N) * mel / float64(sampleRate)
+	}
+
+	energies := make([]float64, numFilters)
+
+	for m := 0; m < numFilters; m++ {
+		var energy float64
+		lower := int(binFreqs[m])
+		center := int(binFreqs[m+1])
+		upper := int(binFreqs[m+2])
+
+		for k := lower; k < center && k < N; k++ {
+			if k >= 0 {
+				weight := float64(k-lower) / float64(center-lower)
+				energy += magnitude[k] * magnitude[k] * weight
+			}
+		}
+
+		for k := center; k < upper && k < N; k++ {
+			if k >= 0 {
+				weight := float64(upper-k) / float64(upper-center)
+				energy += magnitude[k] * magnitude[k] * weight
+			}
+		}
+
+		energies[m] = energy
+	}
+
+	return energies
+}
+
+func computeDCT(input []float64, numCoefficients int) []float64 {
+	N := len(input)
+	if N == 0 || numCoefficients <= 0 {
+		return nil
+	}
+
+	if numCoefficients > N {
+		numCoefficients = N
+	}
+
+	output := make([]float64, numCoefficients)
+
+	for k := 0; k < numCoefficients; k++ {
+		var sum float64
+		for n := 0; n < N; n++ {
+			sum += input[n] * math.Cos(math.Pi*float64(k)*(float64(n)+0.5)/float64(N))
+		}
+		output[k] = sum
+	}
+
+	return output
+}
+
+func DTW(features1, features2 [][]float64) float64 {
+	if len(features1) == 0 || len(features2) == 0 {
+		return math.Inf(1)
+	}
+
+	n := len(features1)
+	m := len(features2)
+
+	if len(features1[0]) != len(features2[0]) {
+		return math.Inf(1)
+	}
+
+	dt := make([][]float64, n+1)
+	for i := range dt {
+		dt[i] = make([]float64, m+1)
+		for j := range dt[i] {
+			dt[i][j] = math.Inf(1)
+		}
+	}
+	dt[0][0] = 0
+
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= m; j++ {
+			cost := euclideanDistance(features1[i-1], features2[j-1])
+			dt[i][j] = cost + min3Float(dt[i-1][j], dt[i][j-1], dt[i-1][j-1])
+		}
+	}
+
+	return dt[n][m]
+}
+
+func euclideanDistance(a, b []float64) float64 {
+	if len(a) != len(b) {
+		return math.Inf(1)
+	}
+
+	var sum float64
+	for i := range a {
+		diff := a[i] - b[i]
+		sum += diff * diff
+	}
+
+	return math.Sqrt(sum)
+}
+
+func min3Float(a, b, c float64) float64 {
+	if a < b {
+		if a < c {
+			return a
+		}
+		return c
+	}
+	if b < c {
+		return b
+	}
+	return c
+}

--- a/pkg/speech/wake_word_engine.go
+++ b/pkg/speech/wake_word_engine.go
@@ -1,0 +1,321 @@
+package speech
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+type WakeWordEngineType string
+
+const (
+	EngineBuiltIn   WakeWordEngineType = "builtin"
+	EnginePorcupine WakeWordEngineType = "porcupine"
+	EngineSnowboy   WakeWordEngineType = "snowboy"
+)
+
+type WakeWordDetectionResult struct {
+	Keyword    string
+	Confidence float64
+	Engine     WakeWordEngineType
+}
+
+type WakeWordEngine interface {
+	Name() string
+	Type() WakeWordEngineType
+	Init() error
+	ProcessFrame(samples []int16) (*WakeWordDetectionResult, bool)
+	Close() error
+	Reset() error
+}
+
+type WakeWordEngineFactory func(cfg WakeWordEngineConfig) (WakeWordEngine, error)
+
+type WakeWordEngineConfig struct {
+	Type         WakeWordEngineType
+	Keywords     []string
+	KeywordPaths []string
+	Sensitivity  float64
+	LibraryPath  string
+	ModelPath    string
+	ResourcePath string
+	AccessKey    string
+	SampleRate   int
+	FrameSize    int
+	Extra        map[string]string
+}
+
+type WakeWordEngineRouter struct {
+	mu        sync.Mutex
+	engines   map[string]WakeWordEngine
+	active    string
+	factory   map[WakeWordEngineType]WakeWordEngineFactory
+	cfg       WakeWordEngineConfig
+	listeners []WakeWordListener
+}
+
+func NewWakeWordEngineRouter(cfg WakeWordEngineConfig) *WakeWordEngineRouter {
+	return &WakeWordEngineRouter{
+		engines: make(map[string]WakeWordEngine),
+		factory: make(map[WakeWordEngineType]WakeWordEngineFactory),
+		cfg:     cfg,
+	}
+}
+
+func (r *WakeWordEngineRouter) RegisterFactory(engineType WakeWordEngineType, factory WakeWordEngineFactory) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.factory[engineType] = factory
+}
+
+func (r *WakeWordEngineRouter) CreateEngine(engineType WakeWordEngineType, cfg WakeWordEngineConfig) error {
+	r.mu.Lock()
+	factory, ok := r.factory[engineType]
+	r.mu.Unlock()
+
+	if !ok {
+		return fmt.Errorf("voicewake: no factory registered for engine type %s", engineType)
+	}
+
+	engine, err := factory(cfg)
+	if err != nil {
+		return fmt.Errorf("voicewake: failed to create engine %s: %w", engineType, err)
+	}
+
+	if err := engine.Init(); err != nil {
+		return fmt.Errorf("voicewake: failed to initialize engine %s: %w", engineType, err)
+	}
+
+	r.mu.Lock()
+	name := engine.Name()
+	r.engines[name] = engine
+	if r.active == "" {
+		r.active = name
+	}
+	r.mu.Unlock()
+
+	return nil
+}
+
+func (r *WakeWordEngineRouter) ProcessFrame(samples []int16) (*WakeWordDetectionResult, bool) {
+	r.mu.Lock()
+	active := r.active
+	engine := r.engines[active]
+	r.mu.Unlock()
+
+	if engine == nil {
+		return nil, false
+	}
+
+	return engine.ProcessFrame(samples)
+}
+
+func (r *WakeWordEngineRouter) SetActive(name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.engines[name]; !ok {
+		return fmt.Errorf("voicewake: engine %s not found", name)
+	}
+	r.active = name
+	return nil
+}
+
+func (r *WakeWordEngineRouter) ActiveEngine() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.active
+}
+
+func (r *WakeWordEngineRouter) RegisterListener(listener WakeWordListener) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.listeners = append(r.listeners, listener)
+}
+
+func (r *WakeWordEngineRouter) notifyListeners(phrase string, confidence float64) {
+	r.mu.Lock()
+	listeners := make([]WakeWordListener, len(r.listeners))
+	copy(listeners, r.listeners)
+	r.mu.Unlock()
+
+	for _, listener := range listeners {
+		listener(phrase, confidence)
+	}
+}
+
+func (r *WakeWordEngineRouter) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var lastErr error
+	for name, engine := range r.engines {
+		if err := engine.Close(); err != nil {
+			lastErr = fmt.Errorf("voicewake: error closing engine %s: %w", name, err)
+		}
+		delete(r.engines, name)
+	}
+	r.active = ""
+	return lastErr
+}
+
+func (r *WakeWordEngineRouter) Reset() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var lastErr error
+	for name, engine := range r.engines {
+		if err := engine.Reset(); err != nil {
+			lastErr = fmt.Errorf("voicewake: error resetting engine %s: %w", name, err)
+		}
+	}
+	return lastErr
+}
+
+func (r *WakeWordEngineRouter) Engines() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	names := make([]string, 0, len(r.engines))
+	for name := range r.engines {
+		names = append(names, name)
+	}
+	return names
+}
+
+type WakeWordEngineAdapter struct {
+	router    *WakeWordEngineRouter
+	detector  *WakeWordDetector
+	mu        sync.Mutex
+	useEngine bool
+}
+
+func NewWakeWordEngineAdapter(router *WakeWordEngineRouter, detector *WakeWordDetector) *WakeWordEngineAdapter {
+	return &WakeWordEngineAdapter{
+		router:    router,
+		detector:  detector,
+		useEngine: router != nil && len(router.Engines()) > 0,
+	}
+}
+
+func (a *WakeWordEngineAdapter) ProcessFrame(samples []int16) (*WakeWordDetectionResult, bool) {
+	a.mu.Lock()
+	useEngine := a.useEngine
+	router := a.router
+	detector := a.detector
+	a.mu.Unlock()
+
+	if useEngine && router != nil {
+		result, detected := router.ProcessFrame(samples)
+		if detected && result != nil {
+			router.notifyListeners(result.Keyword, result.Confidence)
+		}
+		return result, detected
+	}
+
+	if detector != nil {
+		return nil, false
+	}
+
+	return nil, false
+}
+
+func (a *WakeWordEngineAdapter) DetectTranscript(transcript string) (string, float64, bool) {
+	a.mu.Lock()
+	detector := a.detector
+	a.mu.Unlock()
+
+	if detector != nil {
+		return detector.Detect(transcript)
+	}
+	return "", 0, false
+}
+
+func (a *WakeWordEngineAdapter) SetUseEngine(use bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.useEngine = use
+}
+
+func (a *WakeWordEngineAdapter) UseEngine() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.useEngine
+}
+
+func (a *WakeWordEngineAdapter) RegisterListener(listener WakeWordListener) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.router != nil {
+		a.router.RegisterListener(listener)
+	}
+	if a.detector != nil {
+		a.detector.RegisterListener(listener)
+	}
+}
+
+type MockWakeWordEngine struct {
+	name         string
+	keyword      string
+	triggered    bool
+	frameCount   int
+	triggerAfter int
+	sampleRate   int
+	frameSize    int
+}
+
+func NewMockWakeWordEngine(keyword string, triggerAfter int) *MockWakeWordEngine {
+	return &MockWakeWordEngine{
+		name:         "mock-" + keyword,
+		keyword:      keyword,
+		triggerAfter: triggerAfter,
+		sampleRate:   16000,
+		frameSize:    320,
+	}
+}
+
+func (m *MockWakeWordEngine) Name() string {
+	return m.name
+}
+
+func (m *MockWakeWordEngine) Type() WakeWordEngineType {
+	return "mock"
+}
+
+func (m *MockWakeWordEngine) Init() error {
+	return nil
+}
+
+func (m *MockWakeWordEngine) ProcessFrame(samples []int16) (*WakeWordDetectionResult, bool) {
+	m.frameCount++
+
+	if m.frameCount >= m.triggerAfter {
+		m.frameCount = 0
+		return &WakeWordDetectionResult{
+			Keyword:    m.keyword,
+			Confidence: 0.95,
+			Engine:     "mock",
+		}, true
+	}
+
+	return nil, false
+}
+
+func (m *MockWakeWordEngine) Close() error {
+	m.frameCount = 0
+	return nil
+}
+
+func (m *MockWakeWordEngine) Reset() error {
+	m.frameCount = 0
+	m.triggered = false
+	return nil
+}
+
+type WakeWordEngineContext struct {
+	Ctx        context.Context
+	SampleRate int
+	Channels   int
+	FrameSize  int
+}

--- a/pkg/speech/wake_word_porcupine.go
+++ b/pkg/speech/wake_word_porcupine.go
@@ -1,0 +1,264 @@
+package speech
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+type PorcupineEngine struct {
+	mu            sync.Mutex
+	cfg           WakeWordEngineConfig
+	binaryPath    string
+	keywordPaths  []string
+	sensitivities []float64
+	isInit        bool
+	frameSize     int
+	sampleRate    int
+}
+
+func NewPorcupineEngine(cfg WakeWordEngineConfig) *PorcupineEngine {
+	if cfg.SampleRate == 0 {
+		cfg.SampleRate = 16000
+	}
+	if cfg.FrameSize == 0 {
+		cfg.FrameSize = 512
+	}
+	if cfg.Sensitivity <= 0 {
+		cfg.Sensitivity = 0.5
+	}
+	return &PorcupineEngine{
+		cfg:        cfg,
+		frameSize:  cfg.FrameSize,
+		sampleRate: cfg.SampleRate,
+	}
+}
+
+func (p *PorcupineEngine) Name() string {
+	return "porcupine"
+}
+
+func (p *PorcupineEngine) Type() WakeWordEngineType {
+	return EnginePorcupine
+}
+
+func (p *PorcupineEngine) Init() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.isInit {
+		return nil
+	}
+
+	if len(p.cfg.Keywords) == 0 && len(p.cfg.KeywordPaths) == 0 {
+		return fmt.Errorf("porcupine: at least one keyword or keyword path required")
+	}
+
+	if p.cfg.AccessKey == "" {
+		return fmt.Errorf("porcupine: access_key required")
+	}
+
+	binaryPath := p.findBinary()
+	if binaryPath == "" {
+		return fmt.Errorf("porcupine: binary not found, install porcupine_demo or pv_porcupine_demo")
+	}
+	p.binaryPath = binaryPath
+
+	keywordPaths := p.cfg.KeywordPaths
+	if len(keywordPaths) == 0 {
+		keywordPaths = make([]string, len(p.cfg.Keywords))
+		for i, kw := range p.cfg.Keywords {
+			keywordPaths[i] = filepath.Join("lib", "porcupine", "keywords", kw+"_en.ppn")
+		}
+	}
+
+	for _, path := range keywordPaths {
+		if _, err := os.Stat(path); err != nil {
+			return fmt.Errorf("porcupine: keyword file not found: %s", path)
+		}
+	}
+
+	if p.cfg.ModelPath != "" {
+		if _, err := os.Stat(p.cfg.ModelPath); err != nil {
+			return fmt.Errorf("porcupine: model file not found: %s", p.cfg.ModelPath)
+		}
+	}
+
+	p.keywordPaths = keywordPaths
+	p.sensitivities = make([]float64, len(keywordPaths))
+	for i := range p.sensitivities {
+		p.sensitivities[i] = p.cfg.Sensitivity
+	}
+	p.isInit = true
+	return nil
+}
+
+func (p *PorcupineEngine) findBinary() string {
+	candidates := []string{
+		"porcupine_demo",
+		"pv_porcupine_demo",
+		"porcupine_demo_mic",
+	}
+	for _, name := range candidates {
+		if path, err := exec.LookPath(name); err == nil {
+			return path
+		}
+	}
+	return ""
+}
+
+func (p *PorcupineEngine) ProcessFrame(samples []int16) (*WakeWordDetectionResult, bool) {
+	p.mu.Lock()
+	if !p.isInit {
+		p.mu.Unlock()
+		return nil, false
+	}
+	p.mu.Unlock()
+
+	if len(samples) == 0 {
+		return nil, false
+	}
+
+	return p.processSamples(samples)
+}
+
+func (p *PorcupineEngine) processSamples(samples []int16) (*WakeWordDetectionResult, bool) {
+	args := p.buildArgs()
+
+	cmd := exec.Command(p.binaryPath, args...)
+
+	var stdinBuf bytes.Buffer
+	for _, s := range samples {
+		lo := byte(s)
+		hi := byte(s >> 8)
+		stdinBuf.WriteByte(lo)
+		stdinBuf.WriteByte(hi)
+	}
+	cmd.Stdin = &stdinBuf
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	if err := cmd.Run(); err != nil {
+		return nil, false
+	}
+
+	output := stdoutBuf.String()
+	return p.parseOutput(output)
+}
+
+func (p *PorcupineEngine) buildArgs() []string {
+	args := []string{
+		"--access_key", p.cfg.AccessKey,
+		"--sample_rate", fmt.Sprintf("%d", p.sampleRate),
+	}
+
+	if p.cfg.ModelPath != "" {
+		args = append(args, "--model_path", p.cfg.ModelPath)
+	}
+
+	for i, kwPath := range p.keywordPaths {
+		args = append(args, "--keyword_path", kwPath)
+		args = append(args, "--sensitivity", fmt.Sprintf("%.2f", p.sensitivities[i]))
+	}
+
+	args = append(args, "--audio_device", "stdin")
+
+	return args
+}
+
+func (p *PorcupineEngine) parseOutput(output string) (*WakeWordDetectionResult, bool) {
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.Contains(line, "keyword_index") || strings.Contains(line, "detected") {
+			parts := strings.Fields(line)
+			for i, part := range parts {
+				if strings.Contains(part, "index") && i+1 < len(parts) {
+					idxStr := strings.Trim(parts[i+1], "[]:,")
+					var idx int
+					fmt.Sscanf(idxStr, "%d", &idx)
+					if idx >= 0 && idx < len(p.keywordPaths) {
+						keyword := p.keywordPaths[idx]
+						if idx < len(p.cfg.Keywords) && p.cfg.Keywords[idx] != "" {
+							keyword = p.cfg.Keywords[idx]
+						}
+						return &WakeWordDetectionResult{
+							Keyword:    keyword,
+							Confidence: p.sensitivities[idx],
+							Engine:     EnginePorcupine,
+						}, true
+					}
+				}
+			}
+		}
+	}
+	return nil, false
+}
+
+func (p *PorcupineEngine) ProcessBatch(audioPath string) (*WakeWordDetectionResult, bool) {
+	p.mu.Lock()
+	if !p.isInit {
+		p.mu.Unlock()
+		return nil, false
+	}
+	p.mu.Unlock()
+
+	args := p.buildArgs()
+	args = append(args, "--input_audio_path", audioPath)
+
+	cmd := exec.Command(p.binaryPath, args...)
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	if err := cmd.Run(); err != nil {
+		return nil, false
+	}
+
+	return p.parseOutput(stdoutBuf.String())
+}
+
+func (p *PorcupineEngine) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.isInit = false
+	return nil
+}
+
+func (p *PorcupineEngine) Reset() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return nil
+}
+
+func (p *PorcupineEngine) FrameLength() int {
+	return p.frameSize
+}
+
+func (p *PorcupineEngine) SampleRate() int {
+	return p.sampleRate
+}
+
+func (p *PorcupineEngine) IsInitialized() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.isInit
+}
+
+func (p *PorcupineEngine) KeywordPaths() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.keywordPaths...)
+}
+
+func (p *PorcupineEngine) Sensitivities() []float64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]float64(nil), p.sensitivities...)
+}

--- a/pkg/speech/wake_word_snowboy.go
+++ b/pkg/speech/wake_word_snowboy.go
@@ -1,0 +1,299 @@
+package speech
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+type SnowboyEngine struct {
+	mu           sync.Mutex
+	cfg          WakeWordEngineConfig
+	pythonPath   string
+	scriptPath   string
+	modelPaths   []string
+	commonModel  string
+	isInit       bool
+	frameSize    int
+	sampleRate   int
+	hotwordNames []string
+}
+
+func NewSnowboyEngine(cfg WakeWordEngineConfig) *SnowboyEngine {
+	if cfg.SampleRate == 0 {
+		cfg.SampleRate = 16000
+	}
+	if cfg.FrameSize == 0 {
+		cfg.FrameSize = 512
+	}
+	if cfg.Sensitivity <= 0 {
+		cfg.Sensitivity = 0.5
+	}
+	if cfg.ResourcePath == "" {
+		cfg.ResourcePath = "lib/snowboy/resources/common.res"
+	}
+	return &SnowboyEngine{
+		cfg:        cfg,
+		frameSize:  cfg.FrameSize,
+		sampleRate: cfg.SampleRate,
+	}
+}
+
+func (s *SnowboyEngine) Name() string {
+	return "snowboy"
+}
+
+func (s *SnowboyEngine) Type() WakeWordEngineType {
+	return EngineSnowboy
+}
+
+func (s *SnowboyEngine) Init() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.isInit {
+		return nil
+	}
+
+	if len(s.cfg.Keywords) == 0 && len(s.cfg.KeywordPaths) == 0 {
+		return fmt.Errorf("snowboy: at least one keyword or keyword path required")
+	}
+
+	pythonPath := s.findPython()
+	if pythonPath == "" {
+		return fmt.Errorf("snowboy: python3 not found, required for snowboy wrapper")
+	}
+	s.pythonPath = pythonPath
+
+	scriptPath := s.findScript()
+	if scriptPath == "" {
+		return fmt.Errorf("snowboy: demo script not found, install snowboy python demo")
+	}
+	s.scriptPath = scriptPath
+
+	modelPaths := s.cfg.KeywordPaths
+	if len(modelPaths) == 0 {
+		modelPaths = make([]string, len(s.cfg.Keywords))
+		for i, kw := range s.cfg.Keywords {
+			modelPaths[i] = filepath.Join("lib", "snowboy", "models", kw+".pmdl")
+		}
+	}
+
+	for _, path := range modelPaths {
+		if _, err := os.Stat(path); err != nil {
+			return fmt.Errorf("snowboy: model file not found: %s", path)
+		}
+	}
+
+	commonModel := s.cfg.ResourcePath
+	if commonModel != "" {
+		if _, err := os.Stat(commonModel); err != nil {
+			return fmt.Errorf("snowboy: common resource file not found: %s", commonModel)
+		}
+	}
+
+	s.modelPaths = modelPaths
+	s.commonModel = commonModel
+	s.hotwordNames = make([]string, len(modelPaths))
+	for i, path := range modelPaths {
+		s.hotwordNames[i] = strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	}
+	if len(s.cfg.Keywords) > 0 {
+		copy(s.hotwordNames, s.cfg.Keywords)
+	}
+
+	s.isInit = true
+	return nil
+}
+
+func (s *SnowboyEngine) findPython() string {
+	candidates := []string{"python3", "python"}
+	for _, name := range candidates {
+		if path, err := exec.LookPath(name); err == nil {
+			return path
+		}
+	}
+	return ""
+}
+
+func (s *SnowboyEngine) findScript() string {
+	candidates := []string{
+		"lib/snowboy/demo.py",
+		"lib/snowboy/snowboydecoder.py",
+		"snowboy_demo.py",
+	}
+	for _, path := range candidates {
+		if _, err := os.Stat(path); err == nil {
+			abs, _ := filepath.Abs(path)
+			return abs
+		}
+	}
+	return ""
+}
+
+func (s *SnowboyEngine) ProcessFrame(samples []int16) (*WakeWordDetectionResult, bool) {
+	s.mu.Lock()
+	if !s.isInit {
+		s.mu.Unlock()
+		return nil, false
+	}
+	s.mu.Unlock()
+
+	if len(samples) == 0 {
+		return nil, false
+	}
+
+	return s.processSamples(samples)
+}
+
+func (s *SnowboyEngine) processSamples(samples []int16) (*WakeWordDetectionResult, bool) {
+	args := []string{
+		s.scriptPath,
+		"--sample_rate", fmt.Sprintf("%d", s.sampleRate),
+		"--sensitivity", fmt.Sprintf("%.2f", s.cfg.Sensitivity),
+	}
+
+	if s.commonModel != "" {
+		args = append(args, "--common_model", s.commonModel)
+	}
+
+	for _, modelPath := range s.modelPaths {
+		args = append(args, "--model", modelPath)
+	}
+
+	args = append(args, "--stdin")
+
+	cmd := exec.Command(s.pythonPath, args...)
+
+	var stdinBuf bytes.Buffer
+	for _, sample := range samples {
+		lo := byte(sample)
+		hi := byte(sample >> 8)
+		stdinBuf.WriteByte(lo)
+		stdinBuf.WriteByte(hi)
+	}
+	cmd.Stdin = &stdinBuf
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	if err := cmd.Run(); err != nil {
+		return nil, false
+	}
+
+	return s.parseOutput(stdoutBuf.String())
+}
+
+func (s *SnowboyEngine) parseOutput(output string) (*WakeWordDetectionResult, bool) {
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		lower := strings.ToLower(line)
+
+		if strings.Contains(lower, "detected") || strings.Contains(lower, "hotword") || strings.Contains(lower, "keyword") {
+			for _, name := range s.hotwordNames {
+				if strings.Contains(lower, strings.ToLower(name)) {
+					return &WakeWordDetectionResult{
+						Keyword:    name,
+						Confidence: s.cfg.Sensitivity,
+						Engine:     EngineSnowboy,
+					}, true
+				}
+			}
+
+			if len(s.hotwordNames) > 0 {
+				return &WakeWordDetectionResult{
+					Keyword:    s.hotwordNames[0],
+					Confidence: s.cfg.Sensitivity,
+					Engine:     EngineSnowboy,
+				}, true
+			}
+		}
+	}
+	return nil, false
+}
+
+func (s *SnowboyEngine) ProcessBatch(audioPath string) (*WakeWordDetectionResult, bool) {
+	s.mu.Lock()
+	if !s.isInit {
+		s.mu.Unlock()
+		return nil, false
+	}
+	s.mu.Unlock()
+
+	args := []string{
+		s.scriptPath,
+		"--sample_rate", fmt.Sprintf("%d", s.sampleRate),
+		"--sensitivity", fmt.Sprintf("%.2f", s.cfg.Sensitivity),
+		"--input_audio", audioPath,
+	}
+
+	if s.commonModel != "" {
+		args = append(args, "--common_model", s.commonModel)
+	}
+
+	for _, modelPath := range s.modelPaths {
+		args = append(args, "--model", modelPath)
+	}
+
+	cmd := exec.Command(s.pythonPath, args...)
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	if err := cmd.Run(); err != nil {
+		return nil, false
+	}
+
+	return s.parseOutput(stdoutBuf.String())
+}
+
+func (s *SnowboyEngine) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.isInit = false
+	return nil
+}
+
+func (s *SnowboyEngine) Reset() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return nil
+}
+
+func (s *SnowboyEngine) FrameLength() int {
+	return s.frameSize
+}
+
+func (s *SnowboyEngine) SampleRate() int {
+	return s.sampleRate
+}
+
+func (s *SnowboyEngine) IsInitialized() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.isInit
+}
+
+func (s *SnowboyEngine) ModelPaths() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.modelPaths...)
+}
+
+func (s *SnowboyEngine) HotwordNames() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.hotwordNames...)
+}
+
+func (s *SnowboyEngine) CommonModel() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.commonModel
+}


### PR DESCRIPTION
## Summary
- add the STT pipeline and providers
- add VAD, wake word, and voice wake coordination/runtime pieces
- keep the speech stack split into a second focused review step

## Testing
- go test ./pkg/speech/... ./pkg/gateway/transport/reply/...

## Stack
- base branch: `gateway-wiring-gateway-speech1`