### PR TITLE
feat(gateway): add runtime activation wiring

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -86,6 +86,10 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	mux := http.NewServeMux()
+	s.initChannels()
+	s.initMCP(ctx)
+	s.initMarketStore()
+	s.initDiscovery(ctx)
 	if err := s.ensureDefaultWorkspace(); err != nil {
 		return err
 	}
@@ -100,6 +104,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	errCh := make(chan error, 1)
+	go s.runChannels(ctx)
 	go func() {
 		if err := s.httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errCh <- err

--- a/pkg/gateway/gateway_additional_coverage_test.go
+++ b/pkg/gateway/gateway_additional_coverage_test.go
@@ -1,0 +1,216 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+	chatintake "github.com/1024XEngineer/anyclaw/pkg/gateway/intake/chat"
+	"github.com/1024XEngineer/anyclaw/pkg/state"
+)
+
+type fakeChatManager struct{}
+
+func (fakeChatManager) Chat(context.Context, chatintake.ChatRequest) (*chatintake.ChatResponse, error) {
+	return &chatintake.ChatResponse{SessionID: "s1", AgentName: "agent", Message: chatintake.Message{Role: "assistant", Content: "ok"}}, nil
+}
+
+func (fakeChatManager) GetSession(string) (*chatintake.Session, error) { return nil, nil }
+func (fakeChatManager) ListSessions() []chatintake.Session             { return []chatintake.Session{} }
+func (fakeChatManager) GetSessionHistory(string) ([]chatintake.Message, error) {
+	return []chatintake.Message{}, nil
+}
+func (fakeChatManager) DeleteSession(string) error         { return nil }
+func (fakeChatManager) ListAgents() []chatintake.AgentInfo { return []chatintake.AgentInfo{} }
+
+func drainJobQueue(server *Server) {
+	for {
+		select {
+		case job := <-server.jobQueue:
+			job()
+		default:
+			return
+		}
+	}
+}
+
+func TestGatewayAdditionalCoverage_JobQueueAndAudit(t *testing.T) {
+	server := newSplitAPITestServer(t)
+
+	runtimeJob := &state.Job{
+		ID:     "job-refresh",
+		Kind:   "runtimes.refresh.batch",
+		Status: "queued",
+		Payload: map[string]any{
+			"items": []any{map[string]any{"agent": "main", "workspace": ""}},
+		},
+	}
+	server.enqueueJobFromPayload(runtimeJob)
+	drainJobQueue(server)
+	if runtimeJob.Status == "" {
+		t.Fatal("expected runtime refresh job status to be updated")
+	}
+
+	moveJob := &state.Job{
+		ID:     "job-move",
+		Kind:   "sessions.move.batch",
+		Status: "queued",
+		Payload: map[string]any{
+			"session_ids": []any{"s1"},
+			"org":         "",
+			"project":     "",
+			"workspace":   "missing",
+		},
+	}
+	server.enqueueJobFromPayload(moveJob)
+	if moveJob.Status != "failed" {
+		t.Fatalf("expected session move job to fail, got %q", moveJob.Status)
+	}
+
+	retrySource := &state.Job{ID: "retry-source", Kind: "noop", Status: "failed", Summary: "retry me", Retriable: true, Payload: map[string]any{}}
+	if err := server.store.AppendJob(retrySource); err != nil {
+		t.Fatalf("append retry source: %v", err)
+	}
+
+	cancelJob := &state.Job{ID: "cancel-me", Kind: "noop", Status: "queued", Cancellable: true}
+	if err := server.store.AppendJob(cancelJob); err != nil {
+		t.Fatalf("append cancel job: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.handleAudit(rec, newAdminRequest(http.MethodGet, "/audit", ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /audit = %d", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	server.handleJobs(rec, newAdminRequest(http.MethodGet, "/jobs", ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /jobs = %d", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	server.handleJobByID(rec, newAdminRequest(http.MethodGet, "/jobs/retry-source", ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /jobs/id = %d", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	server.handleCancelJob(rec, newAdminRequest(http.MethodPost, "/jobs/cancel", `{"job_id":"cancel-me"}`))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /jobs/cancel = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.handleRetryJob(rec, newAdminRequest(http.MethodPost, "/jobs/retry", `{"job_id":"retry-source"}`))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /jobs/retry = %d body=%s", rec.Code, rec.Body.String())
+	}
+	drainJobQueue(server)
+}
+
+func TestGatewayAdditionalCoverage_CronAndSkills(t *testing.T) {
+	server := newSplitAPITestServer(t)
+	cronInitOnce = sync.Once{}
+	cronScheduler = nil
+	server.initCronScheduler()
+	defer func() {
+		if cronScheduler != nil {
+			cronScheduler.Stop()
+		}
+		cronInitOnce = sync.Once{}
+		cronScheduler = nil
+	}()
+
+	rec := httptest.NewRecorder()
+	server.handleCronList(rec, newAdminRequest(http.MethodGet, "/cron", ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /cron = %d", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	server.handleCronList(rec, newAdminRequest(http.MethodPost, "/cron", `{"name":"hourly","schedule":"@hourly","command":"echo hi"}`))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST /cron = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var created map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode created cron task: %v", err)
+	}
+	taskID := created["id"]
+
+	rec = httptest.NewRecorder()
+	server.handleCronByID(rec, newAdminRequest(http.MethodGet, "/cron/"+taskID, ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /cron/id = %d", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	server.handleCronByID(rec, newAdminRequest(http.MethodPut, "/cron/"+taskID, `{"name":"hourly-updated","schedule":"@hourly","command":"echo ok"}`))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT /cron/id = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.handleCronStats(rec, newAdminRequest(http.MethodGet, "/cron/stats", ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /cron/stats = %d", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	server.handleCronByID(rec, newAdminRequest(http.MethodDelete, "/cron/"+taskID, ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("DELETE /cron/id = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	server.mainRuntime.Config.Agent.Skills = nil
+	if got := server.currentEnabledSkillCount(); got < 0 {
+		t.Fatalf("unexpected skill count %d", got)
+	}
+
+	server.mainRuntime.Config.Agent.Skills = []config.AgentSkillRef{{Name: "alpha", Enabled: true}, {Name: "alpha", Enabled: true}, {Name: "beta", Enabled: false}}
+	if got := server.currentEnabledSkillCount(); got != 1 {
+		t.Fatalf("expected deduplicated enabled skill count, got %d", got)
+	}
+	_ = server.currentConfiguredSkillRefs()
+}
+
+func TestGatewayAdditionalCoverage_ChatV2AndHelpers(t *testing.T) {
+	server := newSplitAPITestServer(t)
+
+	rec := httptest.NewRecorder()
+	server.handleV2Chat(rec, newAdminRequest(http.MethodPost, "/v2/chat", `{}`))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("POST /v2/chat without module = %d", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	server.handleV2ChatSessions(rec, newAdminRequest(http.MethodGet, "/v2/chat/sessions", ""))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /v2/chat/sessions without module = %d", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	server.handleV2ChatSessionByID(rec, newAdminRequest(http.MethodGet, "/v2/chat/sessions/x", ""))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /v2/chat/sessions/id without module = %d", rec.Code)
+	}
+
+	server.chatModule = fakeChatManager{}
+	rec = httptest.NewRecorder()
+	server.handleV2ChatSessions(rec, newAdminRequest(http.MethodGet, "/v2/chat/sessions", ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /v2/chat/sessions = %d", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	server.handleV2ChatSessionByID(rec, newAdminRequest(http.MethodDelete, "/v2/chat/sessions/demo", ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("DELETE /v2/chat/sessions/id = %d body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/pkg/gateway/gateway_additional_coverage_test.go
+++ b/pkg/gateway/gateway_additional_coverage_test.go
@@ -203,6 +203,12 @@ func TestGatewayAdditionalCoverage_ChatV2AndHelpers(t *testing.T) {
 
 	server.chatModule = fakeChatManager{}
 	rec = httptest.NewRecorder()
+	server.handleV2Chat(rec, newAdminRequest(http.MethodPost, "/v2/chat", `{"agent_name":"helper","message":"hello"}`))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /v2/chat = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
 	server.handleV2ChatSessions(rec, newAdminRequest(http.MethodGet, "/v2/chat/sessions", ""))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /v2/chat/sessions = %d", rec.Code)
@@ -212,5 +218,22 @@ func TestGatewayAdditionalCoverage_ChatV2AndHelpers(t *testing.T) {
 	server.handleV2ChatSessionByID(rec, newAdminRequest(http.MethodDelete, "/v2/chat/sessions/demo", ""))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("DELETE /v2/chat/sessions/id = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	server.store.AppendTask(&state.Task{ID: "task-1", Workspace: "default", Status: "queued", Assistant: "helper"})
+	rec = httptest.NewRecorder()
+	server.handleV2Tasks(rec, newAdminRequest(http.MethodGet, "/v2/tasks?workspace=default&status=queued&assistant=helper", ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /v2/tasks filtered = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.handleV2TaskByID(rec, newAdminRequest(http.MethodGet, "/v2/tasks/", ""))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("GET /v2/tasks/ = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	if _, _, _, err := server.v2TaskHierarchy(newAdminRequest(http.MethodGet, "/v2/tasks", ""), "missing-session"); err == nil {
+		t.Fatal("expected missing session hierarchy error")
 	}
 }

--- a/pkg/gateway/gateway_audit_jobs_api.go
+++ b/pkg/gateway/gateway_audit_jobs_api.go
@@ -1,0 +1,106 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/state"
+)
+
+func (s *Server) handleAudit(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	s.appendAudit(UserFromContext(r.Context()), "audit.read", "audit", nil)
+	writeJSON(w, http.StatusOK, s.store.ListAudit(100))
+}
+
+func (s *Server) handleJobs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	s.appendAudit(UserFromContext(r.Context()), "jobs.read", "jobs", nil)
+	writeJSON(w, http.StatusOK, s.store.ListJobs(100))
+}
+
+func (s *Server) handleJobByID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	id := strings.TrimPrefix(r.URL.Path, "/jobs/")
+	if id == "" {
+		http.NotFound(w, r)
+		return
+	}
+	job, ok := s.store.GetJob(id)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "job not found"})
+		return
+	}
+	s.appendAudit(UserFromContext(r.Context()), "jobs.detail.read", id, nil)
+	writeJSON(w, http.StatusOK, job)
+}
+
+func (s *Server) handleCancelJob(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		JobID string `json:"job_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+		return
+	}
+	job, ok := s.store.GetJob(req.JobID)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "job not found"})
+		return
+	}
+	if job.Status == "completed" || job.Status == "failed" || job.Status == "cancelled" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "job is not cancellable"})
+		return
+	}
+	s.jobCancel[job.ID] = true
+	job.Status = "cancelled"
+	job.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+	job.Cancellable = false
+	job.Retriable = true
+	_ = s.store.UpdateJob(job)
+	s.appendAudit(UserFromContext(r.Context()), "jobs.cancel", job.ID, nil)
+	writeJSON(w, http.StatusOK, map[string]any{"status": "cancelled"})
+}
+
+func (s *Server) handleRetryJob(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		JobID string `json:"job_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+		return
+	}
+	job, ok := s.store.GetJob(req.JobID)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "job not found"})
+		return
+	}
+	if !job.Retriable {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "job is not retriable"})
+		return
+	}
+	clone := &state.Job{ID: uniqueID("job"), Kind: job.Kind, Status: "queued", Summary: job.Summary + " (retry)", CreatedAt: time.Now().UTC(), RetryOf: job.ID, Cancellable: true, Retriable: true, Payload: job.Payload}
+	_ = s.store.AppendJob(clone)
+	s.enqueueJobFromPayload(clone)
+	s.appendAudit(UserFromContext(r.Context()), "jobs.retry", job.ID, map[string]any{"new_job": clone.ID})
+	writeJSON(w, http.StatusOK, map[string]any{"status": "queued", "job_id": clone.ID})
+}

--- a/pkg/gateway/gateway_catalog_api.go
+++ b/pkg/gateway/gateway_catalog_api.go
@@ -1,0 +1,67 @@
+package gateway
+
+import (
+	"net/http"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/plugin"
+	inputlayer "github.com/1024XEngineer/anyclaw/pkg/input"
+	routeingress "github.com/1024XEngineer/anyclaw/pkg/route/ingress"
+)
+
+func (s *Server) handleChannels(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.channels == nil {
+		writeJSON(w, http.StatusOK, []inputlayer.Status{})
+		return
+	}
+	writeJSON(w, http.StatusOK, s.channels.Statuses())
+}
+
+func (s *Server) handlePlugins(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.plugins == nil {
+		writeJSON(w, http.StatusOK, []plugin.Manifest{})
+		return
+	}
+	s.appendAudit(UserFromContext(r.Context()), "plugins.read", "plugins", nil)
+	writeJSON(w, http.StatusOK, s.plugins.List())
+}
+
+func (s *Server) handleRouting(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	writeJSON(w, http.StatusOK, s.mainRuntime.Config.Channels.Routing)
+}
+
+func (s *Server) handleRoutingAnalysis(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	writeJSON(w, http.StatusOK, routeingress.AnalyzeRouting(s.mainRuntime.Config.Channels.Routing))
+}
+
+func (s *Server) handlePersonalityTemplates(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	writeJSON(w, http.StatusOK, config.BuiltinPersonalityTemplates)
+}
+
+func (s *Server) handleAssistantSkillCatalog(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	writeJSON(w, http.StatusOK, s.mainRuntime.Skills.Catalog())
+}

--- a/pkg/gateway/gateway_channel_bootstrap.go
+++ b/pkg/gateway/gateway_channel_bootstrap.go
@@ -1,0 +1,124 @@
+package gateway
+
+import (
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+	inputlayer "github.com/1024XEngineer/anyclaw/pkg/input"
+	inputchannels "github.com/1024XEngineer/anyclaw/pkg/input/channels"
+	routeingress "github.com/1024XEngineer/anyclaw/pkg/route/ingress"
+)
+
+func (s *Server) initChannels() {
+	s.initSTT()
+	s.initTTS()
+
+	s.ingress = routeingress.NewService(
+		routeingress.NewRouter(s.mainRuntime.Config.Channels.Routing),
+		routeingress.WithMainAgentNameResolver(s.mainRuntime.Config.ResolveMainAgentName),
+		routeingress.WithSessionStore(ingressSessionStore{server: s, manager: s.sessions}),
+	)
+	if s.plugins != nil {
+		s.ingressPlugins = s.plugins.IngressRunners(s.mainRuntime.Config.Plugins.Dir)
+	}
+	builders := map[string]func() inputlayer.Adapter{
+		"telegram-channel": func() inputlayer.Adapter {
+			s.telegram = inputchannels.NewTelegramAdapter(s.mainRuntime.Config.Channels.Telegram, s.appendEvent)
+			return s.telegram
+		},
+		"slack-channel": func() inputlayer.Adapter {
+			s.slack = inputchannels.NewSlackAdapter(s.mainRuntime.Config.Channels.Slack, s.appendEvent)
+			return s.slack
+		},
+		"discord-channel": func() inputlayer.Adapter {
+			s.discord = inputchannels.NewDiscordAdapter(s.mainRuntime.Config.Channels.Discord, s.appendEvent)
+			return s.discord
+		},
+		"whatsapp-channel": func() inputlayer.Adapter {
+			s.whatsapp = inputchannels.NewWhatsAppAdapter(s.mainRuntime.Config.Channels.WhatsApp, s.appendEvent)
+			return s.whatsapp
+		},
+		"signal-channel": func() inputlayer.Adapter {
+			s.signal = inputchannels.NewSignalAdapter(s.mainRuntime.Config.Channels.Signal, s.appendEvent)
+			return s.signal
+		},
+	}
+	var adapters []inputlayer.Adapter
+	if s.plugins != nil {
+		for _, name := range s.plugins.EnabledPluginNames() {
+			if builder, ok := builders[name]; ok {
+				adapters = append(adapters, builder())
+			}
+		}
+		for _, runner := range s.plugins.ChannelRunners(s.mainRuntime.Config.Plugins.Dir) {
+			adapters = append(adapters, inputlayer.NewPluginChannelAdapter(runner, s.appendEvent))
+		}
+	}
+	if len(adapters) == 0 {
+		adapters = []inputlayer.Adapter{
+			builders["telegram-channel"](),
+			builders["slack-channel"](),
+			builders["discord-channel"](),
+			builders["whatsapp-channel"](),
+			builders["signal-channel"](),
+		}
+	}
+	s.channels = inputlayer.NewManager(adapters...)
+	s.initChannelAdvanced()
+}
+
+func (s *Server) initChannelAdvanced() {
+	botName := s.mainRuntime.Config.Agent.Name
+	if botName == "" {
+		botName = "AnyClaw"
+	}
+
+	botUserID := ""
+	if s.telegram != nil {
+		botUserID = s.mainRuntime.Config.Channels.Telegram.BotToken
+	}
+
+	secCfg := s.mainRuntime.Config.Channels.Security
+	channelPolicy := inputlayer.ChannelPolicyFromConfig(config.ChannelSecurityConfig{
+		DMPolicy:         secCfg.DMPolicy,
+		GroupPolicy:      secCfg.GroupPolicy,
+		AllowFrom:        secCfg.AllowFrom,
+		PairingEnabled:   secCfg.PairingEnabled,
+		PairingTTLHours:  secCfg.PairingTTLHours,
+		MentionGate:      secCfg.MentionGate,
+		RiskAcknowledged: s.mainRuntime.Config.Security.RiskAcknowledged,
+		DefaultDenyDM:    secCfg.DefaultDenyDM,
+	})
+
+	s.mentionGate = inputlayer.NewMentionGate(secCfg.MentionGate, botUserID, nil)
+	s.groupSecurity = inputlayer.NewGroupSecurity()
+	s.channelCmds = inputlayer.NewChannelCommands(botName)
+	s.channelPairing = inputlayer.NewChannelPairing()
+	if secCfg.PairingEnabled {
+		s.channelPairing.SetEnabled(true)
+	}
+	for _, userID := range secCfg.AllowFrom {
+		if userID = strings.TrimSpace(userID); userID != "" {
+			channelPolicy.AddAllowedUser(userID)
+		}
+	}
+
+	s.presenceMgr = inputlayer.NewPresenceManager(func(ch, userID string, presence inputlayer.PresenceInfo) {
+		s.appendEvent("channel.presence", "", map[string]any{
+			"channel": ch,
+			"user_id": userID,
+			"status":  presence.Status,
+		})
+	})
+	s.contactDir = inputlayer.NewContactDirectory()
+
+	s.channelPolicy = channelPolicy
+	s.appendEvent("security.init", "", map[string]any{
+		"dm_policy":         secCfg.DMPolicy,
+		"group_policy":      secCfg.GroupPolicy,
+		"mention_gate":      secCfg.MentionGate,
+		"pairing_enabled":   secCfg.PairingEnabled,
+		"allow_from":        len(secCfg.AllowFrom),
+		"risk_acknowledged": s.mainRuntime.Config.Security.RiskAcknowledged,
+	})
+}

--- a/pkg/gateway/gateway_channel_ingress.go
+++ b/pkg/gateway/gateway_channel_ingress.go
@@ -1,0 +1,54 @@
+package gateway
+
+import (
+	"context"
+	"strings"
+)
+
+func (s *Server) processChannelMessage(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+	source := strings.TrimSpace(meta["channel"])
+	if source == "" {
+		source = "telegram"
+	}
+	response, session, err := s.runOrCreateChannelSession(ctx, source, sessionID, message, meta)
+	if err != nil {
+		return "", "", err
+	}
+
+	if s.ttsIntegration != nil && response != "" {
+		recipient := firstNonEmpty(strings.TrimSpace(meta["chat_id"]), strings.TrimSpace(session.ReplyTarget), strings.TrimSpace(meta["reply_target"]), strings.TrimSpace(meta["user_id"]), sessionID)
+		metadata := make(map[string]any, len(meta))
+		for k, v := range meta {
+			metadata[k] = v
+		}
+		if err := s.ttsIntegration.ProcessMessage(ctx, source, recipient, response, metadata); err != nil {
+			s.appendEvent("tts.process.error", sessionID, map[string]any{"error": err.Error(), "channel": source})
+		}
+	}
+
+	return session.ID, response, nil
+}
+
+func (s *Server) processChannelMessageStream(ctx context.Context, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, error) {
+	source := strings.TrimSpace(meta["channel"])
+	if source == "" {
+		source = "telegram"
+	}
+	_, session, err := s.runOrCreateChannelSessionStream(ctx, source, sessionID, message, meta, onChunk)
+	if err != nil {
+		return "", err
+	}
+
+	if s.ttsIntegration != nil {
+		recipient := firstNonEmpty(strings.TrimSpace(meta["chat_id"]), strings.TrimSpace(session.ReplyTarget), strings.TrimSpace(meta["reply_target"]), strings.TrimSpace(meta["user_id"]), sessionID)
+		metadata := make(map[string]any, len(meta))
+		for k, v := range meta {
+			metadata[k] = v
+		}
+		if err := s.ttsIntegration.ProcessMessage(ctx, source, recipient, session.ID, metadata); err != nil {
+			s.appendEvent("tts.process.error", sessionID, map[string]any{"error": err.Error(), "channel": source})
+		}
+	}
+
+	return session.ID, nil
+}

--- a/pkg/gateway/gateway_channel_route.go
+++ b/pkg/gateway/gateway_channel_route.go
@@ -1,0 +1,54 @@
+package gateway
+
+import (
+	"context"
+
+	gatewaysurface "github.com/1024XEngineer/anyclaw/pkg/gateway/surface"
+	routeingress "github.com/1024XEngineer/anyclaw/pkg/route/ingress"
+	"github.com/1024XEngineer/anyclaw/pkg/state"
+)
+
+func (s *Server) resolveChannelRoute(source string, sessionID string, message string, meta map[string]string) (routeingress.RouteOutput, error) {
+	raw := s.surfaceService().BuildChannelRawRequest(gatewaysurface.ChannelInput{
+		Source:    source,
+		SessionID: sessionID,
+		Message:   message,
+		Meta:      meta,
+	})
+	normalized, err := s.governanceService().Accept(context.Background(), raw)
+	if err != nil {
+		return routeingress.RouteOutput{}, err
+	}
+	return s.ingressHandoffService().RouteNormalized(context.Background(), normalized)
+}
+
+func (s *Server) resolveChannelRouteDecision(source string, sessionID string, message string, meta map[string]string) routeingress.SessionRoute {
+	routed, err := s.resolveChannelRoute(source, sessionID, message, meta)
+	if err != nil {
+		return routeingress.SessionRoute{}
+	}
+	return routed.Request.Route.Session.LegacySessionRoute()
+}
+
+func (s *Server) ingressService() *routeingress.Service {
+	if s == nil {
+		return nil
+	}
+	return s.ingress
+}
+
+func (s *Server) runOrCreateChannelSession(ctx context.Context, source string, sessionID string, message string, meta map[string]string) (string, *state.Session, error) {
+	routed, err := s.resolveChannelRoute(source, sessionID, message, meta)
+	if err != nil {
+		return "", nil, err
+	}
+	return s.channelBridgeService().RunRouted(ctx, source, sessionID, message, routed, meta)
+}
+
+func (s *Server) runOrCreateChannelSessionStream(ctx context.Context, source string, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, *state.Session, error) {
+	routed, err := s.resolveChannelRoute(source, sessionID, message, meta)
+	if err != nil {
+		return "", nil, err
+	}
+	return s.channelBridgeService().RunRoutedStream(ctx, source, sessionID, message, routed, meta, onChunk)
+}

--- a/pkg/gateway/gateway_channel_runtime.go
+++ b/pkg/gateway/gateway_channel_runtime.go
@@ -1,0 +1,60 @@
+package gateway
+
+import (
+	"context"
+
+	inputlayer "github.com/1024XEngineer/anyclaw/pkg/input"
+)
+
+func (s *Server) runChannels(ctx context.Context) {
+	if s.channels == nil {
+		return
+	}
+	handler := s.processChannelMessage
+	handler = s.mentionGate.Wrap(handler)
+	handler = s.groupSecurity.Wrap(handler)
+	handler = s.channelPairing.Wrap(handler)
+	handler = s.channelCmds.Wrap(handler)
+	handler = s.contactDir.Wrap(handler)
+	handler = s.presenceMgr.Wrap(handler)
+	if s.sttIntegration != nil {
+		handler = s.sttIntegration.WrapInboundHandler(handler)
+	}
+	s.channels.Run(ctx, handler)
+	s.runStreamChannels(ctx)
+}
+
+func (s *Server) runStreamChannels(ctx context.Context) {
+	for _, adapter := range s.getStreamAdapters() {
+		if !adapter.Enabled() {
+			continue
+		}
+		go func(sa inputlayer.StreamAdapter) {
+			handler := s.processChannelMessageStream
+			handler = s.mentionGate.WrapStream(handler)
+			handler = s.groupSecurity.WrapStream(handler)
+			handler = s.channelPairing.WrapStream(handler)
+			handler = s.channelCmds.WrapStream(handler)
+			handler = s.contactDir.WrapStream(handler)
+			handler = s.presenceMgr.WrapStream(handler)
+			if s.sttIntegration != nil {
+				handler = s.sttIntegration.WrapStreamInboundHandler(handler)
+			}
+			_ = sa.RunStream(ctx, handler)
+		}(adapter)
+	}
+}
+
+func (s *Server) getStreamAdapters() []inputlayer.StreamAdapter {
+	var adapters []inputlayer.StreamAdapter
+	if s.telegram != nil && s.mainRuntime.Config.Channels.Telegram.StreamReply {
+		adapters = append(adapters, s.telegram)
+	}
+	if s.discord != nil && s.mainRuntime.Config.Channels.Discord.StreamReply {
+		adapters = append(adapters, s.discord)
+	}
+	if s.slack != nil && s.mainRuntime.Config.Channels.Slack.StreamReply {
+		adapters = append(adapters, s.slack)
+	}
+	return adapters
+}

--- a/pkg/gateway/gateway_channel_session_service.go
+++ b/pkg/gateway/gateway_channel_session_service.go
@@ -1,0 +1,9 @@
+package gateway
+
+import (
+	routeingress "github.com/1024XEngineer/anyclaw/pkg/route/ingress"
+)
+
+func (s *Server) ensureChannelSession(source string, sessionID string, routed routeingress.RouteOutput, meta map[string]string, streaming bool) (string, error) {
+	return s.channelBridgeService().EnsureSession(source, sessionID, routed, meta, streaming)
+}

--- a/pkg/gateway/gateway_chat_ingress.go
+++ b/pkg/gateway/gateway_chat_ingress.go
@@ -1,0 +1,42 @@
+package gateway
+
+import (
+	"context"
+
+	gatewaycommands "github.com/1024XEngineer/anyclaw/pkg/gateway/commands"
+	gatewaysurface "github.com/1024XEngineer/anyclaw/pkg/gateway/surface"
+	sessionrunner "github.com/1024XEngineer/anyclaw/pkg/runtime/sessionrunner"
+	"github.com/1024XEngineer/anyclaw/pkg/state"
+)
+
+func (s *Server) runChatIngressMessage(ctx context.Context, source string, req gatewaycommands.ChatSendRequest, requestedAgentName string) (string, *state.Session, error) {
+	raw := s.surfaceService().BuildChatRawRequest(gatewaysurface.ChatIngressInput{
+		Source:             source,
+		Request:            req,
+		RequestedAgentName: requestedAgentName,
+	})
+	normalized, err := s.governanceService().Accept(ctx, raw)
+	if err != nil {
+		return "", nil, err
+	}
+	routed, err := s.ingressHandoffService().RouteNormalized(ctx, normalized)
+	if err != nil {
+		return "", nil, err
+	}
+	sessionID := routed.Request.Route.Session.SessionID
+	if sessionID == "" {
+		sessionID = req.SessionID
+	}
+	if sessionID == "" {
+		return "", nil, nil
+	}
+	if routed.Request.Route.Session.Created {
+		if session, ok := s.sessions.Get(sessionID); ok && session != nil {
+			s.appendEvent("session.created", session.ID, sessionCreatedEventPayload(session))
+		}
+	}
+	return s.sessionBridgeService().RunMessage(ctx, sessionID, req.Title, req.Message, sessionrunner.RunOptions{
+		Source:  source,
+		Channel: source,
+	})
+}

--- a/pkg/gateway/gateway_chat_v1_api.go
+++ b/pkg/gateway/gateway_chat_v1_api.go
@@ -1,0 +1,76 @@
+package gateway
+
+import (
+	"errors"
+	"net/http"
+
+	gatewaycommands "github.com/1024XEngineer/anyclaw/pkg/gateway/commands"
+	taskrunner "github.com/1024XEngineer/anyclaw/pkg/runtime/taskrunner"
+)
+
+func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	req, commandReq, err := s.surfaceService().DecodeHTTPChatSend(r)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+		return
+	}
+	if err := gatewaycommands.ValidateChatSend(req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	dispatch, err := s.commandIntakeService().Dispatch(commandReq)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	agentName, err := s.mainEntryPolicy().NormalizeRequestedAgent(req.Agent, req.Assistant)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if req.SessionID == "" {
+		orgID, projectID, workspaceID := req.OrgID, req.ProjectID, req.WorkspaceID
+		org, project, workspace, err := s.validateResourceSelection(orgID, projectID, workspaceID)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		if !HasHierarchyAccess(UserFromContext(r.Context()), org.ID, project.ID, workspace.ID) {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_org": org.ID, "required_project": project.ID, "required_workspace": workspace.ID})
+			return
+		}
+		req.OrgID = org.ID
+		req.ProjectID = project.ID
+		req.WorkspaceID = workspace.ID
+	}
+
+	response, updatedSession, err := s.runChatIngressMessage(r.Context(), "api", req, agentName)
+	if err != nil {
+		if errors.Is(err, taskrunner.ErrTaskWaitingApproval) {
+			sessionID := req.SessionID
+			if updatedSession != nil {
+				sessionID = updatedSession.ID
+			}
+			s.appendAudit(UserFromContext(r.Context()), "chat.send", sessionID, map[string]any{
+				"message_length": len(req.Message),
+				"status":         "waiting_approval",
+				"command_kind":   dispatch.Kind,
+				"command_target": dispatch.Target,
+			})
+			writeJSON(w, http.StatusAccepted, s.sessionApprovalResponse(sessionID))
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	s.appendAudit(UserFromContext(r.Context()), "chat.send", updatedSession.ID, map[string]any{
+		"message_length": len(req.Message),
+		"command_kind":   dispatch.Kind,
+		"command_target": dispatch.Target,
+	})
+	writeJSON(w, http.StatusOK, map[string]any{"response": response, "session": updatedSession})
+}

--- a/pkg/gateway/gateway_chat_v2_api.go
+++ b/pkg/gateway/gateway_chat_v2_api.go
@@ -1,0 +1,100 @@
+package gateway
+
+import (
+	"net/http"
+	"strings"
+
+	gatewaycommands "github.com/1024XEngineer/anyclaw/pkg/gateway/commands"
+)
+
+func (s *Server) handleV2Chat(w http.ResponseWriter, r *http.Request) {
+	if s.chatModule == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "chat not available"})
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	req, commandReq, err := s.surfaceService().DecodeHTTPV2Chat(r)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+		return
+	}
+
+	if err := gatewaycommands.ValidateV2Chat(req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	dispatch, err := s.commandIntakeService().Dispatch(commandReq)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if dispatch.Kind != "ingress" || dispatch.Target != "ingress" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unexpected command dispatch"})
+		return
+	}
+
+	resp, err := s.chatModule.Chat(r.Context(), req)
+	if err != nil {
+		code := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "not found") {
+			code = http.StatusNotFound
+		}
+		writeJSON(w, code, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleV2ChatSessions(w http.ResponseWriter, r *http.Request) {
+	if s.chatModule == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "chat not available"})
+		return
+	}
+
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	sessions := s.chatModule.ListSessions()
+	writeJSON(w, http.StatusOK, sessions)
+}
+
+func (s *Server) handleV2ChatSessionByID(w http.ResponseWriter, r *http.Request) {
+	if s.chatModule == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "chat not available"})
+		return
+	}
+
+	sessionID := strings.TrimPrefix(r.URL.Path, "/v2/chat/sessions/")
+	if sessionID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "session id required"})
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		history, err := s.chatModule.GetSessionHistory(sessionID)
+		if err != nil {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, history)
+
+	case http.MethodDelete:
+		if err := s.chatModule.DeleteSession(sessionID); err != nil {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+
+	default:
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+	}
+}

--- a/pkg/gateway/gateway_config_api.go
+++ b/pkg/gateway/gateway_config_api.go
@@ -1,0 +1,154 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+func (s *Server) handleConfigAPI(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		if !HasPermission(UserFromContext(r.Context()), "config.read") {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_permission": "config.read"})
+			return
+		}
+		s.appendAudit(UserFromContext(r.Context()), "config.read", "config", nil)
+		writeJSON(w, http.StatusOK, s.mainRuntime.Config)
+	case http.MethodPost:
+		var cfg map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&cfg); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+			return
+		}
+		s.applyLLMConfigPatch(cfg)
+		if err := s.applyChannelRoutingPatch(cfg); err != nil {
+			if duplicateErr, ok := err.(*duplicateRoutingRuleError); ok {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": duplicateErr.Error(), "details": duplicateErr.key})
+				return
+			}
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		if err := s.mainRuntime.Config.Save(s.mainRuntime.ConfigPath); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		s.appendAudit(UserFromContext(r.Context()), "config.write", "config", nil)
+		writeJSON(w, http.StatusOK, s.mainRuntime.Config)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) applyLLMConfigPatch(cfg map[string]any) {
+	llmCfg, ok := cfg["llm"].(map[string]any)
+	if !ok {
+		return
+	}
+	if provider, ok := llmCfg["provider"].(string); ok {
+		s.mainRuntime.Config.LLM.Provider = provider
+	}
+	if model, ok := llmCfg["model"].(string); ok {
+		s.mainRuntime.Config.LLM.Model = model
+	}
+}
+
+func (s *Server) applyChannelRoutingPatch(cfg map[string]any) error {
+	channels, ok := cfg["channels"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	routing, ok := channels["routing"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	if mode, ok := routing["mode"].(string); ok {
+		s.mainRuntime.Config.Channels.Routing.Mode = mode
+	}
+	rawRules, ok := routing["rules"].([]any)
+	if !ok {
+		return nil
+	}
+	rules, err := parseChannelRoutingRules(rawRules)
+	if err != nil {
+		return err
+	}
+	s.mainRuntime.Config.Channels.Routing.Rules = rules
+	return nil
+}
+
+func parseChannelRoutingRules(rawRules []any) ([]config.ChannelRoutingRule, error) {
+	rules := make([]config.ChannelRoutingRule, 0, len(rawRules))
+	seen := map[string]bool{}
+	for _, item := range rawRules {
+		ruleMap, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		rule := config.ChannelRoutingRule{}
+		if v, ok := ruleMap["channel"].(string); ok {
+			rule.Channel = v
+		}
+		if v, ok := ruleMap["match"].(string); ok {
+			rule.Match = v
+		}
+		if v, ok := ruleMap["session_mode"].(string); ok {
+			rule.SessionMode = v
+		}
+		if v, ok := ruleMap["session_id"].(string); ok {
+			rule.SessionID = v
+		}
+		if v, ok := ruleMap["queue_mode"].(string); ok {
+			rule.QueueMode = v
+		}
+		if v, ok := ruleMap["reply_back"].(bool); ok {
+			replyBack := v
+			rule.ReplyBack = &replyBack
+		}
+		if v, ok := ruleMap["title_prefix"].(string); ok {
+			rule.TitlePrefix = v
+		}
+		if v, ok := ruleMap["agent"].(string); ok {
+			rule.Agent = v
+		}
+		if v, ok := ruleMap["org"].(string); ok {
+			rule.Org = v
+		}
+		if v, ok := ruleMap["project"].(string); ok {
+			rule.Project = v
+		}
+		if v, ok := ruleMap["workspace"].(string); ok {
+			rule.Workspace = v
+		}
+		if v, ok := ruleMap["workspace_ref"].(string); ok {
+			rule.WorkspaceRef = v
+		}
+		conflictKey := strings.Join([]string{
+			rule.Channel,
+			rule.Match,
+			rule.SessionMode,
+			rule.SessionID,
+			rule.QueueMode,
+			rule.TitlePrefix,
+			strconv.FormatBool(rule.ReplyBack != nil && *rule.ReplyBack),
+		}, "|")
+		if seen[conflictKey] {
+			return nil, &duplicateRoutingRuleError{key: conflictKey}
+		}
+		seen[conflictKey] = true
+		rules = append(rules, rule)
+	}
+	return rules, nil
+}
+
+type duplicateRoutingRuleError struct {
+	key string
+}
+
+func (e *duplicateRoutingRuleError) Error() string {
+	return "duplicate routing rule"
+}

--- a/pkg/gateway/gateway_control_plane_agent_bindings_api.go
+++ b/pkg/gateway/gateway_control_plane_agent_bindings_api.go
@@ -1,0 +1,79 @@
+package gateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+func (s *Server) handleAgentBindings(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		if !HasPermission(UserFromContext(r.Context()), "config.read") && !HasPermission(UserFromContext(r.Context()), "config.write") {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_permission": "config.read"})
+			return
+		}
+		writeJSON(w, http.StatusOK, s.listAgentBindingViews())
+	case http.MethodPost:
+		if !HasPermission(UserFromContext(r.Context()), "config.write") {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_permission": "config.write"})
+			return
+		}
+		var req struct {
+			Agent       string   `json:"agent"`
+			Agents      []string `json:"agents"`
+			ProviderRef string   `json:"provider_ref"`
+			Model       *string  `json:"model"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+			return
+		}
+		if strings.TrimSpace(req.Agent) != "" {
+			req.Agents = append(req.Agents, req.Agent)
+		}
+		if len(req.Agents) == 0 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "agent or agents is required"})
+			return
+		}
+		providerRef := strings.TrimSpace(req.ProviderRef)
+		if providerRef != "" {
+			if _, ok := s.mainRuntime.Config.FindProviderProfile(providerRef); !ok {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "provider not found"})
+				return
+			}
+		}
+		model := ""
+		modelProvided := req.Model != nil
+		if modelProvided {
+			model = strings.TrimSpace(*req.Model)
+		}
+		updated := make([]agentBindingView, 0, len(req.Agents))
+		for _, name := range req.Agents {
+			profile, ok := s.mainRuntime.Config.FindAgentProfile(name)
+			if !ok {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": fmt.Sprintf("agent not found: %s", name)})
+				return
+			}
+			profile.ProviderRef = providerRef
+			if modelProvided {
+				profile.DefaultModel = model
+			}
+			if err := s.mainRuntime.Config.UpsertAgentProfile(profile); err != nil {
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+				return
+			}
+			s.runtimePool.InvalidateByAgent(profile.Name)
+			updated = append(updated, s.buildAgentBindingView(profile))
+		}
+		if err := s.mainRuntime.Config.Save(s.mainRuntime.ConfigPath); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		s.appendAudit(UserFromContext(r.Context()), "agent-bindings.write", strings.Join(req.Agents, ","), map[string]any{"provider_ref": providerRef, "model": model})
+		writeJSON(w, http.StatusOK, updated)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}

--- a/pkg/gateway/gateway_control_plane_agent_views.go
+++ b/pkg/gateway/gateway_control_plane_agent_views.go
@@ -1,0 +1,157 @@
+package gateway
+
+import (
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+type agentProfileView struct {
+	Name            string                 `json:"name"`
+	Description     string                 `json:"description"`
+	Role            string                 `json:"role,omitempty"`
+	Persona         string                 `json:"persona,omitempty"`
+	AvatarPreset    string                 `json:"avatar_preset,omitempty"`
+	AvatarDataURL   string                 `json:"avatar_data_url,omitempty"`
+	WorkingDir      string                 `json:"working_dir,omitempty"`
+	PermissionLevel string                 `json:"permission_level,omitempty"`
+	ProviderRef     string                 `json:"provider_ref,omitempty"`
+	ProviderName    string                 `json:"provider_name,omitempty"`
+	ProviderType    string                 `json:"provider_type,omitempty"`
+	Provider        string                 `json:"provider,omitempty"`
+	DefaultModel    string                 `json:"default_model,omitempty"`
+	Enabled         bool                   `json:"enabled"`
+	Active          bool                   `json:"active"`
+	Personality     config.PersonalitySpec `json:"personality,omitempty"`
+	Skills          []config.AgentSkillRef `json:"skills,omitempty"`
+}
+
+type agentBindingView struct {
+	Name                string                 `json:"name"`
+	Description         string                 `json:"description"`
+	Role                string                 `json:"role,omitempty"`
+	WorkingDir          string                 `json:"working_dir"`
+	PermissionLevel     string                 `json:"permission_level"`
+	Enabled             bool                   `json:"enabled"`
+	ProviderRef         string                 `json:"provider_ref,omitempty"`
+	ResolvedProviderRef string                 `json:"resolved_provider_ref,omitempty"`
+	ProviderName        string                 `json:"provider_name"`
+	ProviderType        string                 `json:"provider_type,omitempty"`
+	Provider            string                 `json:"provider"`
+	Model               string                 `json:"model"`
+	InheritsDefault     bool                   `json:"inherits_default,omitempty"`
+	RoutingMode         string                 `json:"routing_mode,omitempty"`
+	Health              providerHealth         `json:"health"`
+	Skills              []config.AgentSkillRef `json:"skills,omitempty"`
+	Active              bool                   `json:"active"`
+}
+
+func (s *Server) listAgentBindingViews() []agentBindingView {
+	if s == nil || s.mainRuntime == nil || s.mainRuntime.Config == nil {
+		return nil
+	}
+	items := make([]agentBindingView, 0, len(s.mainRuntime.Config.Agent.Profiles))
+	for _, profile := range s.mainRuntime.Config.Agent.Profiles {
+		items = append(items, s.buildAgentBindingView(profile))
+	}
+	return items
+}
+
+func (s *Server) buildAgentBindingView(profile config.AgentProfile) agentBindingView {
+	view := agentBindingView{
+		Name:            profile.Name,
+		Description:     profile.Description,
+		Role:            profile.Role,
+		WorkingDir:      profile.WorkingDir,
+		PermissionLevel: profile.PermissionLevel,
+		Enabled:         profile.IsEnabled(),
+		ProviderRef:     profile.ProviderRef,
+		Model:           firstNonEmpty(profile.DefaultModel, s.mainRuntime.Config.LLM.Model),
+		Skills:          append([]config.AgentSkillRef{}, profile.Skills...),
+		Active:          s.mainRuntime.Config.IsCurrentAgentProfile(profile.Name),
+		RoutingMode:     "override",
+	}
+	if provider, ok := s.mainRuntime.Config.FindProviderProfile(profile.ProviderRef); ok {
+		view.ResolvedProviderRef = provider.ID
+		view.ProviderName = provider.Name
+		view.ProviderType = provider.Type
+		view.Provider = provider.Provider
+		if strings.TrimSpace(profile.DefaultModel) == "" {
+			view.Model = firstNonEmpty(provider.DefaultModel, s.mainRuntime.Config.LLM.Model)
+		}
+		view.Health = quickProviderHealth(provider)
+	} else if provider, ok := s.currentDefaultProvider(); ok {
+		view.ResolvedProviderRef = provider.ID
+		view.ProviderName = provider.Name
+		view.ProviderType = provider.Type
+		view.Provider = provider.Provider
+		view.InheritsDefault = true
+		view.RoutingMode = "inherit"
+		if strings.TrimSpace(profile.DefaultModel) == "" {
+			view.Model = firstNonEmpty(provider.DefaultModel, s.mainRuntime.Config.LLM.Model)
+		}
+		view.Health = quickProviderHealth(provider)
+	} else {
+		view.ProviderName = "Legacy Global"
+		view.Provider = s.mainRuntime.Config.LLM.Provider
+		view.ProviderType = "global"
+		view.InheritsDefault = true
+		view.RoutingMode = "legacy"
+		view.Health = providerHealth{OK: true, Status: "global_default", Message: "Using legacy global runtime provider."}
+	}
+	return view
+}
+
+func (s *Server) buildAgentProfileView(profile config.AgentProfile) agentProfileView {
+	personality := profile.Personality
+	if strings.TrimSpace(personality.Template) == "" &&
+		len(personality.Traits) == 0 &&
+		strings.TrimSpace(personality.Tone) == "" &&
+		strings.TrimSpace(personality.Style) == "" {
+		personality = config.DefaultPersonalitySpec()
+	}
+	providerName := ""
+	providerType := ""
+	providerRuntime := ""
+	if provider, ok := s.mainRuntime.Config.FindProviderProfile(profile.ProviderRef); ok {
+		providerName = provider.Name
+		providerType = provider.Type
+		providerRuntime = provider.Provider
+	}
+	return agentProfileView{
+		Name:            profile.Name,
+		Description:     profile.Description,
+		Role:            profile.Role,
+		Persona:         profile.Persona,
+		AvatarPreset:    profile.AvatarPreset,
+		AvatarDataURL:   profile.AvatarDataURL,
+		WorkingDir:      profile.WorkingDir,
+		PermissionLevel: profile.PermissionLevel,
+		ProviderRef:     profile.ProviderRef,
+		ProviderName:    providerName,
+		ProviderType:    providerType,
+		Provider:        firstNonEmpty(providerRuntime, s.mainRuntime.Config.LLM.Provider),
+		DefaultModel:    profile.DefaultModel,
+		Enabled:         profile.IsEnabled(),
+		Active:          s.mainRuntime.Config.IsCurrentAgentProfile(profile.Name),
+		Personality:     personality,
+		Skills:          append([]config.AgentSkillRef{}, profile.Skills...),
+	}
+}
+
+func (s *Server) listAgentViews() []agentProfileView {
+	items := make([]agentProfileView, 0, len(s.mainRuntime.Config.Agent.Profiles))
+	for _, profile := range s.mainRuntime.Config.Agent.Profiles {
+		items = append(items, s.buildAgentProfileView(profile))
+	}
+	return items
+}
+
+func (s *Server) getAgentView(name string) (agentProfileView, bool) {
+	for _, profile := range s.mainRuntime.Config.Agent.Profiles {
+		if profile.Name == name {
+			return s.buildAgentProfileView(profile), true
+		}
+	}
+	return agentProfileView{}, false
+}

--- a/pkg/gateway/gateway_control_plane_agents_api.go
+++ b/pkg/gateway/gateway_control_plane_agents_api.go
@@ -1,0 +1,133 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+func (s *Server) handleAgents(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		if !HasPermission(UserFromContext(r.Context()), "config.read") && !HasPermission(UserFromContext(r.Context()), "config.write") {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_permission": "config.read"})
+			return
+		}
+		s.appendAudit(UserFromContext(r.Context()), "agents.read", "agents", nil)
+		writeJSON(w, http.StatusOK, s.listAgentViews())
+	case http.MethodPost:
+		if !HasPermission(UserFromContext(r.Context()), "config.write") {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_permission": "config.write"})
+			return
+		}
+		var req struct {
+			Name            string                 `json:"name"`
+			Description     string                 `json:"description"`
+			Role            string                 `json:"role"`
+			Persona         string                 `json:"persona"`
+			AvatarPreset    *string                `json:"avatar_preset"`
+			AvatarDataURL   *string                `json:"avatar_data_url"`
+			WorkingDir      string                 `json:"working_dir"`
+			PermissionLevel string                 `json:"permission_level"`
+			ProviderRef     string                 `json:"provider_ref"`
+			DefaultModel    string                 `json:"default_model"`
+			Enabled         *bool                  `json:"enabled"`
+			Personality     config.PersonalitySpec `json:"personality"`
+			Skills          []config.AgentSkillRef `json:"skills"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+			return
+		}
+		profile := config.AgentProfile{
+			Name:            req.Name,
+			Description:     req.Description,
+			Role:            req.Role,
+			Persona:         req.Persona,
+			WorkingDir:      req.WorkingDir,
+			PermissionLevel: req.PermissionLevel,
+			ProviderRef:     req.ProviderRef,
+			DefaultModel:    req.DefaultModel,
+			Enabled:         req.Enabled,
+			Personality:     req.Personality,
+			Skills:          req.Skills,
+		}
+		if req.AvatarPreset != nil {
+			profile.AvatarPreset = *req.AvatarPreset
+		}
+		if req.AvatarDataURL != nil {
+			profile.AvatarDataURL = *req.AvatarDataURL
+		}
+		if existing, ok := s.mainRuntime.Config.FindAgentProfile(profile.Name); ok {
+			if req.AvatarPreset == nil {
+				profile.AvatarPreset = existing.AvatarPreset
+			}
+			if req.AvatarDataURL == nil {
+				profile.AvatarDataURL = existing.AvatarDataURL
+			}
+			profile.Domain = existing.Domain
+			profile.Expertise = append([]string{}, existing.Expertise...)
+			profile.SystemPrompt = existing.SystemPrompt
+			if strings.TrimSpace(profile.Personality.Template) == "" &&
+				strings.TrimSpace(profile.Personality.Tone) == "" &&
+				strings.TrimSpace(profile.Personality.Style) == "" &&
+				strings.TrimSpace(profile.Personality.GoalOrientation) == "" &&
+				strings.TrimSpace(profile.Personality.ConstraintMode) == "" &&
+				strings.TrimSpace(profile.Personality.ResponseVerbosity) == "" &&
+				strings.TrimSpace(profile.Personality.CustomInstructions) == "" &&
+				len(profile.Personality.Traits) == 0 {
+				profile.Personality = existing.Personality
+			}
+		}
+		if profile.Enabled == nil {
+			profile.Enabled = config.BoolPtr(true)
+		}
+		if strings.TrimSpace(profile.PermissionLevel) == "" {
+			profile.PermissionLevel = "limited"
+		}
+		if strings.TrimSpace(profile.ProviderRef) != "" {
+			if _, ok := s.mainRuntime.Config.FindProviderProfile(profile.ProviderRef); !ok {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "provider not found"})
+				return
+			}
+		}
+		if err := s.mainRuntime.Config.UpsertAgentProfile(profile); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		if err := s.mainRuntime.Config.Save(s.mainRuntime.ConfigPath); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		s.appendAudit(UserFromContext(r.Context()), "agents.write", profile.Name, map[string]any{"enabled": profile.IsEnabled()})
+		writeJSON(w, http.StatusOK, map[string]any{"status": "ok"})
+	case http.MethodDelete:
+		if !HasPermission(UserFromContext(r.Context()), "config.write") {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_permission": "config.write"})
+			return
+		}
+		name := strings.TrimSpace(r.URL.Query().Get("name"))
+		if name == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
+			return
+		}
+		if !s.mainRuntime.Config.DeleteAgentProfile(name) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "agent not found"})
+			return
+		}
+		if err := s.mainRuntime.Config.Save(s.mainRuntime.ConfigPath); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		s.appendAudit(UserFromContext(r.Context()), "agents.delete", name, nil)
+		writeJSON(w, http.StatusOK, map[string]any{"status": "deleted"})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleAssistants(w http.ResponseWriter, r *http.Request) {
+	s.handleAgents(w, r)
+}

--- a/pkg/gateway/gateway_control_plane_provider_api.go
+++ b/pkg/gateway/gateway_control_plane_provider_api.go
@@ -1,0 +1,119 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+func (s *Server) handleProviders(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		if !HasPermission(UserFromContext(r.Context()), "config.read") && !HasPermission(UserFromContext(r.Context()), "config.write") {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_permission": "config.read"})
+			return
+		}
+		writeJSON(w, http.StatusOK, s.listProviderViews())
+	case http.MethodPost:
+		s.handleProviderUpsert(w, r)
+	case http.MethodDelete:
+		s.handleProviderDelete(w, r)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleProviderUpsert(w http.ResponseWriter, r *http.Request) {
+	if !HasPermission(UserFromContext(r.Context()), "config.write") {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_permission": "config.write"})
+		return
+	}
+	var provider config.ProviderProfile
+	if err := json.NewDecoder(r.Body).Decode(&provider); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+		return
+	}
+	if provider.Enabled == nil {
+		provider.Enabled = config.BoolPtr(true)
+	}
+	existing, hadExisting := s.mainRuntime.Config.FindProviderProfile(firstNonEmpty(provider.ID, provider.Name))
+	if hadExisting {
+		mergeProviderSecretsAndExtra(&provider, existing)
+	}
+	wasDefaultRef := strings.TrimSpace(s.mainRuntime.Config.LLM.DefaultProviderRef)
+	if err := s.mainRuntime.Config.UpsertProviderProfile(provider); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	updated, _ := s.mainRuntime.Config.FindProviderProfile(firstNonEmpty(provider.ID, provider.Name))
+	if strings.TrimSpace(s.mainRuntime.Config.LLM.DefaultProviderRef) == "" && updated.IsEnabled() {
+		_ = s.mainRuntime.Config.SetDefaultProviderProfile(updated.ID)
+	} else if strings.EqualFold(wasDefaultRef, firstNonEmpty(existing.ID, updated.ID)) || strings.EqualFold(wasDefaultRef, updated.ID) {
+		_ = s.mainRuntime.Config.SetDefaultProviderProfile(updated.ID)
+	}
+	if err := s.mainRuntime.Config.Save(s.mainRuntime.ConfigPath); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if strings.EqualFold(strings.TrimSpace(s.mainRuntime.Config.LLM.DefaultProviderRef), strings.TrimSpace(updated.ID)) {
+		if s.runtimePool != nil {
+			s.runtimePool.InvalidateAll()
+		}
+	} else if hadExisting {
+		s.invalidateProviderConsumers(existing.ID)
+	}
+	s.appendAudit(UserFromContext(r.Context()), "providers.write", updated.ID, nil)
+	writeJSON(w, http.StatusOK, providerToView(updated, s.mainRuntime.Config.Agent.Profiles, s.mainRuntime.Config.LLM.DefaultProviderRef))
+}
+
+func (s *Server) handleProviderDelete(w http.ResponseWriter, r *http.Request) {
+	if !HasPermission(UserFromContext(r.Context()), "config.write") {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_permission": "config.write"})
+		return
+	}
+	id := strings.TrimSpace(r.URL.Query().Get("id"))
+	if id == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "id is required"})
+		return
+	}
+	existing, ok := s.mainRuntime.Config.FindProviderProfile(id)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "provider not found"})
+		return
+	}
+	if strings.EqualFold(strings.TrimSpace(s.mainRuntime.Config.LLM.DefaultProviderRef), strings.TrimSpace(existing.ID)) && len(s.mainRuntime.Config.Providers) > 1 {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": "switch the default provider before deleting it"})
+		return
+	}
+	if !s.mainRuntime.Config.DeleteProviderProfile(id) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "provider not found"})
+		return
+	}
+	if strings.EqualFold(strings.TrimSpace(s.mainRuntime.Config.LLM.DefaultProviderRef), strings.TrimSpace(existing.ID)) {
+		s.mainRuntime.Config.LLM.DefaultProviderRef = ""
+	}
+	if err := s.mainRuntime.Config.Save(s.mainRuntime.ConfigPath); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	s.invalidateProviderConsumers(existing.ID)
+	s.appendAudit(UserFromContext(r.Context()), "providers.delete", existing.ID, nil)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted", "id": existing.ID})
+}
+
+func mergeProviderSecretsAndExtra(provider *config.ProviderProfile, existing config.ProviderProfile) {
+	if provider == nil {
+		return
+	}
+	if strings.TrimSpace(provider.APIKey) == "" {
+		provider.APIKey = existing.APIKey
+	}
+	if len(provider.Extra) == 0 && len(existing.Extra) > 0 {
+		provider.Extra = map[string]string{}
+		for k, v := range existing.Extra {
+			provider.Extra[k] = v
+		}
+	}
+}

--- a/pkg/gateway/gateway_control_plane_provider_default_api.go
+++ b/pkg/gateway/gateway_control_plane_provider_default_api.go
@@ -1,0 +1,35 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func (s *Server) handleDefaultProvider(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !HasPermission(UserFromContext(r.Context()), "config.write") {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_permission": "config.write"})
+		return
+	}
+	var req struct {
+		ProviderRef string `json:"provider_ref"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+		return
+	}
+	provider, err := s.applyDefaultProvider(req.ProviderRef)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if err := s.mainRuntime.Config.Save(s.mainRuntime.ConfigPath); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	s.appendAudit(UserFromContext(r.Context()), "providers.default", provider.ID, nil)
+	writeJSON(w, http.StatusOK, providerToView(provider, s.mainRuntime.Config.Agent.Profiles, s.mainRuntime.Config.LLM.DefaultProviderRef))
+}

--- a/pkg/gateway/gateway_control_plane_provider_health.go
+++ b/pkg/gateway/gateway_control_plane_provider_health.go
@@ -1,0 +1,102 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+func quickProviderHealth(provider config.ProviderProfile) providerHealth {
+	if !provider.IsEnabled() {
+		return providerHealth{Status: "disabled", Message: "Provider is disabled."}
+	}
+	if strings.TrimSpace(provider.Provider) == "" {
+		return providerHealth{Status: "invalid", Message: "Missing runtime provider type."}
+	}
+	if providerRequiresAPIKey(provider.Provider) && strings.TrimSpace(provider.APIKey) == "" {
+		return providerHealth{Status: "missing_key", Message: "API key required."}
+	}
+	if base := strings.TrimSpace(provider.BaseURL); base != "" {
+		if _, err := url.ParseRequestURI(base); err != nil {
+			return providerHealth{Status: "invalid_base_url", Message: "Base URL is not a valid URL."}
+		}
+	}
+	return providerHealth{OK: true, Status: "ready", Message: "Ready to use."}
+}
+
+func activeProviderTest(ctx context.Context, provider config.ProviderProfile) providerHealth {
+	initial := quickProviderHealth(provider)
+	if !initial.OK && initial.Status != "ready" {
+		return initial
+	}
+	baseURL := strings.TrimSpace(provider.BaseURL)
+	providerName := strings.TrimSpace(strings.ToLower(provider.Provider))
+	if baseURL == "" {
+		if strings.EqualFold(providerName, "ollama") {
+			baseURL = "http://127.0.0.1:11434"
+		} else {
+			return providerHealth{OK: true, Status: "ready", Message: "Using provider default endpoint."}
+		}
+	}
+	parsed, err := url.ParseRequestURI(baseURL)
+	if err != nil {
+		return providerHealth{Status: "invalid_base_url", Message: "Base URL is not a valid URL."}
+	}
+
+	targetURL := strings.TrimRight(parsed.String(), "/")
+	switch providerName {
+	case "ollama":
+		targetURL += "/api/tags"
+	case "compatible", "qwen":
+		targetURL += "/models"
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
+	if err != nil {
+		return providerHealth{Status: "request_error", Message: err.Error()}
+	}
+	if apiKey := strings.TrimSpace(provider.APIKey); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return providerHealth{Status: "unreachable", Message: err.Error()}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return providerHealth{
+			OK:         true,
+			Status:     "reachable",
+			Message:    fmt.Sprintf("Endpoint responded with HTTP %d.", resp.StatusCode),
+			HTTPStatus: resp.StatusCode,
+		}
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return providerHealth{
+			Status:     "auth_error",
+			Message:    fmt.Sprintf("Endpoint reached but authorization failed with HTTP %d.", resp.StatusCode),
+			HTTPStatus: resp.StatusCode,
+		}
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return providerHealth{
+			Status:     "endpoint_not_found",
+			Message:    "Endpoint returned HTTP 404. Check whether Base URL already contains the correct API path.",
+			HTTPStatus: resp.StatusCode,
+		}
+	}
+	return providerHealth{
+		Status:     "error",
+		Message:    fmt.Sprintf("Endpoint responded with HTTP %d.", resp.StatusCode),
+		HTTPStatus: resp.StatusCode,
+	}
+}

--- a/pkg/gateway/gateway_control_plane_provider_models.go
+++ b/pkg/gateway/gateway_control_plane_provider_models.go
@@ -1,0 +1,88 @@
+package gateway
+
+import (
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+type providerHealth struct {
+	OK         bool   `json:"ok"`
+	Status     string `json:"status"`
+	Message    string `json:"message,omitempty"`
+	HTTPStatus int    `json:"http_status,omitempty"`
+}
+
+type providerView struct {
+	ID              string         `json:"id"`
+	Name            string         `json:"name"`
+	Type            string         `json:"type,omitempty"`
+	Provider        string         `json:"provider"`
+	IsDefault       bool           `json:"is_default"`
+	BaseURL         string         `json:"base_url,omitempty"`
+	DefaultModel    string         `json:"default_model,omitempty"`
+	Capabilities    []string       `json:"capabilities,omitempty"`
+	Enabled         bool           `json:"enabled"`
+	HasAPIKey       bool           `json:"has_api_key"`
+	APIKeyPreview   string         `json:"api_key_preview,omitempty"`
+	BoundAgents     []string       `json:"bound_agents,omitempty"`
+	BoundAgentCount int            `json:"bound_agent_count"`
+	Health          providerHealth `json:"health"`
+}
+
+func providerRequiresAPIKey(provider string) bool {
+	switch strings.TrimSpace(strings.ToLower(provider)) {
+	case "ollama":
+		return false
+	default:
+		return true
+	}
+}
+
+func maskSecret(secret string) string {
+	secret = strings.TrimSpace(secret)
+	if secret == "" {
+		return ""
+	}
+	if len(secret) <= 8 {
+		return strings.Repeat("*", len(secret))
+	}
+	return secret[:4] + strings.Repeat("*", len(secret)-8) + secret[len(secret)-4:]
+}
+
+func providerToView(provider config.ProviderProfile, profiles []config.AgentProfile, defaultRef string) providerView {
+	boundAgents := make([]string, 0, len(profiles))
+	for _, profile := range profiles {
+		if strings.EqualFold(strings.TrimSpace(profile.ProviderRef), strings.TrimSpace(provider.ID)) {
+			boundAgents = append(boundAgents, profile.Name)
+		}
+	}
+	return providerView{
+		ID:              provider.ID,
+		Name:            provider.Name,
+		Type:            provider.Type,
+		Provider:        provider.Provider,
+		IsDefault:       strings.EqualFold(strings.TrimSpace(defaultRef), strings.TrimSpace(provider.ID)),
+		BaseURL:         provider.BaseURL,
+		DefaultModel:    provider.DefaultModel,
+		Capabilities:    append([]string{}, provider.Capabilities...),
+		Enabled:         provider.IsEnabled(),
+		HasAPIKey:       strings.TrimSpace(provider.APIKey) != "",
+		APIKeyPreview:   maskSecret(provider.APIKey),
+		BoundAgents:     boundAgents,
+		BoundAgentCount: len(boundAgents),
+		Health:          quickProviderHealth(provider),
+	}
+}
+
+func (s *Server) listProviderViews() []providerView {
+	if s == nil || s.mainRuntime == nil || s.mainRuntime.Config == nil {
+		return nil
+	}
+	items := make([]providerView, 0, len(s.mainRuntime.Config.Providers))
+	defaultRef := strings.TrimSpace(s.mainRuntime.Config.LLM.DefaultProviderRef)
+	for _, provider := range s.mainRuntime.Config.Providers {
+		items = append(items, providerToView(provider, s.mainRuntime.Config.Agent.Profiles, defaultRef))
+	}
+	return items
+}

--- a/pkg/gateway/gateway_control_plane_provider_runtime.go
+++ b/pkg/gateway/gateway_control_plane_provider_runtime.go
@@ -1,0 +1,65 @@
+package gateway
+
+import (
+	"fmt"
+	"strings"
+
+	llm "github.com/1024XEngineer/anyclaw/pkg/capability/models"
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+func (s *Server) currentDefaultProvider() (config.ProviderProfile, bool) {
+	if s == nil || s.mainRuntime == nil || s.mainRuntime.Config == nil {
+		return config.ProviderProfile{}, false
+	}
+	return s.mainRuntime.Config.FindDefaultProviderProfile()
+}
+
+func (s *Server) applyDefaultProvider(ref string) (config.ProviderProfile, error) {
+	if s == nil || s.mainRuntime == nil || s.mainRuntime.Config == nil {
+		return config.ProviderProfile{}, fmt.Errorf("server is not initialized")
+	}
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return config.ProviderProfile{}, fmt.Errorf("provider_ref is required")
+	}
+	provider, ok := s.mainRuntime.Config.FindProviderProfile(ref)
+	if !ok {
+		return config.ProviderProfile{}, fmt.Errorf("provider not found")
+	}
+	if !provider.IsEnabled() {
+		return config.ProviderProfile{}, fmt.Errorf("provider is disabled")
+	}
+	if !s.mainRuntime.Config.SetDefaultProviderProfile(provider.ID) {
+		return config.ProviderProfile{}, fmt.Errorf("unable to apply provider")
+	}
+	client, err := llm.NewClientWrapper(llm.Config{
+		Provider:    s.mainRuntime.Config.LLM.Provider,
+		Model:       s.mainRuntime.Config.LLM.Model,
+		APIKey:      s.mainRuntime.Config.LLM.APIKey,
+		BaseURL:     s.mainRuntime.Config.LLM.BaseURL,
+		Proxy:       s.mainRuntime.Config.LLM.Proxy,
+		MaxTokens:   s.mainRuntime.Config.LLM.MaxTokens,
+		Temperature: s.mainRuntime.Config.LLM.Temperature,
+	})
+	if err != nil {
+		return config.ProviderProfile{}, err
+	}
+	s.mainRuntime.SetLLMClient(client)
+	if s.tasks != nil {
+		s.tasks.SetPlanner(client)
+	}
+	if s.runtimePool != nil {
+		s.runtimePool.InvalidateAll()
+	}
+	updated, _ := s.mainRuntime.Config.FindProviderProfile(provider.ID)
+	return updated, nil
+}
+
+func (s *Server) invalidateProviderConsumers(providerID string) {
+	for _, profile := range s.mainRuntime.Config.Agent.Profiles {
+		if strings.EqualFold(strings.TrimSpace(profile.ProviderRef), strings.TrimSpace(providerID)) {
+			s.runtimePool.InvalidateByAgent(profile.Name)
+		}
+	}
+}

--- a/pkg/gateway/gateway_control_plane_provider_test_api.go
+++ b/pkg/gateway/gateway_control_plane_provider_test_api.go
@@ -1,0 +1,70 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+func (s *Server) handleProviderTest(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !HasPermission(UserFromContext(r.Context()), "config.write") && !HasPermission(UserFromContext(r.Context()), "config.read") {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_permission": "config.read"})
+		return
+	}
+	var provider config.ProviderProfile
+	if err := json.NewDecoder(r.Body).Decode(&provider); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+		return
+	}
+	enrichProviderForHealthTest(&provider, s.mainRuntime.Config)
+	writeJSON(w, http.StatusOK, activeProviderTest(r.Context(), provider))
+}
+
+func enrichProviderForHealthTest(provider *config.ProviderProfile, cfg *config.Config) {
+	if provider == nil || cfg == nil {
+		return
+	}
+	if strings.TrimSpace(provider.ID) == "" && strings.TrimSpace(provider.Name) != "" {
+		provider.ID = provider.Name
+	}
+	existing, ok := cfg.FindProviderProfile(firstNonEmpty(provider.ID, provider.Name))
+	if !ok {
+		return
+	}
+	if strings.TrimSpace(provider.Name) == "" {
+		provider.Name = existing.Name
+	}
+	if strings.TrimSpace(provider.Type) == "" {
+		provider.Type = existing.Type
+	}
+	if strings.TrimSpace(provider.Provider) == "" {
+		provider.Provider = existing.Provider
+	}
+	if strings.TrimSpace(provider.BaseURL) == "" {
+		provider.BaseURL = existing.BaseURL
+	}
+	if strings.TrimSpace(provider.APIKey) == "" {
+		provider.APIKey = existing.APIKey
+	}
+	if strings.TrimSpace(provider.DefaultModel) == "" {
+		provider.DefaultModel = existing.DefaultModel
+	}
+	if len(provider.Capabilities) == 0 {
+		provider.Capabilities = append([]string{}, existing.Capabilities...)
+	}
+	if provider.Enabled == nil {
+		provider.Enabled = existing.Enabled
+	}
+	if len(provider.Extra) == 0 && len(existing.Extra) > 0 {
+		provider.Extra = map[string]string{}
+		for k, v := range existing.Extra {
+			provider.Extra[k] = v
+		}
+	}
+}

--- a/pkg/gateway/gateway_cron_api.go
+++ b/pkg/gateway/gateway_cron_api.go
@@ -1,0 +1,115 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+
+	runtimeschedule "github.com/1024XEngineer/anyclaw/pkg/runtime/execution/schedule"
+)
+
+var cronScheduler *runtimeschedule.Scheduler
+var cronInitOnce sync.Once
+
+func (s *Server) initCronScheduler() {
+	cronInitOnce.Do(func() {
+		executor := s.mainRuntime.NewCronExecutor()
+		cronScheduler = runtimeschedule.NewScheduler(executor)
+
+		persister, err := runtimeschedule.NewFilePersister("")
+		if err == nil {
+			cronScheduler.SetPersister(persister)
+			_ = cronScheduler.LoadPersisted()
+		}
+
+		_ = cronScheduler.Start()
+	})
+}
+
+func (s *Server) handleCronList(w http.ResponseWriter, r *http.Request) {
+	s.initCronScheduler()
+
+	switch r.Method {
+	case http.MethodGet:
+		tasks := cronScheduler.ListTasks()
+		s.appendAudit(UserFromContext(r.Context()), "cron.read", "cron", map[string]any{"count": len(tasks)})
+		writeJSON(w, http.StatusOK, tasks)
+	case http.MethodPost:
+		var task runtimeschedule.Task
+		if err := json.NewDecoder(r.Body).Decode(&task); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+			return
+		}
+		if err := task.Validate(); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+
+		taskID, err := cronScheduler.AddTask(&task)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+
+		s.appendAudit(UserFromContext(r.Context()), "cron.create", taskID, map[string]any{"name": task.Name, "schedule": task.Schedule})
+		writeJSON(w, http.StatusCreated, map[string]string{"id": taskID})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleCronByID(w http.ResponseWriter, r *http.Request) {
+	s.initCronScheduler()
+
+	path := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/cron/"))
+	if path == "" {
+		http.Error(w, "task id required", http.StatusBadRequest)
+		return
+	}
+
+	taskID := strings.Split(path, "/")[0]
+
+	switch r.Method {
+	case http.MethodGet:
+		task, ok := cronScheduler.GetTask(taskID)
+		if !ok {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+			return
+		}
+		s.appendAudit(UserFromContext(r.Context()), "cron.read", taskID, nil)
+		writeJSON(w, http.StatusOK, task)
+	case http.MethodPut:
+		var task runtimeschedule.Task
+		if err := json.NewDecoder(r.Body).Decode(&task); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+			return
+		}
+		task.ID = taskID
+		if err := cronScheduler.UpdateTask(&task); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		s.appendAudit(UserFromContext(r.Context()), "cron.update", taskID, nil)
+		writeJSON(w, http.StatusOK, map[string]string{"status": "updated"})
+	case http.MethodDelete:
+		if err := cronScheduler.DeleteTask(taskID); err != nil {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+			return
+		}
+		s.appendAudit(UserFromContext(r.Context()), "cron.delete", taskID, nil)
+		writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleCronStats(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.initCronScheduler()
+	writeJSON(w, http.StatusOK, cronScheduler.Stats())
+}

--- a/pkg/gateway/gateway_daemon.go
+++ b/pkg/gateway/gateway_daemon.go
@@ -1,0 +1,95 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/runtime"
+)
+
+func StartDetached(mainRuntime *runtime.MainRuntime) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	if _, err := Probe(ctx, runtime.GatewayURL(mainRuntime.Config)); err == nil {
+		return fmt.Errorf("gateway already running at %s", runtime.GatewayURL(mainRuntime.Config))
+	}
+	logPath := mainRuntime.Config.Daemon.LogFile
+	if logPath == "" {
+		logPath = filepath.Join(mainRuntime.WorkDir, "gateway.log")
+	}
+	pidPath := mainRuntime.Config.Daemon.PIDFile
+	if pidPath == "" {
+		pidPath = filepath.Join(mainRuntime.WorkDir, "gateway.pid")
+	}
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
+		return err
+	}
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(os.Args[0], "gateway", "run", "--config", mainRuntime.ConfigPath)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.Stdin = nil
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	startCtx, startCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer startCancel()
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		probeCtx, probeCancel := context.WithTimeout(startCtx, time.Second)
+		_, err := Probe(probeCtx, runtime.GatewayURL(mainRuntime.Config))
+		probeCancel()
+		if err == nil {
+			pidData := []byte(strconv.Itoa(cmd.Process.Pid))
+			return os.WriteFile(pidPath, pidData, 0o644)
+		}
+		select {
+		case <-startCtx.Done():
+			return fmt.Errorf("gateway daemon failed to start within 5s; see %s", logPath)
+		case <-ticker.C:
+		}
+	}
+}
+
+func StopDetached(mainRuntime *runtime.MainRuntime) error {
+	pidPath := mainRuntime.Config.Daemon.PIDFile
+	if pidPath == "" {
+		pidPath = filepath.Join(mainRuntime.WorkDir, "gateway.pid")
+	}
+	data, err := os.ReadFile(pidPath)
+	if err != nil {
+		return err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return err
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	if err := process.Kill(); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if _, probeErr := Probe(ctx, runtime.GatewayURL(mainRuntime.Config)); probeErr != nil {
+			_ = os.Remove(pidPath)
+			return nil
+		}
+		return err
+	}
+	_ = os.Remove(pidPath)
+	return nil
+}

--- a/pkg/gateway/gateway_device_pairing_api.go
+++ b/pkg/gateway/gateway_device_pairing_api.go
@@ -1,0 +1,82 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+
+	appsecurity "github.com/1024XEngineer/anyclaw/pkg/gateway/auth/security"
+)
+
+func (s *Server) handleDevicePairing(w http.ResponseWriter, r *http.Request) {
+	if s.devicePairing == nil {
+		http.Error(w, "device pairing not initialized", http.StatusServiceUnavailable)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		action := r.URL.Query().Get("action")
+		if action == "list" || action == "" {
+			devices := s.devicePairing.ListPaired()
+			writeJSON(w, http.StatusOK, map[string]any{"devices": devices, "status": s.devicePairing.GetStatus()})
+			return
+		}
+		if action == "status" {
+			writeJSON(w, http.StatusOK, s.devicePairing.GetStatus())
+			return
+		}
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid action"})
+	case http.MethodPost:
+		var req appsecurity.PairingRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+			return
+		}
+
+		resp, err := s.devicePairing.HandleRequest(r.Context(), req)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		if !resp.OK {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": resp.Error})
+			return
+		}
+		writeJSON(w, http.StatusOK, resp)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleDevicePairingCode(w http.ResponseWriter, r *http.Request) {
+	if s.devicePairing == nil {
+		http.Error(w, "device pairing not initialized", http.StatusServiceUnavailable)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		DeviceName string `json:"device_name"`
+		DeviceType string `json:"device_type"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+		return
+	}
+
+	code, err := s.devicePairing.GeneratePairingCode(req.DeviceName, req.DeviceType)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"code":    code.Code,
+		"expires": code.ExpiresAt.Format("2006-01-02T15:04:05Z07:00"),
+		"device":  code.DeviceName,
+		"type":    code.DeviceType,
+	})
+}

--- a/pkg/gateway/gateway_discovery_bootstrap.go
+++ b/pkg/gateway/gateway_discovery_bootstrap.go
@@ -1,0 +1,74 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/1024XEngineer/anyclaw/pkg/gateway/resources/discovery"
+	nodepkg "github.com/1024XEngineer/anyclaw/pkg/gateway/resources/nodes"
+)
+
+func (s *Server) initDiscovery(ctx context.Context) {
+	port := s.mainRuntime.Config.Gateway.Port
+	if port <= 0 {
+		port = 18789
+	}
+
+	caps := []string{"gateway", "chat", "agents"}
+	for _, profile := range s.mainRuntime.Config.Agent.Profiles {
+		caps = append(caps, "agent:"+profile.Name)
+	}
+
+	svc := discovery.NewService(discovery.Config{
+		ServiceName:  s.mainRuntime.Config.Agent.Name,
+		ServicePort:  port,
+		InstanceID:   fmt.Sprintf("anyclaw-%s", s.mainRuntime.Config.Agent.Name),
+		Version:      "1.0.0",
+		Capabilities: caps,
+		Metadata: map[string]string{
+			"provider": s.mainRuntime.Config.LLM.Provider,
+			"model":    s.mainRuntime.Config.LLM.Model,
+		},
+	})
+
+	svc.OnDiscover(func(inst *discovery.Instance) {
+		s.appendEvent("discovery.instance", "", map[string]any{
+			"event":   "discovered",
+			"id":      inst.ID,
+			"name":    inst.Name,
+			"url":     inst.URL,
+			"version": inst.Version,
+			"caps":    inst.Caps,
+		})
+
+		if inst.Address != "" && !discovery.IsLocalhost(inst.Address) {
+			node := &nodepkg.Device{
+				ID:           inst.ID,
+				Name:         inst.Name,
+				Type:         "anyclaw",
+				Capabilities: inst.Caps,
+				Status:       "online",
+				ConnectedAt:  inst.LastSeen,
+				LastSeen:     inst.LastSeen,
+				Metadata: map[string]string{
+					"url":     inst.URL,
+					"version": inst.Version,
+				},
+			}
+			s.nodes.Register(node)
+		}
+	})
+
+	if err := svc.Start(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "discovery start error: %v\n", err)
+		return
+	}
+
+	s.discoverySvc = svc
+
+	go func() {
+		<-ctx.Done()
+		svc.Stop()
+	}()
+}

--- a/pkg/gateway/gateway_job_queue_runtime.go
+++ b/pkg/gateway/gateway_job_queue_runtime.go
@@ -1,0 +1,125 @@
+package gateway
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/state"
+)
+
+func (s *Server) enqueueJobFromPayload(job *state.Job) {
+	if job == nil {
+		return
+	}
+	switch job.Kind {
+	case "runtimes.refresh.batch":
+		s.enqueueRuntimeRefreshBatch(job)
+	case "sessions.move.batch":
+		s.enqueueSessionMoveBatch(job)
+	}
+}
+
+func (s *Server) enqueueRuntimeRefreshBatch(job *state.Job) {
+	rawItems, _ := job.Payload["items"].([]any)
+	items := make([]struct {
+		Agent     string `json:"agent"`
+		Org       string `json:"org"`
+		Project   string `json:"project"`
+		Workspace string `json:"workspace"`
+	}, 0, len(rawItems))
+	for _, raw := range rawItems {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		items = append(items, struct {
+			Agent     string `json:"agent"`
+			Org       string `json:"org"`
+			Project   string `json:"project"`
+			Workspace string `json:"workspace"`
+		}{
+			Agent: fmt.Sprint(m["Agent"], m["agent"]),
+			Org:   fmt.Sprint(m["Org"], m["org"]),
+			Project: fmt.Sprint(m["Project"],
+				m["project"]),
+			Workspace: fmt.Sprint(m["Workspace"], m["workspace"]),
+		})
+	}
+	s.jobQueue <- func() {
+		job.Status = "running"
+		job.StartedAt = time.Now().UTC().Format(time.RFC3339)
+		_ = s.store.UpdateJob(job)
+		results := make([]map[string]any, 0, len(items))
+		failedCount := 0
+		for _, item := range items {
+			if strings.TrimSpace(item.Workspace) == "" {
+				results = append(results, map[string]any{"agent": item.Agent, "org": item.Org, "project": item.Project, "workspace": item.Workspace, "status": "failed", "error": "workspace is required"})
+				failedCount++
+				continue
+			}
+			s.runtimePool.Refresh(item.Agent, item.Org, item.Project, item.Workspace)
+			results = append(results, map[string]any{"agent": item.Agent, "org": item.Org, "project": item.Project, "workspace": item.Workspace, "status": "refreshed"})
+		}
+		if failedCount == len(items) && len(items) > 0 {
+			job.Status = "failed"
+			job.Error = "all runtime refresh items failed"
+		} else {
+			job.Status = "completed"
+		}
+		job.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+		job.Cancellable = false
+		job.Details = map[string]any{"results": results, "failed_count": failedCount}
+		_ = s.store.UpdateJob(job)
+	}
+}
+
+func (s *Server) enqueueSessionMoveBatch(job *state.Job) {
+	rawIDs, _ := job.Payload["session_ids"].([]any)
+	sessionIDs := make([]string, 0, len(rawIDs))
+	for _, raw := range rawIDs {
+		sessionIDs = append(sessionIDs, fmt.Sprint(raw))
+	}
+	orgID := fmt.Sprint(job.Payload["org"])
+	projectID := fmt.Sprint(job.Payload["project"])
+	workspaceID := fmt.Sprint(job.Payload["workspace"])
+	agent := fmt.Sprint(job.Payload["agent"])
+	org, project, workspace, err := s.validateResourceSelection(orgID, projectID, workspaceID)
+	if err != nil {
+		job.Status = "failed"
+		job.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+		job.Error = err.Error()
+		_ = s.store.UpdateJob(job)
+		return
+	}
+	s.jobQueue <- func() {
+		job.Status = "running"
+		job.StartedAt = time.Now().UTC().Format(time.RFC3339)
+		_ = s.store.UpdateJob(job)
+		updatedCount := 0
+		failedCount := 0
+		results := make([]map[string]any, 0, len(sessionIDs))
+		for _, sessionID := range sessionIDs {
+			if _, err := s.sessions.MoveSession(sessionID, org.ID, project.ID, workspace.ID, agent); err == nil {
+				updatedCount++
+				results = append(results, map[string]any{"session_id": sessionID, "status": "moved"})
+			} else {
+				failedCount++
+				results = append(results, map[string]any{"session_id": sessionID, "status": "failed", "error": err.Error()})
+			}
+		}
+		if updatedCount > 0 {
+			s.runtimePool.InvalidateByWorkspace(workspace.ID)
+		}
+		if failedCount == len(sessionIDs) && len(sessionIDs) > 0 {
+			job.Status = "failed"
+			job.Error = "all session move items failed"
+		} else {
+			job.Status = "completed"
+		}
+		job.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+		job.Cancellable = false
+		job.Details = map[string]any{"results": results, "target_workspace": workspace.ID, "failed_count": failedCount}
+		_ = s.store.UpdateJob(job)
+	}
+}

--- a/pkg/gateway/gateway_market_api.go
+++ b/pkg/gateway/gateway_market_api.go
@@ -1,0 +1,159 @@
+package gateway
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/plugin"
+)
+
+func (s *Server) handleMarketSearch(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	filter := plugin.SearchFilter{
+		Query:     r.URL.Query().Get("q"),
+		Author:    r.URL.Query().Get("author"),
+		SortBy:    r.URL.Query().Get("sort"),
+		SortOrder: r.URL.Query().Get("order"),
+		Limit:     parseIntParam(r.URL.Query().Get("limit"), 50),
+		Offset:    parseIntParam(r.URL.Query().Get("offset"), 0),
+	}
+
+	if tags := r.URL.Query().Get("tags"); tags != "" {
+		filter.Tags = strings.Split(tags, ",")
+	}
+
+	results, err := s.marketStore.Search(r.Context(), filter)
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{"error": err.Error(), "plugins": []any{}})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"plugins": results,
+		"total":   len(results),
+	})
+}
+
+func (s *Server) handleMarketPlugins(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		http.Error(w, "plugin id required", http.StatusBadRequest)
+		return
+	}
+
+	listing, err := s.marketStore.GetPlugin(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]any{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, listing)
+}
+
+func (s *Server) handleMarketPluginAction(w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/market/plugins/"), "/")
+	if len(parts) == 0 || parts[0] == "" {
+		http.Error(w, "plugin id required", http.StatusBadRequest)
+		return
+	}
+	pluginID := parts[0]
+
+	ctx := r.Context()
+	switch r.Method {
+	case http.MethodPost:
+		if len(parts) > 1 {
+			switch parts[1] {
+			case "install":
+				version := r.URL.Query().Get("version")
+				result, err := s.marketStore.Install(ctx, pluginID, version)
+				if err != nil {
+					writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+					return
+				}
+				writeJSON(w, http.StatusOK, result)
+				return
+			case "update":
+				result, err := s.marketStore.Update(ctx, pluginID)
+				if err != nil {
+					writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+					return
+				}
+				writeJSON(w, http.StatusOK, result)
+				return
+			case "uninstall":
+				result, err := s.marketStore.Uninstall(pluginID)
+				if err != nil {
+					writeJSON(w, http.StatusNotFound, map[string]any{"error": err.Error()})
+					return
+				}
+				writeJSON(w, http.StatusOK, result)
+				return
+			case "rollback":
+				targetVersion := r.URL.Query().Get("version")
+				if targetVersion == "" {
+					http.Error(w, "version query param required for rollback", http.StatusBadRequest)
+					return
+				}
+				result, err := s.marketStore.Rollback(ctx, pluginID, targetVersion)
+				if err != nil {
+					writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+					return
+				}
+				writeJSON(w, http.StatusOK, result)
+				return
+			}
+		}
+		http.Error(w, "unknown action", http.StatusBadRequest)
+	case http.MethodGet:
+		if len(parts) > 1 && parts[1] == "versions" {
+			versions, err := s.marketStore.GetVersions(ctx, pluginID)
+			if err != nil {
+				writeJSON(w, http.StatusNotFound, map[string]any{"error": err.Error()})
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"versions": versions})
+			return
+		}
+		if len(parts) > 1 && parts[1] == "history" {
+			history := s.marketStore.GetInstallHistory(pluginID)
+			writeJSON(w, http.StatusOK, map[string]any{"history": history})
+			return
+		}
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleMarketInstalled(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	records := s.marketStore.ListInstalled()
+	writeJSON(w, http.StatusOK, map[string]any{"installed": records})
+}
+
+func (s *Server) handleMarketCategories(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	categories := []string{
+		"channel", "tool", "mcp", "skill", "app",
+		"model-provider", "speech", "context-engine",
+		"node", "surface", "ingress", "workflow-pack",
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"categories": categories})
+}

--- a/pkg/gateway/gateway_market_bootstrap.go
+++ b/pkg/gateway/gateway_market_bootstrap.go
@@ -1,0 +1,27 @@
+package gateway
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/plugin"
+)
+
+func (s *Server) initMarketStore() {
+	pluginDir := s.mainRuntime.Config.Plugins.Dir
+	if pluginDir == "" {
+		pluginDir = "plugins"
+	}
+	marketDir := filepath.Join(pluginDir, ".market")
+	cacheDir := filepath.Join(pluginDir, ".cache")
+
+	_ = os.MkdirAll(marketDir, 0o755)
+	_ = os.MkdirAll(cacheDir, 0o755)
+
+	sources := []plugin.PluginSource{
+		{Name: "default", URL: "https://market.anyclaw.github.io", Type: "http"},
+	}
+
+	trustStore := plugin.NewTrustStore()
+	s.marketStore = plugin.NewStore(pluginDir, marketDir, cacheDir, sources, trustStore, s.plugins)
+}

--- a/pkg/gateway/gateway_mcp_api.go
+++ b/pkg/gateway/gateway_mcp_api.go
@@ -1,0 +1,159 @@
+package gateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+func (s *Server) handleMCPServers(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.mcpRegistry == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"servers": []any{}})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"servers": s.mcpRegistry.Status()})
+}
+
+func (s *Server) handleMCPTools(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.mcpRegistry == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"tools": map[string]any{}})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"tools": s.mcpRegistry.AllTools()})
+}
+
+func (s *Server) handleMCPResources(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.mcpRegistry == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"resources": map[string]any{}})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"resources": s.mcpRegistry.AllResources()})
+}
+
+func (s *Server) handleMCPPrompts(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.mcpRegistry == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"prompts": map[string]any{}})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"prompts": s.mcpRegistry.AllPrompts()})
+}
+
+func (s *Server) handleMCPCall(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		Server   string         `json:"server"`
+		Tool     string         `json:"tool"`
+		Resource string         `json:"resource"`
+		Prompt   string         `json:"prompt"`
+		Args     map[string]any `json:"args"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	if s.mcpRegistry == nil {
+		http.Error(w, "MCP not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	ctx := r.Context()
+	var result any
+	var err error
+
+	if req.Tool != "" {
+		result, err = s.mcpRegistry.CallTool(ctx, req.Server, req.Tool, req.Args)
+	} else if req.Resource != "" {
+		result, err = s.mcpRegistry.ReadResource(ctx, req.Server, req.Resource)
+	} else if req.Prompt != "" {
+		strArgs := make(map[string]string)
+		for k, v := range req.Args {
+			strArgs[k] = fmt.Sprintf("%v", v)
+		}
+		result, err = s.mcpRegistry.GetPrompt(ctx, req.Server, req.Prompt, strArgs)
+	} else {
+		http.Error(w, "must specify tool, resource, or prompt", http.StatusBadRequest)
+		return
+	}
+
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"result": result})
+}
+
+func (s *Server) handleMCPServerAction(w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/mcp/servers/"), "/")
+	if len(parts) == 0 || parts[0] == "" {
+		http.Error(w, "server name required", http.StatusBadRequest)
+		return
+	}
+	serverName := parts[0]
+
+	if s.mcpRegistry == nil {
+		http.Error(w, "MCP not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	client, ok := s.mcpRegistry.Get(serverName)
+	if !ok {
+		http.Error(w, "server not found", http.StatusNotFound)
+		return
+	}
+
+	ctx := r.Context()
+	switch r.Method {
+	case http.MethodPost:
+		if len(parts) > 1 {
+			switch parts[1] {
+			case "connect":
+				if err := client.Connect(ctx); err != nil {
+					writeJSON(w, http.StatusOK, map[string]any{"error": err.Error()})
+					return
+				}
+				writeJSON(w, http.StatusOK, map[string]any{"status": "connected"})
+				return
+			case "disconnect":
+				client.Close()
+				writeJSON(w, http.StatusOK, map[string]any{"status": "disconnected"})
+				return
+			}
+		}
+		http.Error(w, "unknown action", http.StatusBadRequest)
+	case http.MethodGet:
+		status := map[string]any{
+			"name":      serverName,
+			"connected": client.IsConnected(),
+		}
+		if client.IsConnected() {
+			status["tools"] = len(client.ListTools())
+			status["resources"] = len(client.ListResources())
+			status["prompts"] = len(client.ListPrompts())
+		}
+		writeJSON(w, http.StatusOK, status)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}

--- a/pkg/gateway/gateway_mcp_bootstrap.go
+++ b/pkg/gateway/gateway_mcp_bootstrap.go
@@ -1,0 +1,106 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/mcp"
+)
+
+func (s *Server) initMCP(ctx context.Context) {
+	s.mcpRegistry = mcp.NewRegistry()
+
+	cfg := s.mainRuntime.Config.MCP
+	if !cfg.Enabled || len(cfg.Servers) == 0 {
+		return
+	}
+
+	for _, srvCfg := range cfg.Servers {
+		if !srvCfg.Enabled || srvCfg.Command == "" {
+			continue
+		}
+		client := mcp.NewClient(srvCfg.Name, srvCfg.Command, srvCfg.Args, srvCfg.Env)
+		if err := s.mcpRegistry.Register(srvCfg.Name, client); err != nil {
+			fmt.Fprintf(os.Stderr, "MCP register %s: %v\n", srvCfg.Name, err)
+			continue
+		}
+	}
+
+	if errs := s.mcpRegistry.ConnectAll(ctx); len(errs) > 0 {
+		for _, err := range errs {
+			fmt.Fprintf(os.Stderr, "MCP connect: %v\n", err)
+		}
+	}
+
+	if s.mcpRegistry != nil {
+		if err := mcp.BridgeToToolRegistry(s.mainRuntime.ToolRegistry(), s.mcpRegistry); err != nil {
+			fmt.Fprintf(os.Stderr, "MCP bridge: %v\n", err)
+		}
+	}
+
+	s.mcpServer = mcp.NewServer("anyclaw", "1.0.0")
+	s.registerBuiltinMCPTools()
+}
+
+func (s *Server) registerBuiltinMCPTools() {
+	s.mcpServer.RegisterTool(mcp.ServerTool{
+		Name:        "chat",
+		Description: "Send a message to AnyClaw AI agent",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"message": map[string]any{"type": "string", "description": "User message"},
+			},
+			"required": []string{"message"},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (any, error) {
+			msg, _ := args["message"].(string)
+			if msg == "" {
+				return nil, fmt.Errorf("message is required")
+			}
+			return "Chat endpoint available via HTTP POST /chat", nil
+		},
+	})
+
+	s.mcpServer.RegisterResource(mcp.ServerResource{
+		URI:         "status://gateway",
+		Name:        "Gateway Status",
+		Description: "Current gateway server status",
+		MimeType:    "application/json",
+		Handler: func(ctx context.Context) (any, error) {
+			return map[string]any{
+				"started_at": s.startedAt,
+				"uptime":     time.Since(s.startedAt).String(),
+			}, nil
+		},
+	})
+
+	s.mcpServer.RegisterPrompt(mcp.ServerPrompt{
+		Name:        "code_review",
+		Description: "Code review prompt template",
+		Arguments: []mcp.PromptArg{
+			{Name: "language", Description: "Programming language", Required: false},
+			{Name: "focus", Description: "Review focus (security, performance, style)", Required: false},
+		},
+		Handler: func(ctx context.Context, args map[string]string) ([]mcp.PromptMessage, error) {
+			lang := args["language"]
+			focus := args["focus"]
+			text := "Please review the following code"
+			if lang != "" {
+				text += " (" + lang + ")"
+			}
+			if focus != "" {
+				text += " with focus on " + focus
+			}
+			text += ":\n\n"
+			return []mcp.PromptMessage{
+				{Role: "user", Content: struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				}{Type: "text", Text: text}},
+			}, nil
+		},
+	})
+}

--- a/pkg/gateway/gateway_memory_api.go
+++ b/pkg/gateway/gateway_memory_api.go
@@ -1,0 +1,17 @@
+package gateway
+
+import "net/http"
+
+func (s *Server) handleMemory(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		mem, err := s.mainRuntime.ShowMemory()
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"memory": mem})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}

--- a/pkg/gateway/gateway_presence_api.go
+++ b/pkg/gateway/gateway_presence_api.go
@@ -1,0 +1,7 @@
+package gateway
+
+import "net/http"
+
+func (s *Server) handlePresence(w http.ResponseWriter, r *http.Request) {
+	s.controlPlanePresenceAPI().Handle(w, r)
+}

--- a/pkg/gateway/gateway_response_helpers.go
+++ b/pkg/gateway/gateway_response_helpers.go
@@ -1,0 +1,11 @@
+package gateway
+
+import (
+	"net/http"
+
+	gatewaysurface "github.com/1024XEngineer/anyclaw/pkg/gateway/surface"
+)
+
+func writeError(w http.ResponseWriter, statusCode int, message string) {
+	_ = gatewaysurface.Service{}.WriteError(w, statusCode, message)
+}

--- a/pkg/gateway/gateway_roles_api.go
+++ b/pkg/gateway/gateway_roles_api.go
@@ -1,0 +1,123 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+	gatewayauth "github.com/1024XEngineer/anyclaw/pkg/gateway/auth"
+)
+
+func (s *Server) handleRoles(w http.ResponseWriter, r *http.Request) {
+	builtinRoles := make([]map[string]any, 0, len(gatewayauth.BuiltinRoleTemplates()))
+	for _, role := range gatewayauth.BuiltinRoleTemplates() {
+		builtinRoles = append(builtinRoles, map[string]any{
+			"name":        role.Name,
+			"description": role.Description,
+			"permissions": role.Permissions,
+		})
+	}
+	switch r.Method {
+	case http.MethodGet:
+		if !HasPermission(UserFromContext(r.Context()), "auth.users.read") {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_permission": "auth.users.read"})
+			return
+		}
+		roles := append([]map[string]any{}, builtinRoles...)
+		for _, role := range s.mainRuntime.Config.Security.Roles {
+			roles = append(roles, map[string]any{"name": role.Name, "description": role.Description, "permissions": role.Permissions, "custom": true})
+		}
+		writeJSON(w, http.StatusOK, roles)
+	case http.MethodPost:
+		if !HasPermission(UserFromContext(r.Context()), "auth.users.read") {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_permission": "auth.users.read"})
+			return
+		}
+		var role config.SecurityRole
+		if err := json.NewDecoder(r.Body).Decode(&role); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+			return
+		}
+		if strings.TrimSpace(role.Name) == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "role name is required"})
+			return
+		}
+		updated := false
+		for i := range s.mainRuntime.Config.Security.Roles {
+			if s.mainRuntime.Config.Security.Roles[i].Name == role.Name {
+				s.mainRuntime.Config.Security.Roles[i] = role
+				updated = true
+				break
+			}
+		}
+		if !updated {
+			s.mainRuntime.Config.Security.Roles = append(s.mainRuntime.Config.Security.Roles, role)
+		}
+		if err := s.mainRuntime.Config.Save(s.mainRuntime.ConfigPath); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		s.appendAudit(UserFromContext(r.Context()), "auth.roles.write", role.Name, nil)
+		writeJSON(w, http.StatusOK, map[string]any{"status": "ok"})
+	case http.MethodDelete:
+		if !HasPermission(UserFromContext(r.Context()), "auth.users.read") {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_permission": "auth.users.read"})
+			return
+		}
+		name := strings.TrimSpace(r.URL.Query().Get("name"))
+		if name == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
+			return
+		}
+		filtered := make([]config.SecurityRole, 0, len(s.mainRuntime.Config.Security.Roles))
+		removed := false
+		for _, role := range s.mainRuntime.Config.Security.Roles {
+			if role.Name == name {
+				removed = true
+				continue
+			}
+			filtered = append(filtered, role)
+		}
+		if !removed {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "role not found"})
+			return
+		}
+		s.mainRuntime.Config.Security.Roles = filtered
+		if err := s.mainRuntime.Config.Save(s.mainRuntime.ConfigPath); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		s.appendAudit(UserFromContext(r.Context()), "auth.roles.delete", name, nil)
+		writeJSON(w, http.StatusOK, map[string]any{"status": "deleted"})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleRoleImpact(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	roles := []config.SecurityRole{}
+	roles = append(roles, gatewayauth.BuiltinRoleTemplates()...)
+	roles = append(roles, s.mainRuntime.Config.Security.Roles...)
+	impact := make([]map[string]any, 0, len(roles))
+	for _, role := range roles {
+		users := []string{}
+		for _, user := range s.mainRuntime.Config.Security.Users {
+			if user.Role == role.Name {
+				users = append(users, user.Name)
+			}
+		}
+		impact = append(impact, map[string]any{
+			"name":        role.Name,
+			"description": role.Description,
+			"permissions": role.Permissions,
+			"user_count":  len(users),
+			"users":       users,
+		})
+	}
+	writeJSON(w, http.StatusOK, impact)
+}

--- a/pkg/gateway/gateway_routes.go
+++ b/pkg/gateway/gateway_routes.go
@@ -6,7 +6,9 @@ import (
 	"time"
 
 	gatewaytransport "github.com/1024XEngineer/anyclaw/pkg/gateway/transport"
+	"github.com/1024XEngineer/anyclaw/pkg/runtime"
 	"github.com/1024XEngineer/anyclaw/pkg/state"
+	"github.com/1024XEngineer/anyclaw/pkg/state/observability"
 )
 
 type Status = gatewaytransport.Status
@@ -33,9 +35,10 @@ func typingSessionActive(session *state.Session, now time.Time, maxAge time.Dura
 
 func (s *Server) statusDeps() gatewaytransport.StatusDeps {
 	deps := gatewaytransport.StatusDeps{
-		MainRuntime: s.mainRuntime,
-		StartedAt:   s.startedAt,
-		Store:       s.store,
+		MainRuntime:       s.mainRuntime,
+		StartedAt:         s.startedAt,
+		Store:             s.store,
+		EnabledSkillCount: s.currentEnabledSkillCount,
 	}
 	if s.channels != nil {
 		deps.Channels = s.channels
@@ -67,55 +70,20 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) registerGatewayRoutes(mux *http.ServeMux) {
-	if mux == nil {
-		return
-	}
+	obs := observability.NewGatewayHTTP(runtime.Version)
+	obs.RegisterHealthChecks(s.mainRuntime)
 
-	mux.HandleFunc("/healthz", s.wrap("/healthz", s.handleHealth))
-	mux.HandleFunc("/status", s.wrap("/status", requirePermission("status.read", s.handleStatus)))
-	mux.HandleFunc("/events", s.wrap("/events", requirePermission("events.read", s.handleEvents)))
-	mux.HandleFunc("/events/stream", s.wrap("/events/stream", requirePermission("events.read", s.handleEventStream)))
-	mux.HandleFunc("/control-plane", s.wrap("/control-plane", requirePermission("status.read", s.controlPlaneRuntimeAPI().HandleControlPlane)))
+	mux.Handle("/health", obs.HealthHandler())
+	mux.Handle("/ready", obs.ReadyHandler())
+	mux.Handle("/live", obs.LiveHandler())
+	mux.Handle("/metrics", obs.MetricsHandler())
+	mux.Handle("/metrics.json", obs.MetricsJSONHandler())
+	observability.RegisterPprof(mux, "/debug/pprof/")
 
-	mux.HandleFunc("/resources", s.wrap("/resources", s.resourcesAPI().HandleCollection))
+	s.registerSharedRoutes(mux)
+	s.registerGatewayPlatformRoutes(mux)
+}
 
-	mux.HandleFunc("/runtimes", s.wrap("/runtimes", requirePermission("runtimes.read", requireHierarchyAccess(s.resolveHierarchyFromQuery, s.controlPlaneRuntimeAPI().HandleList))))
-	mux.HandleFunc("/runtimes/refresh", s.wrap("/runtimes/refresh", requirePermission("runtimes.write", s.controlPlaneRuntimeAPI().HandleRefresh)))
-	mux.HandleFunc("/runtimes/refresh-batch", s.wrap("/runtimes/refresh-batch", requirePermission("runtimes.write", s.controlPlaneRuntimeAPI().HandleRefreshBatch)))
-	mux.HandleFunc("/runtimes/metrics", s.wrap("/runtimes/metrics", requirePermission("runtimes.read", s.controlPlaneRuntimeAPI().HandleMetrics)))
-
-	mux.HandleFunc("/approvals", s.wrap("/approvals", requirePermission("approvals.read", s.handleApprovals)))
-	mux.HandleFunc("/approvals/", s.wrap("/approvals/", requirePermission("approvals.write", s.handleApprovalByID)))
-
-	mux.HandleFunc("/sessions", s.wrap("/sessions", requirePermissionByMethod(map[string]string{
-		http.MethodGet:  "sessions.read",
-		http.MethodPost: "sessions.write",
-	}, "sessions.read", requireHierarchyAccess(s.resolveHierarchyFromQuery, s.sessionCommandsAPI().HandleCollection))))
-	mux.HandleFunc("/sessions/", s.wrap("/sessions/", requirePermissionByMethod(map[string]string{
-		http.MethodDelete: "sessions.write",
-		http.MethodGet:    "sessions.read",
-	}, "sessions.read", requireHierarchyAccess(s.resolveHierarchyFromSessionPath, s.sessionCommandsAPI().HandleByID))))
-	mux.HandleFunc("/sessions/move", s.wrap("/sessions/move", requirePermission("sessions.write", s.sessionMoveCommandsAPI().HandleSingle)))
-	mux.HandleFunc("/sessions/move-batch", s.wrap("/sessions/move-batch", requirePermission("sessions.write", s.sessionMoveCommandsAPI().HandleBatch)))
-
-	mux.HandleFunc("/tasks", s.wrap("/tasks", requirePermissionByMethod(map[string]string{
-		http.MethodGet:  "tasks.read",
-		http.MethodPost: "tasks.write",
-	}, "tasks.read", requireHierarchyAccess(s.resolveHierarchyFromQuery, s.taskCommandsAPI().HandleCollection))))
-	mux.HandleFunc("/tasks/", s.wrap("/tasks/", s.taskCommandsAPI().HandleByID))
-
-	mux.HandleFunc("/nodes", s.wrap("/nodes", requirePermission("nodes.read", s.nodesAPI().HandleList)))
-	mux.HandleFunc("/nodes/", s.wrap("/nodes/", s.nodesAPI().HandleByID))
-	mux.HandleFunc("/nodes/invoke", s.wrap("/nodes/invoke", requirePermission("nodes.write", s.nodesAPI().HandleInvoke)))
-
-	mux.HandleFunc("/discovery/instances", s.wrap("/discovery/instances", s.discoveryAPI().HandleInstances))
-	mux.HandleFunc("/discovery/query", s.wrap("/discovery/query", s.discoveryAPI().HandleQuery))
-
-	if s.openAICompat != nil {
-		mux.HandleFunc("/v1/chat/completions", s.wrap("/v1/chat/completions", s.openAICompat.HandleChatCompletions))
-		mux.HandleFunc("/v1/models", s.wrap("/v1/models", s.openAICompat.HandleModels))
-		mux.HandleFunc("/v1/responses", s.wrap("/v1/responses", s.openAICompat.HandleResponses))
-	}
-
-	mux.HandleFunc("/", s.handleRootAPI)
+func (s *Server) registerWorkerRoutes(mux *http.ServeMux) {
+	s.registerSharedRoutes(mux)
 }

--- a/pkg/gateway/gateway_routes_platform.go
+++ b/pkg/gateway/gateway_routes_platform.go
@@ -1,0 +1,63 @@
+package gateway
+
+import (
+	"net/http"
+
+	gatewayintake "github.com/1024XEngineer/anyclaw/pkg/gateway/intake"
+	scheduleui "github.com/1024XEngineer/anyclaw/pkg/gateway/transport/scheduleui"
+)
+
+func (s *Server) registerGatewayPlatformRoutes(mux *http.ServeMux) {
+	s.registerOpenAIRoutes(mux)
+	s.registerExtensionRoutes(mux)
+	s.registerNodeRoutes(mux)
+	s.registerDiscoveryRoutes(mux)
+	s.registerMCPRoutes(mux)
+	s.registerMarketRoutes(mux)
+	scheduleui.RegisterUIHandler(mux, cronScheduler, "/cron")
+}
+
+func (s *Server) registerOpenAIRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/v1/chat/completions", s.wrap("/v1/chat/completions", s.openAICompat.HandleChatCompletions))
+	mux.HandleFunc("/v1/models", s.wrap("/v1/models", s.openAICompat.HandleModels))
+	mux.HandleFunc("/v1/responses", s.wrap("/v1/responses", s.openAICompat.HandleResponses))
+}
+
+func (s *Server) registerExtensionRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/webhooks/", s.rateLimit.Wrap(gatewayintake.WebhookIngressAPI{
+		Webhooks:               s.webhooks,
+		MainRuntime:            s.mainRuntime,
+		RuntimePool:            s.runtimePool,
+		EnsureDefaultWorkspace: s.ensureDefaultWorkspace,
+		DefaultResourceIDs:     defaultResourceIDs,
+		AppendEvent:            s.appendEvent,
+	}.Handle))
+}
+
+func (s *Server) registerNodeRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/nodes", s.wrap("/nodes", requirePermission("nodes.read", s.nodesAPI().HandleList)))
+	mux.HandleFunc("/nodes/", s.wrap("/nodes/", s.nodesAPI().HandleByID))
+	mux.HandleFunc("/nodes/invoke", s.wrap("/nodes/invoke", requirePermission("nodes.write", s.nodesAPI().HandleInvoke)))
+}
+
+func (s *Server) registerDiscoveryRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/discovery/instances", s.wrap("/discovery/instances", s.discoveryAPI().HandleInstances))
+	mux.HandleFunc("/discovery/query", s.wrap("/discovery/query", s.discoveryAPI().HandleQuery))
+}
+
+func (s *Server) registerMCPRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/mcp/servers", s.wrap("/mcp/servers", requirePermission("mcp.read", s.handleMCPServers)))
+	mux.HandleFunc("/mcp/tools", s.wrap("/mcp/tools", requirePermission("mcp.read", s.handleMCPTools)))
+	mux.HandleFunc("/mcp/resources", s.wrap("/mcp/resources", requirePermission("mcp.read", s.handleMCPResources)))
+	mux.HandleFunc("/mcp/prompts", s.wrap("/mcp/prompts", requirePermission("mcp.read", s.handleMCPPrompts)))
+	mux.HandleFunc("/mcp/call", s.wrap("/mcp/call", requirePermission("mcp.write", s.handleMCPCall)))
+	mux.HandleFunc("/mcp/servers/", s.wrap("/mcp/servers/", s.handleMCPServerAction))
+}
+
+func (s *Server) registerMarketRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/market/search", s.wrap("/market/search", requirePermission("market.read", s.handleMarketSearch)))
+	mux.HandleFunc("/market/plugins", s.wrap("/market/plugins", requirePermission("market.read", s.handleMarketPlugins)))
+	mux.HandleFunc("/market/plugins/", s.wrap("/market/plugins/", s.handleMarketPluginAction))
+	mux.HandleFunc("/market/installed", s.wrap("/market/installed", requirePermission("market.read", s.handleMarketInstalled)))
+	mux.HandleFunc("/market/categories", s.wrap("/market/categories", requirePermission("market.read", s.handleMarketCategories)))
+}

--- a/pkg/gateway/gateway_routes_shared.go
+++ b/pkg/gateway/gateway_routes_shared.go
@@ -1,0 +1,119 @@
+package gateway
+
+import (
+	"net/http"
+
+	gatewayintake "github.com/1024XEngineer/anyclaw/pkg/gateway/intake"
+	controlui "github.com/1024XEngineer/anyclaw/pkg/gateway/transport/controlui"
+)
+
+func (s *Server) registerSharedRoutes(mux *http.ServeMux) {
+	s.registerStatusRoutes(mux)
+	s.registerCatalogRoutes(mux)
+	s.registerRuntimeGovernanceRoutes(mux)
+	s.registerSessionTaskRoutes(mux)
+	s.registerChannelRoutes(mux)
+
+	controlui.RegisterRoutes(mux, controlui.Options{
+		BasePath: s.mainRuntime.Config.Gateway.ControlUI.BasePath,
+		Root:     s.mainRuntime.Config.Gateway.ControlUI.Root,
+	})
+	mux.HandleFunc("/", s.handleRootAPI)
+}
+
+func (s *Server) registerStatusRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/healthz", s.wrap("/healthz", s.handleHealth))
+	mux.HandleFunc("/status", s.wrap("/status", requirePermission("status.read", s.handleStatus)))
+	mux.HandleFunc("/events", s.wrap("/events", requirePermission("events.read", s.handleEvents)))
+	mux.HandleFunc("/events/stream", s.wrap("/events/stream", requirePermission("events.read", s.handleEventStream)))
+	mux.HandleFunc("/ws", s.wrap("/ws", s.handleOpenClawWS))
+	mux.HandleFunc("/control-plane", s.wrap("/control-plane", requirePermission("status.read", s.controlPlaneRuntimeAPI().HandleControlPlane)))
+}
+
+func (s *Server) registerCatalogRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/chat", s.wrap("/chat", requirePermission("chat.send", requireHierarchyAccess(func(r *http.Request) (string, string, string) {
+		return s.resolveHierarchyFromQuery(r)
+	}, s.handleChat))))
+	mux.HandleFunc("/channels", s.wrap("/channels", requirePermission("channels.read", s.handleChannels)))
+	mux.HandleFunc("/plugins", s.wrap("/plugins", requirePermission("plugins.read", s.handlePlugins)))
+	mux.HandleFunc("/routing", s.wrap("/routing", requirePermission("routing.read", s.handleRouting)))
+	mux.HandleFunc("/routing/analysis", s.wrap("/routing/analysis", requirePermission("routing.read", s.handleRoutingAnalysis)))
+	mux.HandleFunc("/agents", s.wrap("/agents", s.handleAgents))
+	mux.HandleFunc("/agents/personality-templates", s.wrap("/agents/personality-templates", requirePermission("config.read", s.handlePersonalityTemplates)))
+	mux.HandleFunc("/agents/skill-catalog", s.wrap("/agents/skill-catalog", requirePermission("skills.read", s.handleAssistantSkillCatalog)))
+	mux.HandleFunc("/assistants", s.wrap("/assistants", s.handleAssistants))
+	mux.HandleFunc("/assistants/personality-templates", s.wrap("/assistants/personality-templates", requirePermission("config.read", s.handlePersonalityTemplates)))
+	mux.HandleFunc("/assistants/skill-catalog", s.wrap("/assistants/skill-catalog", requirePermission("skills.read", s.handleAssistantSkillCatalog)))
+	mux.HandleFunc("/providers", s.wrap("/providers", s.handleProviders))
+	mux.HandleFunc("/providers/test", s.wrap("/providers/test", s.handleProviderTest))
+	mux.HandleFunc("/providers/default", s.wrap("/providers/default", s.handleDefaultProvider))
+	mux.HandleFunc("/agent-bindings", s.wrap("/agent-bindings", s.handleAgentBindings))
+	mux.HandleFunc("/resources", s.wrap("/resources", s.resourcesAPI().HandleCollection))
+	mux.HandleFunc("/skills", s.wrap("/skills", s.handleSkills))
+	mux.HandleFunc("/tools/activity", s.wrap("/tools/activity", requirePermission("tools.read", s.handleToolActivity)))
+	mux.HandleFunc("/tools", s.wrap("/tools", requirePermission("tools.read", s.handleTools)))
+}
+
+func (s *Server) registerRuntimeGovernanceRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/runtimes", s.wrap("/runtimes", requirePermission("runtimes.read", requireHierarchyAccess(s.resolveHierarchyFromQuery, s.controlPlaneRuntimeAPI().HandleList))))
+	mux.HandleFunc("/runtimes/refresh", s.wrap("/runtimes/refresh", requirePermission("runtimes.write", s.controlPlaneRuntimeAPI().HandleRefresh)))
+	mux.HandleFunc("/runtimes/refresh-batch", s.wrap("/runtimes/refresh-batch", requirePermission("runtimes.write", s.controlPlaneRuntimeAPI().HandleRefreshBatch)))
+	mux.HandleFunc("/runtimes/metrics", s.wrap("/runtimes/metrics", requirePermission("runtimes.read", s.controlPlaneRuntimeAPI().HandleMetrics)))
+	mux.HandleFunc("/auth/users", s.wrap("/auth/users", s.handleUsers))
+	mux.HandleFunc("/auth/roles", s.wrap("/auth/roles", s.handleRoles))
+	mux.HandleFunc("/auth/roles/impact", s.wrap("/auth/roles/impact", requirePermission("auth.users.read", s.handleRoleImpact)))
+	mux.HandleFunc("/audit", s.wrap("/audit", requirePermission("audit.read", s.handleAudit)))
+	mux.HandleFunc("/jobs", s.wrap("/jobs", requirePermission("audit.read", s.handleJobs)))
+	mux.HandleFunc("/jobs/", s.wrap("/jobs/", requirePermission("audit.read", s.handleJobByID)))
+	mux.HandleFunc("/jobs/retry", s.wrap("/jobs/retry", requirePermission("audit.read", s.handleRetryJob)))
+	mux.HandleFunc("/jobs/cancel", s.wrap("/jobs/cancel", requirePermission("audit.read", s.handleCancelJob)))
+	mux.HandleFunc("/config", s.wrap("/config", s.handleConfigAPI))
+	mux.HandleFunc("/memory", s.wrap("/memory", requirePermission("memory.read", requireHierarchyAccess(s.resolveHierarchyFromQuery, s.handleMemory))))
+	mux.HandleFunc("/approvals", s.wrap("/approvals", requirePermission("approvals.read", s.handleApprovals)))
+	mux.HandleFunc("/approvals/", s.wrap("/approvals/", requirePermission("approvals.write", s.handleApprovalByID)))
+}
+
+func (s *Server) registerSessionTaskRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/sessions", s.wrap("/sessions", requirePermissionByMethod(map[string]string{
+		http.MethodGet:  "sessions.read",
+		http.MethodPost: "sessions.write",
+	}, "sessions.read", requireHierarchyAccess(s.resolveHierarchyFromQuery, s.sessionCommandsAPI().HandleCollection))))
+	mux.HandleFunc("/sessions/", s.wrap("/sessions/", requirePermissionByMethod(map[string]string{
+		http.MethodDelete: "sessions.write",
+		http.MethodGet:    "sessions.read",
+	}, "sessions.read", requireHierarchyAccess(s.resolveHierarchyFromSessionPath, s.sessionCommandsAPI().HandleByID))))
+	mux.HandleFunc("/sessions/move", s.wrap("/sessions/move", requirePermission("sessions.write", s.sessionMoveCommandsAPI().HandleSingle)))
+	mux.HandleFunc("/sessions/move-batch", s.wrap("/sessions/move-batch", requirePermission("sessions.write", s.sessionMoveCommandsAPI().HandleBatch)))
+	mux.HandleFunc("/tasks", s.wrap("/tasks", requirePermission("tasks.write", requireHierarchyAccess(s.resolveHierarchyFromQuery, s.taskCommandsAPI().HandleCollection))))
+	mux.HandleFunc("/tasks/", s.wrap("/tasks/", s.taskCommandsAPI().HandleByID))
+	mux.HandleFunc("/v2/tasks", s.wrap("/v2/tasks", requirePermission("tasks.write", s.handleV2Tasks)))
+	mux.HandleFunc("/v2/tasks/", s.wrap("/v2/tasks/", requirePermission("tasks.read", s.handleV2TaskByID)))
+	mux.HandleFunc("/v2/agents", s.wrap("/v2/agents", requirePermission("tasks.read", s.handleV2Agents)))
+	mux.HandleFunc("/v2/chat", s.wrap("/v2/chat", requirePermission("tasks.write", s.handleV2Chat)))
+	mux.HandleFunc("/v2/chat/sessions", s.wrap("/v2/chat/sessions", requirePermission("tasks.read", s.handleV2ChatSessions)))
+	mux.HandleFunc("/v2/chat/sessions/", s.wrap("/v2/chat/sessions/", requirePermission("tasks.read", s.handleV2ChatSessionByID)))
+	mux.HandleFunc("/v2/store", s.wrap("/v2/store", requirePermission("tasks.read", s.handleV2Store)))
+	mux.HandleFunc("/v2/store/", s.wrap("/v2/store/", requirePermission("tasks.read", s.handleV2StoreByID)))
+}
+
+func (s *Server) registerChannelRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/channel/mention-gate", s.wrap("/channel/mention-gate", gatewayintake.MentionGateAPI{Gate: s.mentionGate}.Handle))
+	mux.HandleFunc("/channel/group-security", s.wrap("/channel/group-security", gatewayintake.GroupSecurityAPI{Security: s.groupSecurity}.Handle))
+	mux.HandleFunc("/channel/pairing", s.wrap("/channel/pairing", gatewayintake.ChannelPairingAPI{Pairing: s.channelPairing}.Handle))
+	mux.HandleFunc("/channel/presence", s.wrap("/channel/presence", s.controlPlanePresenceAPI().Handle))
+	mux.HandleFunc("/channel/contacts", s.wrap("/channel/contacts", gatewayintake.ContactsAPI{Directory: s.contactDir}.Handle))
+	mux.HandleFunc("/device/pairing", s.wrap("/device/pairing", s.handleDevicePairing))
+	mux.HandleFunc("/device/pairing/code", s.wrap("/device/pairing/code", s.handleDevicePairingCode))
+	mux.HandleFunc("/channels/whatsapp/webhook", s.rateLimit.Wrap(gatewayintake.WhatsAppWebhookAPI{
+		Adapter:       s.whatsapp,
+		HandleMessage: s.processChannelMessage,
+		VerifyToken:   s.mainRuntime.Config.Channels.WhatsApp.VerifyToken,
+		AppSecret:     s.mainRuntime.Config.Channels.WhatsApp.AppSecret,
+	}.Handle))
+	mux.HandleFunc("/channels/discord/interactions", s.rateLimit.Wrap(gatewayintake.DiscordInteractionAPI{
+		Adapter:       s.discord,
+		HandleMessage: s.processChannelMessage,
+	}.Handle))
+	mux.HandleFunc("/ingress/web", s.rateLimit.Wrap(s.signedIngressAPI().Handle))
+	mux.HandleFunc("/ingress/plugins/", s.rateLimit.Wrap(s.pluginIngressAPI().Handle))
+}

--- a/pkg/gateway/gateway_runtime_surface_test.go
+++ b/pkg/gateway/gateway_runtime_surface_test.go
@@ -1,0 +1,45 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGatewayRuntimeSurface_WorkerAndDeviceHelpers(t *testing.T) {
+	server := newSplitAPITestServer(t)
+
+	var buf bytes.Buffer
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	printWorkerStatus([]int{11}, []int{18789}, 18789)
+	_ = w.Close()
+	os.Stdout = oldStdout
+	_, _ = buf.ReadFrom(r)
+	if !strings.Contains(buf.String(), "Gateway workers started") {
+		t.Fatalf("unexpected worker status output: %q", buf.String())
+	}
+
+	if err := killProcess(-1); err == nil {
+		t.Fatal("expected killProcess to fail for invalid pid")
+	}
+
+	server.mainRuntime.Config.Speech.TTS.Enabled = false
+	server.initTTS()
+	server.registerAudioSenders()
+	if server.ttsManager != nil || server.ttsPipeline != nil {
+		t.Fatal("expected TTS to remain uninitialized when disabled")
+	}
+
+	conn := &openClawWSConn{server: server, closed: make(chan struct{})}
+	handled, err := conn.handleDeviceWSRequest(context.Background(), openClawWSFrame{ID: "1"}, "unknown.method")
+	if err != nil || handled {
+		t.Fatalf("unexpected device ws result: handled=%v err=%v", handled, err)
+	}
+}

--- a/pkg/gateway/gateway_skills_api.go
+++ b/pkg/gateway/gateway_skills_api.go
@@ -1,0 +1,56 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	skillscatalog "github.com/1024XEngineer/anyclaw/pkg/capability/skills"
+)
+
+type skillView = skillscatalog.View
+
+func (s *Server) handleSkills(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		if !HasPermission(UserFromContext(r.Context()), "skills.read") &&
+			!HasPermission(UserFromContext(r.Context()), "config.read") &&
+			!HasPermission(UserFromContext(r.Context()), "config.write") {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_permission": "skills.read"})
+			return
+		}
+		views, err := s.listSkillViews()
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		s.appendAudit(UserFromContext(r.Context()), "skills.read", "skills", nil)
+		writeJSON(w, http.StatusOK, views)
+	case http.MethodPost:
+		if !HasPermission(UserFromContext(r.Context()), "config.write") {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_permission": "config.write"})
+			return
+		}
+		var req struct {
+			Name    string `json:"name"`
+			Enabled bool   `json:"enabled"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+			return
+		}
+		view, err := s.setSkillEnabled(req.Name, req.Enabled)
+		if err != nil {
+			statusCode := http.StatusBadRequest
+			if strings.Contains(strings.ToLower(err.Error()), "not found") {
+				statusCode = http.StatusNotFound
+			}
+			writeJSON(w, statusCode, map[string]string{"error": err.Error()})
+			return
+		}
+		s.appendAudit(UserFromContext(r.Context()), "skills.write", view.Name, map[string]any{"enabled": view.Enabled})
+		writeJSON(w, http.StatusOK, view)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}

--- a/pkg/gateway/gateway_skills_service.go
+++ b/pkg/gateway/gateway_skills_service.go
@@ -1,0 +1,122 @@
+package gateway
+
+import (
+	"fmt"
+	"strings"
+
+	skillscatalog "github.com/1024XEngineer/anyclaw/pkg/capability/skills"
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+func (s *Server) currentConfiguredSkillRefs() []config.AgentSkillRef {
+	if s == nil || s.mainRuntime == nil || s.mainRuntime.Config == nil {
+		return nil
+	}
+	if profile, ok := s.mainRuntime.Config.ResolveMainAgentProfile(); ok {
+		return append([]config.AgentSkillRef(nil), profile.Skills...)
+	}
+	return append([]config.AgentSkillRef(nil), s.mainRuntime.Config.Agent.Skills...)
+}
+
+func (s *Server) currentEnabledSkillCount() int {
+	refs := s.currentConfiguredSkillRefs()
+	if len(refs) == 0 {
+		if s == nil || s.mainRuntime == nil {
+			return 0
+		}
+		return len(s.mainRuntime.ListSkills())
+	}
+	count := 0
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		if !ref.Enabled {
+			continue
+		}
+		key := skillscatalog.NormalizeKey(ref.Name)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		count++
+	}
+	return count
+}
+
+func (s *Server) loadSkillCatalog() (*skillscatalog.SkillsManager, error) {
+	if s == nil || s.mainRuntime == nil || s.mainRuntime.Config == nil {
+		return nil, fmt.Errorf("server is not initialized")
+	}
+	manager := skillscatalog.NewSkillsManager(s.mainRuntime.Config.Skills.Dir)
+	if err := manager.Load(); err != nil {
+		return nil, err
+	}
+	return manager, nil
+}
+
+func (s *Server) listSkillViews() ([]skillView, error) {
+	manager, err := s.loadSkillCatalog()
+	if err != nil {
+		return nil, err
+	}
+	return skillscatalog.BuildViews(manager, s.currentConfiguredSkillRefs()), nil
+}
+
+func (s *Server) setSkillEnabled(name string, enabled bool) (skillView, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return skillView{}, fmt.Errorf("name is required")
+	}
+
+	manager, err := s.loadSkillCatalog()
+	if err != nil {
+		return skillView{}, err
+	}
+
+	refs := skillscatalog.MaterializeRefs(manager.List(), s.currentConfiguredSkillRefs())
+	targetKey := skillscatalog.NormalizeKey(name)
+	found := false
+	for i := range refs {
+		if skillscatalog.NormalizeKey(refs[i].Name) != targetKey {
+			continue
+		}
+		refs[i].Enabled = enabled
+		found = true
+		break
+	}
+	if !found {
+		return skillView{}, fmt.Errorf("skill not found: %s", name)
+	}
+
+	if err := s.applyConfiguredSkillRefs(refs); err != nil {
+		return skillView{}, err
+	}
+	if s.runtimePool != nil {
+		s.runtimePool.InvalidateAll()
+	}
+
+	for _, view := range skillscatalog.BuildViews(manager, refs) {
+		if skillscatalog.NormalizeKey(view.Name) == targetKey {
+			return view, nil
+		}
+	}
+	return skillView{}, fmt.Errorf("skill not found: %s", name)
+}
+
+func (s *Server) applyConfiguredSkillRefs(refs []config.AgentSkillRef) error {
+	if s == nil || s.mainRuntime == nil || s.mainRuntime.Config == nil {
+		return fmt.Errorf("server is not initialized")
+	}
+	snapshot := append([]config.AgentSkillRef(nil), refs...)
+	if profile, ok := s.mainRuntime.Config.ResolveMainAgentProfile(); ok {
+		profile.Skills = snapshot
+		if err := s.mainRuntime.Config.UpsertAgentProfile(profile); err != nil {
+			return err
+		}
+	} else {
+		s.mainRuntime.Config.Agent.Skills = snapshot
+	}
+	return s.mainRuntime.Config.Save(s.mainRuntime.ConfigPath)
+}

--- a/pkg/gateway/gateway_speech_stt.go
+++ b/pkg/gateway/gateway_speech_stt.go
@@ -1,0 +1,87 @@
+package gateway
+
+import (
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/speech"
+)
+
+func (s *Server) initSTT() {
+	sttCfg := s.mainRuntime.Config.Speech.STT
+	if !sttCfg.Enabled {
+		return
+	}
+
+	s.sttManager = speech.NewSTTManager()
+
+	if sttCfg.Provider != "" && sttCfg.APIKey != "" {
+		providerType := speech.STTProviderType(sttCfg.Provider)
+		sttProviderCfg := speech.STTConfig{
+			Type:     providerType,
+			APIKey:   sttCfg.APIKey,
+			BaseURL:  sttCfg.BaseURL,
+			Model:    sttCfg.Model,
+			Language: sttCfg.DefaultLang,
+			Timeout:  time.Duration(sttCfg.TimeoutSec) * time.Second,
+		}
+		if sttCfg.TimeoutSec <= 0 {
+			sttProviderCfg.Timeout = 120 * time.Second
+		}
+
+		provider, err := speech.NewSTTProvider(sttProviderCfg)
+		if err != nil {
+			s.appendEvent("stt.init.error", "", map[string]any{"error": err.Error(), "provider": sttCfg.Provider})
+			return
+		}
+
+		if err := s.sttManager.Register(sttCfg.Provider, provider); err != nil {
+			s.appendEvent("stt.init.error", "", map[string]any{"error": err.Error(), "provider": sttCfg.Provider})
+			return
+		}
+	}
+
+	pipelineCfg := speech.STTPipelineConfig{
+		Provider:      sttCfg.Provider,
+		DefaultLang:   sttCfg.DefaultLang,
+		AutoDetect:    sttCfg.DefaultLang == "auto",
+		MaxDuration:   time.Duration(sttCfg.MaxDurationSec) * time.Second,
+		MinConfidence: sttCfg.MinConfidence,
+		Timeout:       time.Duration(sttCfg.TimeoutSec) * time.Second,
+	}
+	if sttCfg.MaxDurationSec <= 0 {
+		pipelineCfg.MaxDuration = 10 * time.Minute
+	}
+	if sttCfg.TimeoutSec <= 0 {
+		pipelineCfg.Timeout = 120 * time.Second
+	}
+
+	s.sttPipeline = speech.NewSTTPipeline(s.sttManager, pipelineCfg)
+
+	integrationCfg := speech.STTIntegrationConfig{
+		Enabled:          sttCfg.Enabled,
+		AutoSTT:          sttCfg.AutoSTT,
+		TriggerPrefix:    sttCfg.TriggerPrefix,
+		Provider:         sttCfg.Provider,
+		DefaultLang:      sttCfg.DefaultLang,
+		MaxDuration:      pipelineCfg.MaxDuration,
+		MinConfidence:    sttCfg.MinConfidence,
+		Timeout:          pipelineCfg.Timeout,
+		Channels:         sttCfg.Channels,
+		ExcludeChannels:  sttCfg.ExcludeChannels,
+		FallbackToVoice:  sttCfg.FallbackToVoice,
+		AppendTranscript: sttCfg.AppendTranscript,
+	}
+	if integrationCfg.TriggerPrefix == "" {
+		integrationCfg.TriggerPrefix = "/transcribe"
+	}
+
+	s.sttIntegration = speech.NewSTTIntegration(s.sttPipeline, integrationCfg)
+
+	s.appendEvent("stt.init.ok", "", map[string]any{
+		"provider": sttCfg.Provider,
+		"auto_stt": sttCfg.AutoSTT,
+		"language": sttCfg.DefaultLang,
+		"channels": len(sttCfg.Channels),
+		"excluded": len(sttCfg.ExcludeChannels),
+	})
+}

--- a/pkg/gateway/gateway_speech_tts.go
+++ b/pkg/gateway/gateway_speech_tts.go
@@ -1,0 +1,130 @@
+package gateway
+
+import (
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/speech"
+)
+
+func (s *Server) initTTS() {
+	ttsCfg := s.mainRuntime.Config.Speech.TTS
+	if !ttsCfg.Enabled {
+		return
+	}
+
+	s.ttsManager = speech.NewManager()
+
+	if ttsCfg.Provider != "" {
+		providerType := speech.ProviderType(ttsCfg.Provider)
+		ttsProviderCfg := speech.Config{
+			Type:        providerType,
+			APIKey:      ttsCfg.APIKey,
+			BaseURL:     ttsCfg.BaseURL,
+			Voice:       ttsCfg.Voice,
+			AudioFormat: speech.AudioFormat(ttsCfg.Format),
+			Timeout:     time.Duration(ttsCfg.TimeoutSec) * time.Second,
+		}
+		if ttsProviderCfg.AudioFormat == "" {
+			ttsProviderCfg.AudioFormat = speech.FormatMP3
+		}
+		if ttsCfg.TimeoutSec <= 0 {
+			ttsProviderCfg.Timeout = 30 * time.Second
+		}
+
+		provider, err := speech.NewProvider(ttsProviderCfg)
+		if err != nil {
+			s.appendEvent("tts.init.error", "", map[string]any{"error": err.Error(), "provider": ttsCfg.Provider})
+			return
+		}
+
+		if err := s.ttsManager.Register(ttsCfg.Provider, provider); err != nil {
+			s.appendEvent("tts.init.error", "", map[string]any{"error": err.Error(), "provider": ttsCfg.Provider})
+			return
+		}
+	}
+
+	pipelineCfg := speech.PipelineConfig{
+		Enabled:         ttsCfg.Enabled,
+		AutoTrigger:     ttsCfg.AutoTTS,
+		TriggerKeywords: []string{ttsCfg.TriggerPrefix},
+		DefaultProvider: ttsCfg.Provider,
+		DefaultVoice:    ttsCfg.Voice,
+		DefaultSpeed:    ttsCfg.Speed,
+		DefaultFormat:   speech.AudioFormat(ttsCfg.Format),
+		FallbackToText:  ttsCfg.FallbackToText,
+		Timeout:         time.Duration(ttsCfg.TimeoutSec) * time.Second,
+	}
+	if pipelineCfg.TriggerKeywords[0] == "" {
+		pipelineCfg.TriggerKeywords = []string{"/speak", "/voice", "/tts"}
+	}
+	if pipelineCfg.DefaultFormat == "" {
+		pipelineCfg.DefaultFormat = speech.FormatMP3
+	}
+	if pipelineCfg.DefaultSpeed <= 0 {
+		pipelineCfg.DefaultSpeed = 1.0
+	}
+	if pipelineCfg.Timeout <= 0 {
+		pipelineCfg.Timeout = 30 * time.Second
+	}
+
+	s.ttsPipeline = speech.NewTTSPipeline(s.ttsManager, pipelineCfg)
+
+	s.registerAudioSenders()
+
+	integrationCfg := speech.IntegrationConfig{
+		Enabled:          ttsCfg.Enabled,
+		AutoTTS:          ttsCfg.AutoTTS,
+		TTSTriggerPrefix: ttsCfg.TriggerPrefix,
+		VoiceProvider:    ttsCfg.Provider,
+		Voice:            ttsCfg.Voice,
+		Speed:            ttsCfg.Speed,
+		Format:           speech.AudioFormat(ttsCfg.Format),
+		FallbackToText:   ttsCfg.FallbackToText,
+		Timeout:          pipelineCfg.Timeout,
+		Channels:         ttsCfg.Channels,
+		ExcludeChannels:  ttsCfg.ExcludeChannels,
+	}
+	if integrationCfg.TTSTriggerPrefix == "" {
+		integrationCfg.TTSTriggerPrefix = "/speak"
+	}
+	if integrationCfg.Format == "" {
+		integrationCfg.Format = speech.FormatMP3
+	}
+	if integrationCfg.Speed <= 0 {
+		integrationCfg.Speed = 1.0
+	}
+
+	s.ttsIntegration = speech.NewIntegration(s.ttsPipeline, nil, nil, integrationCfg)
+
+	s.appendEvent("tts.init.ok", "", map[string]any{
+		"provider": ttsCfg.Provider,
+		"auto_tts": ttsCfg.AutoTTS,
+		"voice":    ttsCfg.Voice,
+		"channels": len(ttsCfg.Channels),
+		"excluded": len(ttsCfg.ExcludeChannels),
+	})
+}
+
+func (s *Server) registerAudioSenders() {
+	if s.ttsPipeline == nil {
+		return
+	}
+
+	chCfg := s.mainRuntime.Config.Channels
+
+	if chCfg.Telegram.Enabled && chCfg.Telegram.BotToken != "" {
+		s.ttsPipeline.RegisterAudioSender("telegram", speech.NewTelegramAudioSender(chCfg.Telegram.BotToken))
+	}
+	if chCfg.Discord.Enabled && chCfg.Discord.BotToken != "" {
+		s.ttsPipeline.RegisterAudioSender("discord", speech.NewDiscordAudioSender(chCfg.Discord.BotToken))
+	}
+	if chCfg.Slack.Enabled && chCfg.Slack.BotToken != "" {
+		s.ttsPipeline.RegisterAudioSender("slack", speech.NewSlackAudioSender(chCfg.Slack.BotToken))
+	}
+	if chCfg.WhatsApp.Enabled && chCfg.WhatsApp.PhoneNumberID != "" && chCfg.WhatsApp.AccessToken != "" {
+		s.ttsPipeline.RegisterAudioSender("whatsapp", speech.NewWhatsAppAudioSender(chCfg.WhatsApp.PhoneNumberID, chCfg.WhatsApp.AccessToken))
+	}
+	if chCfg.Signal.Enabled && chCfg.Signal.Number != "" {
+		s.ttsPipeline.RegisterAudioSender("signal", speech.NewSignalAudioSender(chCfg.Signal.Number, ""))
+	}
+}

--- a/pkg/gateway/gateway_split_api_test.go
+++ b/pkg/gateway/gateway_split_api_test.go
@@ -1,0 +1,293 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/plugin"
+	gatewayauth "github.com/1024XEngineer/anyclaw/pkg/gateway/auth"
+)
+
+func newAdminRequest(method string, target string, body string) *http.Request {
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	user := &gatewayauth.User{Name: "tester", Permissions: []string{"*"}}
+	return req.WithContext(gatewayauth.WithUser(req.Context(), user))
+}
+
+func decodeBodyMap(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, rec.Body.String())
+	}
+	return payload
+}
+
+func newSplitAPITestServer(t *testing.T) *Server {
+	t.Helper()
+	server := New(newTestMainRuntime(t))
+	if err := server.ensureDefaultWorkspace(); err != nil {
+		t.Fatalf("ensure default workspace: %v", err)
+	}
+	server.marketStore = plugin.NewStore(
+		filepath.Join(t.TempDir(), "plugins"),
+		filepath.Join(t.TempDir(), "market"),
+		filepath.Join(t.TempDir(), "cache"),
+		nil,
+		nil,
+		server.plugins,
+	)
+	server.mainRuntime.Config.Security.Users = []config.SecurityUser{{Name: "tester", Token: "token-1", Role: "admin"}}
+	server.mainRuntime.Config.Security.Roles = []config.SecurityRole{{Name: "custom", Permissions: []string{"config.read"}}}
+	server.mainRuntime.Config.Agent.Profiles = []config.AgentProfile{{Name: "helper", Enabled: config.BoolPtr(true)}}
+	server.mainRuntime.Config.Providers = []config.ProviderProfile{{ID: "provider-1", Name: "Provider 1", Type: "openai", Provider: "openai", Enabled: config.BoolPtr(true)}}
+	server.mainRuntime.Config.LLM.DefaultProviderRef = "provider-1"
+	return server
+}
+
+func TestSplitAPIs_ConfigUsersRolesAndTasks(t *testing.T) {
+	server := newSplitAPITestServer(t)
+
+	t.Run("config api", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		server.handleConfigAPI(rec, newAdminRequest(http.MethodGet, "/config", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /config = %d", rec.Code)
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleConfigAPI(rec, newAdminRequest(http.MethodPost, "/config", `{"llm":{"provider":"x","model":"y"}}`))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("POST /config = %d body=%s", rec.Code, rec.Body.String())
+		}
+		if server.mainRuntime.Config.LLM.Provider != "x" || server.mainRuntime.Config.LLM.Model != "y" {
+			t.Fatalf("llm patch not applied")
+		}
+
+		_, err := parseChannelRoutingRules([]any{
+			map[string]any{"channel": "discord", "match": "support"},
+			map[string]any{"channel": "discord", "match": "support"},
+		})
+		if err == nil {
+			t.Fatal("expected duplicate routing rule error")
+		}
+	})
+
+	t.Run("users api", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		server.handleUsers(rec, newAdminRequest(http.MethodGet, "/auth/users", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /auth/users = %d", rec.Code)
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleUsers(rec, newAdminRequest(http.MethodPost, "/auth/users", `{"name":"new-user","token":"token-2"}`))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("POST /auth/users = %d body=%s", rec.Code, rec.Body.String())
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleUsers(rec, newAdminRequest(http.MethodDelete, "/auth/users?name=new-user", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("DELETE /auth/users = %d body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("roles api", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		server.handleRoles(rec, newAdminRequest(http.MethodGet, "/auth/roles", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /auth/roles = %d", rec.Code)
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleRoles(rec, newAdminRequest(http.MethodPost, "/auth/roles", `{"name":"writers","permissions":["config.write"]}`))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("POST /auth/roles = %d body=%s", rec.Code, rec.Body.String())
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleRoleImpact(rec, newAdminRequest(http.MethodGet, "/auth/roles/impact", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /auth/roles/impact = %d", rec.Code)
+		}
+	})
+
+	t.Run("tasks api", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		server.handleV2Tasks(rec, newAdminRequest(http.MethodGet, "/v2/tasks", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /v2/tasks = %d", rec.Code)
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleV2TaskByID(rec, newAdminRequest(http.MethodGet, "/v2/tasks/missing", ""))
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("GET missing /v2/tasks/id = %d", rec.Code)
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleV2Agents(rec, newAdminRequest(http.MethodGet, "/v2/agents", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /v2/agents = %d", rec.Code)
+		}
+
+		server.executeTaskAsync("", "test")
+	})
+}
+
+func TestSplitAPIs_MarketMCPProvidersAndBindings(t *testing.T) {
+	server := newSplitAPITestServer(t)
+
+	t.Run("market api", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		server.handleMarketSearch(rec, newAdminRequest(http.MethodGet, "/market/search?q=test", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /market/search = %d body=%s", rec.Code, rec.Body.String())
+		}
+		payload := decodeBodyMap(t, rec)
+		if payload["total"] == nil {
+			t.Fatalf("expected total in market search response")
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleMarketPlugins(rec, newAdminRequest(http.MethodGet, "/market/plugins", ""))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("GET /market/plugins missing id = %d", rec.Code)
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleMarketPluginAction(rec, newAdminRequest(http.MethodGet, "/market/plugins/plugin-1/history", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /market/plugins/history = %d body=%s", rec.Code, rec.Body.String())
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleMarketInstalled(rec, newAdminRequest(http.MethodGet, "/market/installed", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /market/installed = %d", rec.Code)
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleMarketCategories(rec, newAdminRequest(http.MethodGet, "/market/categories", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /market/categories = %d", rec.Code)
+		}
+	})
+
+	t.Run("mcp api", func(t *testing.T) {
+		for _, handler := range []func(http.ResponseWriter, *http.Request){
+			server.handleMCPServers,
+			server.handleMCPTools,
+			server.handleMCPResources,
+			server.handleMCPPrompts,
+		} {
+			rec := httptest.NewRecorder()
+			handler(rec, newAdminRequest(http.MethodGet, "/mcp", ""))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("mcp GET = %d body=%s", rec.Code, rec.Body.String())
+			}
+		}
+
+		rec := httptest.NewRecorder()
+		server.handleMCPCall(rec, newAdminRequest(http.MethodPost, "/mcp/call", `{`))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("POST /mcp/call invalid json = %d", rec.Code)
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleMCPServerAction(rec, newAdminRequest(http.MethodGet, "/mcp/servers/", ""))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("GET /mcp/servers/ missing name = %d", rec.Code)
+		}
+	})
+
+	t.Run("providers api", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		server.handleProviders(rec, newAdminRequest(http.MethodGet, "/providers", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /providers = %d", rec.Code)
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleProviderUpsert(rec, newAdminRequest(http.MethodPost, "/providers", `{"id":"provider-2","name":"Provider 2","type":"openai","provider":"openai"}`))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("POST /providers = %d body=%s", rec.Code, rec.Body.String())
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleProviderDelete(rec, newAdminRequest(http.MethodDelete, "/providers?id=provider-2", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("DELETE /providers = %d body=%s", rec.Code, rec.Body.String())
+		}
+
+		provider := config.ProviderProfile{ID: "provider-3"}
+		mergeProviderSecretsAndExtra(&provider, config.ProviderProfile{APIKey: "secret", Extra: map[string]string{"k": "v"}})
+		if provider.APIKey != "secret" || provider.Extra["k"] != "v" {
+			t.Fatalf("expected provider secrets to merge")
+		}
+	})
+
+	t.Run("provider helpers and agent bindings", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		server.handleDefaultProvider(rec, newAdminRequest(http.MethodPost, "/providers/default", `{"provider_ref":"provider-1"}`))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("POST /providers/default = %d body=%s", rec.Code, rec.Body.String())
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleProviderTest(rec, newAdminRequest(http.MethodPost, "/providers/test", `{"name":"Provider 1"}`))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("POST /providers/test = %d body=%s", rec.Code, rec.Body.String())
+		}
+
+		probe := config.ProviderProfile{Name: "Provider 1"}
+		enrichProviderForHealthTest(&probe, server.mainRuntime.Config)
+		if probe.ID == "" || probe.Provider == "" {
+			t.Fatalf("expected provider health enrichment to fill fields: %+v", probe)
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleAgentBindings(rec, newAdminRequest(http.MethodGet, "/agent-bindings", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /agent-bindings = %d", rec.Code)
+		}
+
+		model := "model-x"
+		body, _ := json.Marshal(map[string]any{"agent": "helper", "provider_ref": "provider-1", "model": model})
+		rec = httptest.NewRecorder()
+		server.handleAgentBindings(rec, newAdminRequest(http.MethodPost, "/agent-bindings", string(body)))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("POST /agent-bindings = %d body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("agents api", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		server.handleAgents(rec, newAdminRequest(http.MethodGet, "/agents", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /agents = %d", rec.Code)
+		}
+
+		payload := bytes.NewBufferString(`{"name":"helper-2","provider_ref":"provider-1"}`)
+		rec = httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/agents", payload)
+		req = req.WithContext(gatewayauth.WithUser(req.Context(), &gatewayauth.User{Name: "tester", Permissions: []string{"*"}}))
+		server.handleAgents(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("POST /agents = %d body=%s", rec.Code, rec.Body.String())
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleAssistants(rec, newAdminRequest(http.MethodGet, "/assistants", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /assistants = %d", rec.Code)
+		}
+	})
+}

--- a/pkg/gateway/gateway_split_api_test.go
+++ b/pkg/gateway/gateway_split_api_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/1024XEngineer/anyclaw/pkg/config"
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/mcp"
 	"github.com/1024XEngineer/anyclaw/pkg/extensions/plugin"
 	gatewayauth "github.com/1024XEngineer/anyclaw/pkg/gateway/auth"
 )
@@ -97,6 +98,12 @@ func TestSplitAPIs_ConfigUsersRolesAndTasks(t *testing.T) {
 		if rec.Code != http.StatusOK {
 			t.Fatalf("DELETE /auth/users = %d body=%s", rec.Code, rec.Body.String())
 		}
+
+		rec = httptest.NewRecorder()
+		server.handleUsers(rec, newAdminRequest(http.MethodPost, "/auth/users", `{"name":"bad-user","token":"token-3","permission_overrides":["unknown"]}`))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("POST /auth/users invalid permission = %d body=%s", rec.Code, rec.Body.String())
+		}
 	})
 
 	t.Run("roles api", func(t *testing.T) {
@@ -117,6 +124,12 @@ func TestSplitAPIs_ConfigUsersRolesAndTasks(t *testing.T) {
 		if rec.Code != http.StatusOK {
 			t.Fatalf("GET /auth/roles/impact = %d", rec.Code)
 		}
+
+		rec = httptest.NewRecorder()
+		server.handleRoles(rec, newAdminRequest(http.MethodDelete, "/auth/roles?name=missing", ""))
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("DELETE /auth/roles missing = %d body=%s", rec.Code, rec.Body.String())
+		}
 	})
 
 	t.Run("tasks api", func(t *testing.T) {
@@ -124,6 +137,12 @@ func TestSplitAPIs_ConfigUsersRolesAndTasks(t *testing.T) {
 		server.handleV2Tasks(rec, newAdminRequest(http.MethodGet, "/v2/tasks", ""))
 		if rec.Code != http.StatusOK {
 			t.Fatalf("GET /v2/tasks = %d", rec.Code)
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleV2Tasks(rec, newAdminRequest(http.MethodPost, "/v2/tasks", `{`))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("POST /v2/tasks = %d body=%s", rec.Code, rec.Body.String())
 		}
 
 		rec = httptest.NewRecorder()
@@ -168,6 +187,23 @@ func TestSplitAPIs_MarketMCPProvidersAndBindings(t *testing.T) {
 			t.Fatalf("GET /market/plugins/history = %d body=%s", rec.Code, rec.Body.String())
 		}
 
+		for _, path := range []string{
+			"/market/plugins/plugin-1/update",
+			"/market/plugins/plugin-1/uninstall",
+			"/market/plugins/plugin-1/rollback?version=v1",
+			"/market/plugins/plugin-1/versions",
+		} {
+			method := http.MethodPost
+			if strings.Contains(path, "versions") {
+				method = http.MethodGet
+			}
+			rec = httptest.NewRecorder()
+			server.handleMarketPluginAction(rec, newAdminRequest(method, path, ""))
+			if rec.Code == 0 {
+				t.Fatalf("unexpected market action status for %s", path)
+			}
+		}
+
 		rec = httptest.NewRecorder()
 		server.handleMarketInstalled(rec, newAdminRequest(http.MethodGet, "/market/installed", ""))
 		if rec.Code != http.StatusOK {
@@ -201,10 +237,23 @@ func TestSplitAPIs_MarketMCPProvidersAndBindings(t *testing.T) {
 			t.Fatalf("POST /mcp/call invalid json = %d", rec.Code)
 		}
 
+		server.mcpRegistry = mcp.NewRegistry()
+		rec = httptest.NewRecorder()
+		server.handleMCPCall(rec, newAdminRequest(http.MethodPost, "/mcp/call", `{}`))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("POST /mcp/call missing target = %d body=%s", rec.Code, rec.Body.String())
+		}
+
 		rec = httptest.NewRecorder()
 		server.handleMCPServerAction(rec, newAdminRequest(http.MethodGet, "/mcp/servers/", ""))
 		if rec.Code != http.StatusBadRequest {
 			t.Fatalf("GET /mcp/servers/ missing name = %d", rec.Code)
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleMCPServerAction(rec, newAdminRequest(http.MethodGet, "/mcp/servers/missing", ""))
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("GET /mcp/servers/missing = %d body=%s", rec.Code, rec.Body.String())
 		}
 	})
 
@@ -213,6 +262,12 @@ func TestSplitAPIs_MarketMCPProvidersAndBindings(t *testing.T) {
 		server.handleProviders(rec, newAdminRequest(http.MethodGet, "/providers", ""))
 		if rec.Code != http.StatusOK {
 			t.Fatalf("GET /providers = %d", rec.Code)
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleProviderUpsert(rec, newAdminRequest(http.MethodPost, "/providers", `{`))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("POST /providers invalid body = %d body=%s", rec.Code, rec.Body.String())
 		}
 
 		rec = httptest.NewRecorder()
@@ -225,6 +280,12 @@ func TestSplitAPIs_MarketMCPProvidersAndBindings(t *testing.T) {
 		server.handleProviderDelete(rec, newAdminRequest(http.MethodDelete, "/providers?id=provider-2", ""))
 		if rec.Code != http.StatusOK {
 			t.Fatalf("DELETE /providers = %d body=%s", rec.Code, rec.Body.String())
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleProviderDelete(rec, newAdminRequest(http.MethodDelete, "/providers?id=missing", ""))
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("DELETE /providers missing = %d body=%s", rec.Code, rec.Body.String())
 		}
 
 		provider := config.ProviderProfile{ID: "provider-3"}
@@ -273,6 +334,12 @@ func TestSplitAPIs_MarketMCPProvidersAndBindings(t *testing.T) {
 		server.handleAgents(rec, newAdminRequest(http.MethodGet, "/agents", ""))
 		if rec.Code != http.StatusOK {
 			t.Fatalf("GET /agents = %d", rec.Code)
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleAgents(rec, newAdminRequest(http.MethodDelete, "/agents?name=missing", ""))
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("DELETE /agents missing = %d body=%s", rec.Code, rec.Body.String())
 		}
 
 		payload := bytes.NewBufferString(`{"name":"helper-2","provider_ref":"provider-1"}`)

--- a/pkg/gateway/gateway_store_api.go
+++ b/pkg/gateway/gateway_store_api.go
@@ -1,0 +1,92 @@
+package gateway
+
+import (
+	"net/http"
+	"strings"
+
+	agentstore "github.com/1024XEngineer/anyclaw/pkg/capability/catalogs"
+)
+
+func (s *Server) handleV2Store(w http.ResponseWriter, r *http.Request) {
+	if s.storeModule == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "store not available"})
+		return
+	}
+
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	filter := agentstore.StoreFilter{
+		Category: r.URL.Query().Get("category"),
+		Tag:      r.URL.Query().Get("tag"),
+		Keyword:  r.URL.Query().Get("q"),
+	}
+
+	if installedStr := r.URL.Query().Get("installed"); installedStr != "" {
+		installed := installedStr == "true"
+		filter.Installed = &installed
+	}
+
+	packages := s.storeModule.List(filter)
+	writeJSON(w, http.StatusOK, packages)
+}
+
+func (s *Server) handleV2StoreByID(w http.ResponseWriter, r *http.Request) {
+	if s.storeModule == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "store not available"})
+		return
+	}
+
+	id := strings.TrimPrefix(r.URL.Path, "/v2/store/")
+	if id == "" {
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"categories": s.storeModule.GetCategories(),
+			"tags":       s.storeModule.GetTags(),
+		})
+		return
+	}
+
+	parts := strings.SplitN(id, "/", 2)
+	pkgID := parts[0]
+	action := ""
+	if len(parts) > 1 {
+		action = parts[1]
+	}
+
+	switch {
+	case action == "install" && r.Method == http.MethodPost:
+		if err := s.storeModule.Install(pkgID); err != nil {
+			code := http.StatusInternalServerError
+			if strings.Contains(err.Error(), "not found") {
+				code = http.StatusNotFound
+			}
+			writeJSON(w, code, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "installed", "id": pkgID})
+
+	case action == "uninstall" && r.Method == http.MethodPost:
+		if err := s.storeModule.Uninstall(pkgID); err != nil {
+			code := http.StatusInternalServerError
+			if strings.Contains(err.Error(), "not found") {
+				code = http.StatusNotFound
+			}
+			writeJSON(w, code, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "uninstalled", "id": pkgID})
+
+	case action == "" && r.Method == http.MethodGet:
+		pkg, err := s.storeModule.Get(pkgID)
+		if err != nil {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, pkg)
+
+	default:
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+	}
+}

--- a/pkg/gateway/gateway_store_health_test.go
+++ b/pkg/gateway/gateway_store_health_test.go
@@ -1,0 +1,150 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	agentstore "github.com/1024XEngineer/anyclaw/pkg/capability/catalogs"
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+type fakeStoreManager struct {
+	packages     map[string]agentstore.AgentPackage
+	installErr   error
+	uninstallErr error
+}
+
+func (f *fakeStoreManager) List(filter agentstore.StoreFilter) []agentstore.AgentPackage {
+	items := make([]agentstore.AgentPackage, 0, len(f.packages))
+	for _, pkg := range f.packages {
+		items = append(items, pkg)
+	}
+	return items
+}
+
+func (f *fakeStoreManager) Get(id string) (*agentstore.AgentPackage, error) {
+	pkg, ok := f.packages[id]
+	if !ok {
+		return nil, fmt.Errorf("package not found: %s", id)
+	}
+	return &pkg, nil
+}
+
+func (f *fakeStoreManager) Search(string) []agentstore.AgentPackage {
+	return f.List(agentstore.StoreFilter{})
+}
+func (f *fakeStoreManager) Install(id string) error {
+	if f.installErr != nil {
+		return f.installErr
+	}
+	if _, ok := f.packages[id]; !ok {
+		return fmt.Errorf("package not found: %s", id)
+	}
+	return nil
+}
+func (f *fakeStoreManager) Uninstall(id string) error {
+	if f.uninstallErr != nil {
+		return f.uninstallErr
+	}
+	if _, ok := f.packages[id]; !ok {
+		return fmt.Errorf("package not found: %s", id)
+	}
+	return nil
+}
+func (f *fakeStoreManager) Installed() []agentstore.AgentPackage {
+	return f.List(agentstore.StoreFilter{})
+}
+func (f *fakeStoreManager) IsInstalled(string) bool { return true }
+func (f *fakeStoreManager) GetCategories() []string { return []string{"tool", "assistant"} }
+func (f *fakeStoreManager) GetTags() []string       { return []string{"featured", "fast"} }
+
+func TestGatewayStoreAndProviderHealth(t *testing.T) {
+	server := newSplitAPITestServer(t)
+	server.storeModule = &fakeStoreManager{packages: map[string]agentstore.AgentPackage{
+		"pkg-1": {ID: "pkg-1", Name: "One"},
+	}}
+
+	t.Run("store list and details", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		server.handleV2Store(rec, newAdminRequest(http.MethodGet, "/v2/store?installed=true&q=test", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /v2/store = %d body=%s", rec.Code, rec.Body.String())
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleV2StoreByID(rec, newAdminRequest(http.MethodGet, "/v2/store/", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /v2/store/ = %d body=%s", rec.Code, rec.Body.String())
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleV2StoreByID(rec, newAdminRequest(http.MethodGet, "/v2/store/pkg-1", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /v2/store/pkg-1 = %d body=%s", rec.Code, rec.Body.String())
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleV2StoreByID(rec, newAdminRequest(http.MethodPost, "/v2/store/pkg-1/install", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("POST /v2/store/pkg-1/install = %d body=%s", rec.Code, rec.Body.String())
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleV2StoreByID(rec, newAdminRequest(http.MethodPost, "/v2/store/pkg-1/uninstall", ""))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("POST /v2/store/pkg-1/uninstall = %d body=%s", rec.Code, rec.Body.String())
+		}
+
+		rec = httptest.NewRecorder()
+		server.handleV2StoreByID(rec, newAdminRequest(http.MethodGet, "/v2/store/missing", ""))
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("GET /v2/store/missing = %d body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("provider health", func(t *testing.T) {
+		if got := quickProviderHealth(config.ProviderProfile{Enabled: config.BoolPtr(false)}); got.Status != "disabled" {
+			t.Fatalf("disabled provider status = %q", got.Status)
+		}
+		if got := quickProviderHealth(config.ProviderProfile{Enabled: config.BoolPtr(true)}); got.Status != "invalid" {
+			t.Fatalf("missing provider status = %q", got.Status)
+		}
+		if got := quickProviderHealth(config.ProviderProfile{Enabled: config.BoolPtr(true), Provider: "openai"}); got.Status != "missing_key" {
+			t.Fatalf("missing key status = %q", got.Status)
+		}
+		if got := quickProviderHealth(config.ProviderProfile{Enabled: config.BoolPtr(true), Provider: "ollama", BaseURL: "://bad"}); got.Status != "invalid_base_url" {
+			t.Fatalf("invalid url status = %q", got.Status)
+		}
+
+		successSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer successSrv.Close()
+		if got := activeProviderTest(context.Background(), config.ProviderProfile{Enabled: config.BoolPtr(true), Provider: "compatible", APIKey: "key", BaseURL: successSrv.URL}); got.Status != "reachable" {
+			t.Fatalf("reachable provider status = %q", got.Status)
+		}
+
+		authSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer authSrv.Close()
+		if got := activeProviderTest(context.Background(), config.ProviderProfile{Enabled: config.BoolPtr(true), Provider: "compatible", APIKey: "key", BaseURL: authSrv.URL}); got.Status != "auth_error" {
+			t.Fatalf("auth provider status = %q", got.Status)
+		}
+
+		notFoundSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer notFoundSrv.Close()
+		if got := activeProviderTest(context.Background(), config.ProviderProfile{Enabled: config.BoolPtr(true), Provider: "compatible", APIKey: "key", BaseURL: notFoundSrv.URL}); got.Status != "endpoint_not_found" {
+			t.Fatalf("404 provider status = %q", got.Status)
+		}
+
+		if got := activeProviderTest(context.Background(), config.ProviderProfile{Enabled: config.BoolPtr(true), Provider: "compatible", APIKey: "key"}); got.Status != "ready" {
+			t.Fatalf("default endpoint status = %q", got.Status)
+		}
+	})
+}

--- a/pkg/gateway/gateway_tasks_v2_api.go
+++ b/pkg/gateway/gateway_tasks_v2_api.go
@@ -1,0 +1,248 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	gatewaycommands "github.com/1024XEngineer/anyclaw/pkg/gateway/commands"
+	taskrunner "github.com/1024XEngineer/anyclaw/pkg/runtime/taskrunner"
+	"github.com/1024XEngineer/anyclaw/pkg/state"
+)
+
+func (s *Server) handleV2Agents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, s.v2VisibleAgents())
+}
+
+func (s *Server) handleV2Tasks(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		tasks := s.v2ListTasks(r)
+		writeJSON(w, http.StatusOK, tasks)
+	case http.MethodPost:
+		s.handleV2TaskCreate(w, r)
+	default:
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+	}
+}
+
+func (s *Server) handleV2TaskCreate(w http.ResponseWriter, r *http.Request) {
+	req, commandReq, err := s.surfaceService().DecodeHTTPV2TaskCreate(r)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+		return
+	}
+	mode, err := gatewaycommands.ValidateV2TaskCreate(req)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	dispatch, err := s.commandIntakeService().Dispatch(commandReq)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if dispatch.Kind != "mutate" || dispatch.Target != "tasks" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unexpected command dispatch"})
+		return
+	}
+
+	selectedAgents, err := s.mainEntryPolicy().NormalizeSelectionList(append([]string{req.SelectedAgent}, req.SelectedAgents...)...)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	assistantName, err := s.mainEntryPolicy().NormalizeRequestedAgent(req.SelectedAgent, req.Assistant)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	orgID, projectID, workspaceID, err := s.v2TaskHierarchy(r, req.SessionID)
+	if err != nil {
+		status := http.StatusBadRequest
+		if errors.Is(err, errSessionNotFound) {
+			status = http.StatusNotFound
+		}
+		writeJSON(w, status, map[string]string{"error": err.Error()})
+		return
+	}
+
+	task, err := s.tasks.Create(taskrunner.CreateOptions{
+		Title:     req.Title,
+		Input:     req.Input,
+		Assistant: assistantName,
+		Org:       orgID,
+		Project:   projectID,
+		Workspace: workspaceID,
+		SessionID: req.SessionID,
+	})
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	if req.Sync {
+		result, err := s.tasks.Execute(r.Context(), task.ID)
+		if err != nil {
+			if errors.Is(err, taskrunner.ErrTaskWaitingApproval) {
+				response := s.taskResponse(result.Task, result.Session)
+				response["status"] = "waiting_approval"
+				response["requested_mode"] = mode
+				response["routing_mode"] = "main_agent"
+				response["selected_agents"] = selectedAgents
+				writeJSON(w, http.StatusAccepted, response)
+				return
+			}
+			writeJSON(w, http.StatusInternalServerError, map[string]any{
+				"task":  task,
+				"error": err.Error(),
+			})
+			return
+		}
+		s.recordTaskCompletion(result, "task_api_v2")
+		response := s.taskResponse(result.Task, result.Session)
+		response["requested_mode"] = mode
+		response["routing_mode"] = "main_agent"
+		response["selected_agents"] = selectedAgents
+		writeJSON(w, http.StatusOK, response)
+		return
+	}
+
+	taskID := task.ID
+	go s.executeTaskAsync(taskID, "task_api_v2_async")
+
+	response := s.taskResponse(task, nil)
+	response["status"] = "queued"
+	response["requested_mode"] = mode
+	response["routing_mode"] = "main_agent"
+	response["selected_agents"] = selectedAgents
+	writeJSON(w, http.StatusAccepted, response)
+}
+
+func (s *Server) handleV2TaskByID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	taskID := strings.TrimPrefix(r.URL.Path, "/v2/tasks/")
+	if taskID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "task id required"})
+		return
+	}
+
+	task, ok := s.tasks.Get(taskID)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, s.taskResponse(task, nil))
+}
+
+var errSessionNotFound = errors.New("session not found")
+
+func (s *Server) v2ListTasks(r *http.Request) []*state.Task {
+	items := s.store.ListTasks()
+	workspace := strings.TrimSpace(r.URL.Query().Get("workspace"))
+	status := strings.TrimSpace(r.URL.Query().Get("status"))
+	assistant := strings.TrimSpace(r.URL.Query().Get("assistant"))
+	if workspace == "" && status == "" && assistant == "" {
+		return items
+	}
+	filtered := make([]*state.Task, 0, len(items))
+	for _, task := range items {
+		if workspace != "" && !strings.EqualFold(strings.TrimSpace(task.Workspace), workspace) {
+			continue
+		}
+		if status != "" && !strings.EqualFold(strings.TrimSpace(task.Status), status) {
+			continue
+		}
+		if assistant != "" && !strings.EqualFold(strings.TrimSpace(task.Assistant), assistant) {
+			continue
+		}
+		filtered = append(filtered, task)
+	}
+	return filtered
+}
+
+func (s *Server) v2TaskHierarchy(r *http.Request, sessionID string) (string, string, string, error) {
+	if sessionID != "" {
+		session, ok := s.sessions.Get(sessionID)
+		if !ok {
+			return "", "", "", errSessionNotFound
+		}
+		orgID, projectID, workspaceID := state.SessionExecutionHierarchy(session)
+		return orgID, projectID, workspaceID, nil
+	}
+	queryOrg, queryProject, queryWorkspace := s.resolveHierarchyFromQuery(r)
+	org, project, workspace, err := s.validateResourceSelection(queryOrg, queryProject, queryWorkspace)
+	if err != nil {
+		return "", "", "", err
+	}
+	return org.ID, project.ID, workspace.ID, nil
+}
+
+func (s *Server) executeTaskAsync(taskID string, source string) {
+	if s == nil || s.tasks == nil || strings.TrimSpace(taskID) == "" {
+		return
+	}
+	result, err := s.tasks.Execute(context.Background(), taskID)
+	if err != nil {
+		if errors.Is(err, taskrunner.ErrTaskWaitingApproval) {
+			return
+		}
+		return
+	}
+	s.recordTaskCompletion(result, source)
+}
+
+func (s *Server) v2VisibleAgents() []map[string]any {
+	items := make([]map[string]any, 0, len(s.mainRuntime.Config.Agent.Profiles)+1)
+	seen := make(map[string]struct{}, len(s.mainRuntime.Config.Agent.Profiles)+1)
+	appendProfile := func(name string, description string, role string, persona string, domain string, expertise []string, entry string, publicEntry bool, routingDecision string) {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return
+		}
+		key := strings.ToLower(name)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		record := map[string]any{
+			"name":             name,
+			"description":      strings.TrimSpace(description),
+			"role":             strings.TrimSpace(role),
+			"persona":          strings.TrimSpace(persona),
+			"domain":           strings.TrimSpace(domain),
+			"expertise":        expertise,
+			"entry":            entry,
+			"public_entry":     publicEntry,
+			"routing_decision": routingDecision,
+		}
+		items = append(items, record)
+	}
+
+	if profile, ok := s.mainRuntime.Config.ResolveMainAgentProfile(); ok {
+		appendProfile(profile.Name, profile.Description, profile.Role, profile.Persona, profile.Domain, append([]string(nil), profile.Expertise...), "main", true, "main_agent")
+	} else if mainName := strings.TrimSpace(s.mainRuntime.Config.ResolveMainAgentName()); mainName != "" {
+		appendProfile(mainName, s.mainRuntime.Config.Agent.Description, "", "", "", nil, "main", true, "main_agent")
+	}
+
+	for _, profile := range s.mainRuntime.Config.Agent.Profiles {
+		if !profile.IsEnabled() {
+			continue
+		}
+		appendProfile(profile.Name, profile.Description, profile.Role, profile.Persona, profile.Domain, append([]string(nil), profile.Expertise...), "specialist", false, "main_agent_handoff")
+	}
+	return items
+}

--- a/pkg/gateway/gateway_tool_activity_api.go
+++ b/pkg/gateway/gateway_tool_activity_api.go
@@ -1,0 +1,22 @@
+package gateway
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+func (s *Server) handleToolActivity(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	limit := 100
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+	sessionID := strings.TrimSpace(r.URL.Query().Get("session_id"))
+	writeJSON(w, http.StatusOK, s.store.ListToolActivities(limit, sessionID))
+}

--- a/pkg/gateway/gateway_tools_api.go
+++ b/pkg/gateway/gateway_tools_api.go
@@ -1,0 +1,11 @@
+package gateway
+
+import "net/http"
+
+func (s *Server) handleTools(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	writeJSON(w, http.StatusOK, s.mainRuntime.ListTools())
+}

--- a/pkg/gateway/gateway_users_api.go
+++ b/pkg/gateway/gateway_users_api.go
@@ -1,0 +1,161 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+	gatewayauth "github.com/1024XEngineer/anyclaw/pkg/gateway/auth"
+)
+
+func (s *Server) handleUsers(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		if !HasPermission(UserFromContext(r.Context()), "auth.users.read") {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_permission": "auth.users.read"})
+			return
+		}
+		s.appendAudit(UserFromContext(r.Context()), "auth.users.read", "users", nil)
+		writeJSON(w, http.StatusOK, s.listUserViews())
+	case http.MethodPost:
+		s.handleUserUpsert(w, r)
+	case http.MethodDelete:
+		s.handleUserDelete(w, r)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) listUserViews() []map[string]any {
+	rolesIndex := map[string]config.SecurityRole{}
+	for _, role := range s.mainRuntime.Config.Security.Roles {
+		rolesIndex[role.Name] = role
+	}
+	for _, role := range gatewayauth.BuiltinRoleTemplates() {
+		rolesIndex[role.Name] = role
+	}
+	items := make([]map[string]any, 0, len(s.mainRuntime.Config.Security.Users))
+	for _, user := range s.mainRuntime.Config.Security.Users {
+		effective := append([]string{}, user.PermissionOverrides...)
+		if role, ok := rolesIndex[user.Role]; ok {
+			effective = append(append([]string{}, role.Permissions...), user.PermissionOverrides...)
+		}
+		items = append(items, map[string]any{
+			"name":                 user.Name,
+			"role":                 user.Role,
+			"permissions":          effective,
+			"permission_overrides": user.PermissionOverrides,
+			"scopes":               user.Scopes,
+			"orgs":                 user.Orgs,
+			"projects":             user.Projects,
+			"workspaces":           user.Workspaces,
+		})
+	}
+	return items
+}
+
+func (s *Server) handleUserUpsert(w http.ResponseWriter, r *http.Request) {
+	if !HasPermission(UserFromContext(r.Context()), "auth.users.read") {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_permission": "auth.users.read"})
+		return
+	}
+	var user config.SecurityUser
+	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+		return
+	}
+	if strings.TrimSpace(user.Name) == "" || strings.TrimSpace(user.Token) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name and token are required"})
+		return
+	}
+	for _, permission := range user.PermissionOverrides {
+		if !allowedSecurityPermissions()[permission] {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown permission", "permission": permission})
+			return
+		}
+	}
+	for _, existing := range s.mainRuntime.Config.Security.Users {
+		if existing.Name != user.Name && existing.Token == user.Token {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "token already in use"})
+			return
+		}
+	}
+	updated := false
+	for i := range s.mainRuntime.Config.Security.Users {
+		if s.mainRuntime.Config.Security.Users[i].Name == user.Name {
+			s.mainRuntime.Config.Security.Users[i] = user
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		s.mainRuntime.Config.Security.Users = append(s.mainRuntime.Config.Security.Users, user)
+	}
+	if err := s.mainRuntime.Config.Save(s.mainRuntime.ConfigPath); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	s.appendAudit(UserFromContext(r.Context()), "auth.users.write", user.Name, nil)
+	writeJSON(w, http.StatusOK, map[string]any{"status": "ok"})
+}
+
+func (s *Server) handleUserDelete(w http.ResponseWriter, r *http.Request) {
+	if !HasPermission(UserFromContext(r.Context()), "auth.users.read") {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden", "required_permission": "auth.users.read"})
+		return
+	}
+	name := strings.TrimSpace(r.URL.Query().Get("name"))
+	if name == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
+		return
+	}
+	filtered := make([]config.SecurityUser, 0, len(s.mainRuntime.Config.Security.Users))
+	removed := false
+	for _, user := range s.mainRuntime.Config.Security.Users {
+		if user.Name == name {
+			removed = true
+			continue
+		}
+		filtered = append(filtered, user)
+	}
+	if !removed {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "user not found"})
+		return
+	}
+	s.mainRuntime.Config.Security.Users = filtered
+	if err := s.mainRuntime.Config.Save(s.mainRuntime.ConfigPath); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	s.appendAudit(UserFromContext(r.Context()), "auth.users.delete", name, nil)
+	writeJSON(w, http.StatusOK, map[string]any{"status": "deleted"})
+}
+
+func allowedSecurityPermissions() map[string]bool {
+	return map[string]bool{
+		"*":               true,
+		"status.read":     true,
+		"chat.send":       true,
+		"tasks.read":      true,
+		"tasks.write":     true,
+		"approvals.read":  true,
+		"approvals.write": true,
+		"sessions.read":   true,
+		"sessions.write":  true,
+		"memory.read":     true,
+		"events.read":     true,
+		"tools.read":      true,
+		"plugins.read":    true,
+		"channels.read":   true,
+		"routing.read":    true,
+		"runtimes.read":   true,
+		"runtimes.write":  true,
+		"resources.read":  true,
+		"resources.write": true,
+		"config.read":     true,
+		"config.write":    true,
+		"audit.read":      true,
+		"auth.users.read": true,
+	}
+}

--- a/pkg/gateway/gateway_worker_runtime.go
+++ b/pkg/gateway/gateway_worker_runtime.go
@@ -1,0 +1,134 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/runtime"
+)
+
+func RunWithWorkers(ctx context.Context, mainRuntime *runtime.MainRuntime) error {
+	workerCount := mainRuntime.Config.Gateway.WorkerCount
+	if workerCount <= 0 {
+		workerCount = 4
+	}
+	if workerCount > 64 {
+		workerCount = 64
+	}
+
+	if os.Getenv("ANYCLAW_WORKER_MODE") == "1" {
+		return runWorker(ctx, mainRuntime)
+	}
+
+	return runMaster(ctx, mainRuntime, workerCount)
+}
+
+func runMaster(ctx context.Context, mainRuntime *runtime.MainRuntime, workerCount int) error {
+	execPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("get executable path: %w", err)
+	}
+
+	basePort := mainRuntime.Config.Gateway.Port
+	workerPIDs := make([]int, workerCount)
+	workerPorts := make([]int, workerCount)
+
+	for i := 0; i < workerCount; i++ {
+		workerPort := basePort + i
+		workerPorts[i] = workerPort
+		cmd := exec.Command(execPath, "gateway", "run",
+			"--config", mainRuntime.ConfigPath,
+			"--host", mainRuntime.Config.Gateway.Host,
+			"--port", strconv.Itoa(workerPort),
+			"--workers", "1")
+		cmd.Env = append(os.Environ(),
+			"ANYCLAW_WORKER_MODE=1",
+			fmt.Sprintf("ANYCLAW_WORKER_ID=%d", i),
+		)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		if err := cmd.Start(); err != nil {
+			for _, pid := range workerPIDs[:i] {
+				killProcess(pid)
+			}
+			return fmt.Errorf("start worker %d: %w", i, err)
+		}
+		workerPIDs[i] = cmd.Process.Pid
+	}
+
+	printWorkerStatus(workerPIDs, workerPorts, basePort)
+
+	<-ctx.Done()
+
+	for _, pid := range workerPIDs {
+		killProcess(pid)
+	}
+
+	return nil
+}
+
+func killProcess(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return proc.Kill()
+}
+
+func runWorker(ctx context.Context, mainRuntime *runtime.MainRuntime) error {
+	workerID := os.Getenv("ANYCLAW_WORKER_ID")
+	addr := runtime.GatewayAddress(mainRuntime.Config)
+
+	server := New(mainRuntime)
+	mux := http.NewServeMux()
+
+	server.initChannels()
+	if err := server.ensureDefaultWorkspace(); err != nil {
+		return err
+	}
+	server.startWorkers(ctx)
+	server.registerWorkerRoutes(mux)
+
+	server.startedAt = time.Now().UTC()
+	server.httpServer = &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	errCh := make(chan error, 1)
+	go server.runChannels(ctx)
+	go func() {
+		if err := server.httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return server.httpServer.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return fmt.Errorf("worker %s server failed: %w", workerID, err)
+	}
+}
+
+func printWorkerStatus(pids []int, ports []int, basePort int) {
+	if len(pids) == 0 {
+		return
+	}
+	fmt.Printf("Gateway workers started:\n")
+	for i, pid := range pids {
+		addr := fmt.Sprintf("127.0.0.1:%d", ports[i])
+		fmt.Printf("  Worker %d: PID=%d, addr=%s\n", i, pid, addr)
+	}
+	fmt.Printf("Main Gateway: 127.0.0.1:%d (load balancer)\n", basePort)
+}

--- a/pkg/gateway/gateway_ws_catalog_filters.go
+++ b/pkg/gateway/gateway_ws_catalog_filters.go
@@ -1,0 +1,39 @@
+package gateway
+
+import (
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/state"
+)
+
+func (c *openClawWSConn) filteredSessions(params map[string]any) []*state.Session {
+	workspace := mapString(params, "workspace")
+	items := c.server.store.ListSessions()
+	if workspace == "" {
+		return items
+	}
+	filtered := make([]*state.Session, 0, len(items))
+	for _, session := range items {
+		if state.SessionExecutionWorkspace(session) == workspace {
+			filtered = append(filtered, session)
+		}
+	}
+	return filtered
+}
+
+func (c *openClawWSConn) filteredTasks(params map[string]any) []*state.Task {
+	workspace := mapString(params, "workspace")
+	status := mapString(params, "status")
+	items := c.server.store.ListTasks()
+	filtered := make([]*state.Task, 0, len(items))
+	for _, task := range items {
+		if workspace != "" && task.Workspace != workspace {
+			continue
+		}
+		if status != "" && !strings.EqualFold(task.Status, status) {
+			continue
+		}
+		filtered = append(filtered, task)
+	}
+	return filtered
+}

--- a/pkg/gateway/gateway_ws_chat.go
+++ b/pkg/gateway/gateway_ws_chat.go
@@ -1,0 +1,71 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	gatewaycommands "github.com/1024XEngineer/anyclaw/pkg/gateway/commands"
+	taskrunner "github.com/1024XEngineer/anyclaw/pkg/runtime/taskrunner"
+)
+
+func (s *Server) wsChatSend(ctx context.Context, user *AuthUser, params map[string]any) (map[string]any, error) {
+	req, commandReq := s.surfaceService().DecodeWSChatSend(params)
+	if err := gatewaycommands.ValidateChatSend(req); err != nil {
+		return nil, err
+	}
+	dispatch, err := s.commandIntakeService().Dispatch(commandReq)
+	if err != nil {
+		return nil, err
+	}
+	assistantName, err := s.mainEntryPolicy().NormalizeRequestedAgent(req.Agent, req.Assistant)
+	if err != nil {
+		return nil, err
+	}
+	if req.SessionID == "" {
+		orgID := req.OrgID
+		projectID := req.ProjectID
+		workspaceID := req.WorkspaceID
+		if workspaceID == "" {
+			orgID, projectID, workspaceID = defaultResourceIDs(s.mainRuntime.WorkingDir)
+		}
+		org, project, workspace, err := s.validateResourceSelection(orgID, projectID, workspaceID)
+		if err != nil {
+			return nil, err
+		}
+		if !HasHierarchyAccess(user, org.ID, project.ID, workspace.ID) {
+			return nil, fmt.Errorf("forbidden")
+		}
+		req.OrgID = org.ID
+		req.ProjectID = project.ID
+		req.WorkspaceID = workspace.ID
+	}
+	response, updatedSession, err := s.runChatIngressMessage(ctx, "ws", req, assistantName)
+	if err != nil {
+		if errors.Is(err, taskrunner.ErrTaskWaitingApproval) {
+			sessionID := req.SessionID
+			if updatedSession != nil {
+				sessionID = updatedSession.ID
+			}
+			s.appendAudit(user, "chat.send", sessionID, map[string]any{
+				"message_length": len(req.Message),
+				"transport":      "ws",
+				"status":         "waiting_approval",
+				"command_kind":   dispatch.Kind,
+				"command_target": dispatch.Target,
+			})
+			return s.sessionApprovalResponse(sessionID), nil
+		}
+		return nil, err
+	}
+	s.appendAudit(user, "chat.send", updatedSession.ID, map[string]any{
+		"message_length": len(req.Message),
+		"transport":      "ws",
+		"command_kind":   dispatch.Kind,
+		"command_target": dispatch.Target,
+	})
+	return map[string]any{
+		"response": response,
+		"session":  updatedSession,
+	}, nil
+}

--- a/pkg/gateway/gateway_ws_conn_helpers.go
+++ b/pkg/gateway/gateway_ws_conn_helpers.go
@@ -1,0 +1,92 @@
+package gateway
+
+import (
+	"context"
+	"strings"
+
+	gatewayauth "github.com/1024XEngineer/anyclaw/pkg/gateway/auth"
+	gatewaygovernance "github.com/1024XEngineer/anyclaw/pkg/gateway/governance"
+)
+
+func (c *openClawWSConn) userSummary() map[string]any {
+	if c.user == nil {
+		return map[string]any{"name": "", "role": ""}
+	}
+	return map[string]any{
+		"name":        c.user.Name,
+		"role":        c.user.Role,
+		"permissions": c.user.Permissions,
+	}
+}
+
+func (c *openClawWSConn) requirePermission(permission string) error {
+	_, err := c.server.governanceService().AuthorizeCommand(c.contextWithUser(), gatewaygovernance.CommandRequest{
+		Method:             permission,
+		RequiredPermission: permission,
+	})
+	return err
+}
+
+func (c *openClawWSConn) writeResponse(id string, ok bool, data any, errMsg string) error {
+	frame := openClawWSFrame{
+		Type: "res",
+		ID:   id,
+		OK:   ok,
+		Data: data,
+	}
+	if strings.TrimSpace(errMsg) != "" {
+		frame.Error = strings.TrimSpace(errMsg)
+	}
+	return c.writeFrame(frame)
+}
+
+func (c *openClawWSConn) writeError(id string, errMsg string) error {
+	return c.writeResponse(id, false, nil, errMsg)
+}
+
+func (c *openClawWSConn) writeFrame(frame openClawWSFrame) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	return c.conn.WriteJSON(frame)
+}
+
+func (c *openClawWSConn) shutdown() {
+	c.closeOnce.Do(func() {
+		close(c.closed)
+		c.stopEventStream()
+		_ = c.conn.Close()
+	})
+}
+
+func mapString(values map[string]any, key string) string {
+	if values == nil {
+		return ""
+	}
+	value, _ := values[key].(string)
+	return strings.TrimSpace(value)
+}
+
+func mapInt(values map[string]any, key string, fallback int) int {
+	if values == nil {
+		return fallback
+	}
+	switch value := values[key].(type) {
+	case float64:
+		if int(value) > 0 {
+			return int(value)
+		}
+	case int:
+		if value > 0 {
+			return value
+		}
+	}
+	return fallback
+}
+
+func (c *openClawWSConn) contextWithUser() context.Context {
+	ctx := context.Background()
+	if c == nil || c.user == nil {
+		return ctx
+	}
+	return gatewayauth.WithUser(ctx, c.user)
+}

--- a/pkg/gateway/gateway_ws_connection_loop.go
+++ b/pkg/gateway/gateway_ws_connection_loop.go
@@ -1,0 +1,51 @@
+package gateway
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+)
+
+const openClawWSReadTimeout = 90 * time.Second
+
+func (c *openClawWSConn) run(ctx context.Context) {
+	defer c.shutdown()
+	_ = c.conn.SetReadDeadline(time.Now().Add(openClawWSReadTimeout))
+	c.conn.SetPongHandler(func(string) error {
+		return c.conn.SetReadDeadline(time.Now().Add(openClawWSReadTimeout))
+	})
+	if err := c.writeFrame(openClawWSFrame{
+		Type:  "event",
+		Event: "connect.challenge",
+		Data: map[string]any{
+			"nonce":    c.challenge,
+			"protocol": "openclaw.gateway.v1",
+			"methods":  openClawWSMethods,
+		},
+	}); err != nil {
+		return
+	}
+	var handlerWg sync.WaitGroup
+	defer func() {
+		handlerWg.Wait()
+	}()
+	for {
+		var frame openClawWSFrame
+		if err := c.conn.ReadJSON(&frame); err != nil {
+			return
+		}
+		_ = c.conn.SetReadDeadline(time.Now().Add(openClawWSReadTimeout))
+		if !strings.EqualFold(strings.TrimSpace(frame.Type), "req") {
+			_ = c.writeError(frame.ID, "frame type must be req")
+			continue
+		}
+		handlerWg.Add(1)
+		go func(f openClawWSFrame) {
+			defer handlerWg.Done()
+			if err := c.handleRequest(ctx, f); err != nil {
+				_ = c.writeError(f.ID, err.Error())
+			}
+		}(frame)
+	}
+}

--- a/pkg/gateway/gateway_ws_dispatch.go
+++ b/pkg/gateway/gateway_ws_dispatch.go
@@ -1,0 +1,41 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+func (c *openClawWSConn) handleRequest(ctx context.Context, frame openClawWSFrame) error {
+	method := strings.TrimSpace(frame.Method)
+	if method == "" {
+		return fmt.Errorf("method is required")
+	}
+	if err := c.ensureConnected(method); err != nil {
+		return err
+	}
+	normalized := strings.ToLower(method)
+	handlers := []func(context.Context, openClawWSFrame, string) (bool, error){
+		c.handleCoreWSRequest,
+		c.handleCatalogWSRequest,
+		c.handleMutationWSRequest,
+		c.handleDeviceWSRequest,
+	}
+	for _, handler := range handlers {
+		handled, err := handler(ctx, frame, normalized)
+		if handled {
+			return err
+		}
+	}
+	return fmt.Errorf("unsupported method: %s", method)
+}
+
+func (c *openClawWSConn) ensureConnected(method string) error {
+	c.connMu.RLock()
+	connected := c.connected
+	c.connMu.RUnlock()
+	if !connected && !strings.EqualFold(method, "connect") {
+		return fmt.Errorf("connect required before calling %s", method)
+	}
+	return nil
+}

--- a/pkg/gateway/gateway_ws_event_stream.go
+++ b/pkg/gateway/gateway_ws_event_stream.go
@@ -1,0 +1,54 @@
+package gateway
+
+import "github.com/1024XEngineer/anyclaw/pkg/state"
+
+func (c *openClawWSConn) startEventStream() {
+	if c.eventStream != nil || c.server.bus == nil {
+		return
+	}
+	ch := c.server.bus.Subscribe(32)
+	c.eventStream = ch
+	go func() {
+		for {
+			select {
+			case <-c.closed:
+				return
+			case event, ok := <-ch:
+				if !ok {
+					return
+				}
+				if !c.canSeeEvent(event) {
+					continue
+				}
+				if err := c.writeFrame(openClawWSFrame{
+					Type:  "event",
+					Event: "events.updated",
+					Data:  event,
+				}); err != nil {
+					c.shutdown()
+					return
+				}
+			}
+		}
+	}()
+}
+
+func (c *openClawWSConn) stopEventStream() {
+	if c.eventStream == nil || c.server.bus == nil {
+		return
+	}
+	c.server.bus.Unsubscribe(c.eventStream)
+	c.eventStream = nil
+}
+
+func (c *openClawWSConn) canSeeEvent(event *state.Event) bool {
+	if event == nil || event.SessionID == "" || c.user == nil || c.user.Role == "admin" {
+		return true
+	}
+	session, ok := c.server.sessions.Get(event.SessionID)
+	if !ok {
+		return true
+	}
+	orgID, projectID, workspaceID := state.SessionExecutionHierarchy(session)
+	return HasHierarchyAccess(c.user, orgID, projectID, workspaceID)
+}

--- a/pkg/gateway/gateway_ws_requests_catalog.go
+++ b/pkg/gateway/gateway_ws_requests_catalog.go
@@ -1,0 +1,75 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+)
+
+func (c *openClawWSConn) handleCatalogWSRequest(ctx context.Context, frame openClawWSFrame, method string) (bool, error) {
+	switch method {
+	case "agents.list":
+		if err := c.requireConfigRead(); err != nil {
+			return true, err
+		}
+		return true, c.writeResponse(frame.ID, true, c.server.listAgentViews(), "")
+	case "agents.get":
+		if err := c.requireConfigRead(); err != nil {
+			return true, err
+		}
+		name := mapString(frame.Params, "name")
+		if name == "" {
+			return true, fmt.Errorf("name parameter required")
+		}
+		agent, ok := c.server.getAgentView(name)
+		if !ok {
+			return true, fmt.Errorf("agent not found: %s", name)
+		}
+		return true, c.writeResponse(frame.ID, true, agent, "")
+	case "providers.list":
+		if err := c.requireConfigRead(); err != nil {
+			return true, err
+		}
+		return true, c.writeResponse(frame.ID, true, c.server.listProviderViews(), "")
+	case "agent-bindings.list", "agent_bindings.list":
+		if err := c.requireConfigRead(); err != nil {
+			return true, err
+		}
+		return true, c.writeResponse(frame.ID, true, c.server.listAgentBindingViews(), "")
+	case "channels.list", "channels.status":
+		if err := c.requirePermission("channels.read"); err != nil {
+			return true, err
+		}
+		if c.server.channels == nil {
+			return true, c.writeResponse(frame.ID, true, []any{}, "")
+		}
+		return true, c.writeResponse(frame.ID, true, c.server.channels.Statuses(), "")
+	case "sessions.list":
+		if err := c.requirePermission("sessions.read"); err != nil {
+			return true, err
+		}
+		return true, c.writeResponse(frame.ID, true, c.filteredSessions(frame.Params), "")
+	case "tasks.list":
+		if err := c.requirePermission("tasks.read"); err != nil {
+			return true, err
+		}
+		return true, c.writeResponse(frame.ID, true, c.filteredTasks(frame.Params), "")
+	case "tools.list", "tools.catalog":
+		if err := c.requirePermission("tools.read"); err != nil {
+			return true, err
+		}
+		if c.server.mainRuntime == nil {
+			return true, c.writeResponse(frame.ID, true, []any{}, "")
+		}
+		return true, c.writeResponse(frame.ID, true, c.server.mainRuntime.ListTools(), "")
+	case "plugins.list":
+		if err := c.requirePermission("plugins.read"); err != nil {
+			return true, err
+		}
+		if c.server.plugins == nil {
+			return true, c.writeResponse(frame.ID, true, []any{}, "")
+		}
+		return true, c.writeResponse(frame.ID, true, c.server.plugins.List(), "")
+	default:
+		return false, nil
+	}
+}

--- a/pkg/gateway/gateway_ws_requests_core.go
+++ b/pkg/gateway/gateway_ws_requests_core.go
@@ -1,0 +1,90 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	gatewaygovernance "github.com/1024XEngineer/anyclaw/pkg/gateway/governance"
+)
+
+func (c *openClawWSConn) handleCoreWSRequest(ctx context.Context, frame openClawWSFrame, method string) (bool, error) {
+	switch method {
+	case "connect":
+		return true, c.handleWSConnect(frame)
+	case "ping":
+		return true, c.writeResponse(frame.ID, true, c.server.controlPlaneService().Ping(time.Now()), "")
+	case "methods.list":
+		return true, c.writeResponse(frame.ID, true, c.server.controlPlaneService().MethodsList(), "")
+	case "status", "status.get":
+		if err := c.requirePermission("status.read"); err != nil {
+			return true, err
+		}
+		return true, c.writeResponse(frame.ID, true, c.server.status(), "")
+	case "control-plane.get", "control_plane.get":
+		if err := c.requirePermission("status.read"); err != nil {
+			return true, err
+		}
+		return true, c.writeResponse(frame.ID, true, c.server.controlPlaneRuntimeAPI().Snapshot(), "")
+	case "events.list":
+		if err := c.requirePermission("events.read"); err != nil {
+			return true, err
+		}
+		limit := mapInt(frame.Params, "limit", 24)
+		return true, c.writeResponse(frame.ID, true, c.server.store.ListEvents(limit), "")
+	case "events.subscribe":
+		if err := c.requirePermission("events.read"); err != nil {
+			return true, err
+		}
+		c.startEventStream()
+		return true, c.writeResponse(frame.ID, true, c.server.controlPlaneService().Subscription(true), "")
+	case "events.unsubscribe":
+		if err := c.requirePermission("events.read"); err != nil {
+			return true, err
+		}
+		c.stopEventStream()
+		return true, c.writeResponse(frame.ID, true, c.server.controlPlaneService().Subscription(false), "")
+	case "chat.send":
+		if err := c.requirePermission("chat.send"); err != nil {
+			return true, err
+		}
+		result, err := c.server.wsChatSend(ctx, c.user, frame.Params)
+		if err != nil {
+			return true, err
+		}
+		return true, c.writeResponse(frame.ID, true, result, "")
+	default:
+		return false, nil
+	}
+}
+
+func (c *openClawWSConn) handleWSConnect(frame openClawWSFrame) error {
+	provided := firstNonEmpty(mapString(frame.Params, "challenge"), mapString(frame.Params, "nonce"))
+	if provided == "" || provided != c.challenge {
+		return c.writeResponse(frame.ID, false, nil, "challenge verification failed")
+	}
+	if _, err := c.server.governanceService().AuthorizeConnection(c.contextWithUser(), gatewaygovernance.ConnectionRequest{
+		ConnectionID: c.challenge,
+		Protocol:     c.transport.Protocol,
+		Path:         c.transport.Path,
+		ClientID:     c.transport.ClientID,
+		Metadata: map[string]string{
+			"method": "connect",
+		},
+	}); err != nil {
+		return c.writeResponse(frame.ID, false, nil, err.Error())
+	}
+	connectedAt := time.Now().UTC()
+	c.connMu.Lock()
+	c.connected = true
+	c.connectedAt = connectedAt
+	c.connMu.Unlock()
+	return c.writeResponse(frame.ID, true, c.server.controlPlaneService().ConnectAck(connectedAt, c.userSummary()), "")
+}
+
+func (c *openClawWSConn) requireConfigRead() error {
+	if HasPermission(c.user, "config.read") || HasPermission(c.user, "config.write") {
+		return nil
+	}
+	return fmt.Errorf("forbidden: missing config.read")
+}

--- a/pkg/gateway/gateway_ws_requests_device.go
+++ b/pkg/gateway/gateway_ws_requests_device.go
@@ -1,0 +1,111 @@
+package gateway
+
+import (
+	"context"
+	"time"
+)
+
+func (c *openClawWSConn) handleDeviceWSRequest(_ context.Context, frame openClawWSFrame, method string) (bool, error) {
+	switch method {
+	case "device.pairing.generate":
+		if err := c.ensureDevicePairing(frame); err != nil {
+			return true, err
+		}
+		deviceName := mapString(frame.Params, "device_name")
+		deviceType := mapString(frame.Params, "device_type")
+		if deviceType == "" {
+			deviceType = "cli"
+		}
+		code, err := c.server.devicePairing.GeneratePairingCode(deviceName, deviceType)
+		if err != nil {
+			return true, c.writeResponse(frame.ID, false, nil, err.Error())
+		}
+		return true, c.writeResponse(frame.ID, true, map[string]any{
+			"code":    code.Code,
+			"expires": code.ExpiresAt.Format(time.RFC3339),
+			"device":  code.DeviceName,
+			"type":    code.DeviceType,
+		}, "")
+	case "device.pairing.validate":
+		if err := c.ensureDevicePairing(frame); err != nil {
+			return true, err
+		}
+		code := mapString(frame.Params, "code")
+		if code == "" {
+			return true, c.writeResponse(frame.ID, false, nil, "code is required")
+		}
+		codeObj, err := c.server.devicePairing.ValidatePairingCode(code)
+		if err != nil {
+			return true, c.writeResponse(frame.ID, false, nil, err.Error())
+		}
+		return true, c.writeResponse(frame.ID, true, map[string]any{
+			"valid":       true,
+			"device_name": codeObj.DeviceName,
+			"device_type": codeObj.DeviceType,
+			"expires":     codeObj.ExpiresAt.Format(time.RFC3339),
+		}, "")
+	case "device.pairing.pair":
+		if err := c.ensureDevicePairing(frame); err != nil {
+			return true, err
+		}
+		code := mapString(frame.Params, "code")
+		deviceID := mapString(frame.Params, "device_id")
+		deviceName := mapString(frame.Params, "device_name")
+		if code == "" || deviceID == "" {
+			return true, c.writeResponse(frame.ID, false, nil, "code and device_id are required")
+		}
+		pairing, err := c.server.devicePairing.CompletePairing(code, deviceID)
+		if err != nil {
+			return true, c.writeResponse(frame.ID, false, nil, err.Error())
+		}
+		if deviceName != "" {
+			pairing.DeviceName = deviceName
+		}
+		return true, c.writeResponse(frame.ID, true, pairing, "")
+	case "device.pairing.unpair":
+		if err := c.ensureDevicePairing(frame); err != nil {
+			return true, err
+		}
+		deviceID := mapString(frame.Params, "device_id")
+		if deviceID == "" {
+			return true, c.writeResponse(frame.ID, false, nil, "device_id is required")
+		}
+		if err := c.server.devicePairing.Unpair(deviceID); err != nil {
+			return true, c.writeResponse(frame.ID, false, nil, err.Error())
+		}
+		return true, c.writeResponse(frame.ID, true, map[string]any{"ok": true}, "")
+	case "device.pairing.list":
+		if err := c.ensureDevicePairing(frame); err != nil {
+			return true, err
+		}
+		devices := c.server.devicePairing.ListPaired()
+		return true, c.writeResponse(frame.ID, true, map[string]any{"devices": devices}, "")
+	case "device.pairing.status":
+		if err := c.ensureDevicePairing(frame); err != nil {
+			return true, err
+		}
+		return true, c.writeResponse(frame.ID, true, c.server.devicePairing.GetStatus(), "")
+	case "device.pairing.renew":
+		if err := c.ensureDevicePairing(frame); err != nil {
+			return true, err
+		}
+		deviceID := mapString(frame.Params, "device_id")
+		if deviceID == "" {
+			return true, c.writeResponse(frame.ID, false, nil, "device_id is required")
+		}
+		pairing, err := c.server.devicePairing.RenewPairing(deviceID)
+		if err != nil {
+			return true, c.writeResponse(frame.ID, false, nil, err.Error())
+		}
+		return true, c.writeResponse(frame.ID, true, pairing, "")
+	default:
+		return false, nil
+	}
+}
+
+func (c *openClawWSConn) ensureDevicePairing(frame openClawWSFrame) error {
+	if c.server.devicePairing == nil {
+		return c.writeResponse(frame.ID, false, nil, "device pairing not initialized")
+	}
+	return nil
+}

--- a/pkg/gateway/gateway_ws_requests_mutations.go
+++ b/pkg/gateway/gateway_ws_requests_mutations.go
@@ -1,0 +1,108 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+func (c *openClawWSConn) handleMutationWSRequest(ctx context.Context, frame openClawWSFrame, method string) (bool, error) {
+	switch method {
+	case "providers.update":
+		if err := c.requirePermission("config.write"); err != nil {
+			return true, err
+		}
+		providerJSON, err := marshalWSParam(frame.Params, "provider", "provider data required", "invalid provider data")
+		if err != nil {
+			return true, err
+		}
+		var provider config.ProviderProfile
+		if err := json.Unmarshal(providerJSON, &provider); err != nil {
+			return true, fmt.Errorf("invalid provider format: %v", err)
+		}
+		var result providerView
+		if err := c.invokeWSJSONPost(ctx, "/api/providers", providerJSON, c.server.handleProviders, &result, "provider update failed"); err != nil {
+			return true, err
+		}
+		return true, c.writeResponse(frame.ID, true, result, "")
+	case "providers.default":
+		if err := c.requirePermission("config.write"); err != nil {
+			return true, err
+		}
+		providerRef := mapString(frame.Params, "provider_ref")
+		if providerRef == "" {
+			return true, fmt.Errorf("provider_ref required")
+		}
+		reqBody, err := json.Marshal(map[string]string{"provider_ref": providerRef})
+		if err != nil {
+			return true, fmt.Errorf("failed to marshal request: %v", err)
+		}
+		var result providerView
+		if err := c.invokeWSJSONPost(ctx, "/api/providers/default", reqBody, c.server.handleDefaultProvider, &result, "default provider update failed"); err != nil {
+			return true, err
+		}
+		return true, c.writeResponse(frame.ID, true, result, "")
+	case "providers.test":
+		if err := c.requireConfigRead(); err != nil {
+			return true, err
+		}
+		providerJSON, err := marshalWSParam(frame.Params, "provider", "provider data required", "invalid provider data")
+		if err != nil {
+			return true, err
+		}
+		var result providerHealth
+		if err := c.invokeWSJSONPost(ctx, "/api/providers/test", providerJSON, c.server.handleProviderTest, &result, "provider test failed"); err != nil {
+			return true, err
+		}
+		return true, c.writeResponse(frame.ID, true, result, "")
+	case "agent-bindings.update", "agent_bindings.update":
+		if err := c.requirePermission("config.write"); err != nil {
+			return true, err
+		}
+		bindingJSON, err := marshalWSParam(frame.Params, "binding", "binding data required", "invalid binding data")
+		if err != nil {
+			return true, err
+		}
+		var result []agentBindingView
+		if err := c.invokeWSJSONPost(ctx, "/api/agent-bindings", bindingJSON, c.server.handleAgentBindings, &result, "agent binding update failed"); err != nil {
+			return true, err
+		}
+		return true, c.writeResponse(frame.ID, true, result, "")
+	default:
+		return false, nil
+	}
+}
+
+func marshalWSParam(params map[string]any, key string, requiredMsg string, invalidMsg string) ([]byte, error) {
+	if params == nil {
+		return nil, fmt.Errorf("params required")
+	}
+	value := params[key]
+	if value == nil {
+		return nil, fmt.Errorf("%s", requiredMsg)
+	}
+	body, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %v", invalidMsg, err)
+	}
+	return body, nil
+}
+
+func (c *openClawWSConn) invokeWSJSONPost(ctx context.Context, path string, body []byte, handler func(http.ResponseWriter, *http.Request), target any, failurePrefix string) error {
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	req = req.WithContext(ctx)
+	handler(recorder, req)
+	if recorder.Code >= 400 {
+		return fmt.Errorf("%s: %s", failurePrefix, recorder.Body.String())
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), target); err != nil {
+		return fmt.Errorf("failed to parse response: %v", err)
+	}
+	return nil
+}

--- a/pkg/gateway/gateway_ws_requests_test.go
+++ b/pkg/gateway/gateway_ws_requests_test.go
@@ -1,0 +1,168 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	gatewayauth "github.com/1024XEngineer/anyclaw/pkg/gateway/auth"
+	gatewaysurface "github.com/1024XEngineer/anyclaw/pkg/gateway/surface"
+	"github.com/gorilla/websocket"
+)
+
+func newWSTestConn(t *testing.T, server *Server) (*openClawWSConn, *websocket.Conn) {
+	t.Helper()
+	upgrader := websocket.Upgrader{}
+	connCh := make(chan *websocket.Conn, 1)
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		connCh <- conn
+	}))
+	t.Cleanup(httpServer.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(httpServer.URL, "http")
+	clientConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial ws: %v", err)
+	}
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	serverConn := <-connCh
+	t.Cleanup(func() { _ = serverConn.Close() })
+
+	return &openClawWSConn{
+		server:    server,
+		conn:      serverConn,
+		user:      &gatewayauth.User{Name: "tester", Role: "admin", Permissions: []string{"*"}},
+		closed:    make(chan struct{}),
+		challenge: "challenge-token",
+		transport: gatewaysurface.TransportRef{Protocol: "ws", Path: "/ws", ClientID: "client-1"},
+	}, clientConn
+}
+
+func readWSFrame(t *testing.T, conn *websocket.Conn) openClawWSFrame {
+	t.Helper()
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var frame openClawWSFrame
+	if err := conn.ReadJSON(&frame); err != nil {
+		t.Fatalf("read ws frame: %v", err)
+	}
+	return frame
+}
+
+func TestOpenClawWSCoreMutationAndDeviceRequests(t *testing.T) {
+	server := newSplitAPITestServer(t)
+	server.devicePairing.SetEnabled(true)
+	providerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer providerSrv.Close()
+	server.mainRuntime.Config.Providers[0].BaseURL = providerSrv.URL
+	server.mainRuntime.Config.Providers[0].APIKey = "secret"
+
+	conn, clientConn := newWSTestConn(t, server)
+	ctx := gatewayauth.WithUser(context.Background(), conn.user)
+
+	handled, err := conn.handleCoreWSRequest(ctx, openClawWSFrame{ID: "connect-1", Params: map[string]any{"challenge": "challenge-token"}}, "connect")
+	if err != nil || !handled {
+		t.Fatalf("connect handled=%v err=%v", handled, err)
+	}
+	if frame := readWSFrame(t, clientConn); !frame.OK {
+		t.Fatalf("connect response not ok: %+v", frame)
+	}
+
+	for _, tc := range []struct {
+		id     string
+		method string
+		params map[string]any
+	}{
+		{id: "ping-1", method: "ping"},
+		{id: "methods-1", method: "methods.list"},
+		{id: "status-1", method: "status.get"},
+		{id: "events-1", method: "events.list", params: map[string]any{"limit": 2}},
+		{id: "sub-1", method: "events.subscribe"},
+		{id: "unsub-1", method: "events.unsubscribe"},
+	} {
+		handled, err = conn.handleCoreWSRequest(ctx, openClawWSFrame{ID: tc.id, Params: tc.params}, tc.method)
+		if err != nil || !handled {
+			t.Fatalf("core method %s handled=%v err=%v", tc.method, handled, err)
+		}
+		if frame := readWSFrame(t, clientConn); !frame.OK {
+			t.Fatalf("core method %s response not ok: %+v", tc.method, frame)
+		}
+	}
+
+	if err := (&openClawWSConn{}).requireConfigRead(); err == nil {
+		t.Fatal("expected requireConfigRead to fail without user")
+	}
+	if ok, err := conn.handleCoreWSRequest(ctx, openClawWSFrame{}, "unknown"); err != nil || ok {
+		t.Fatalf("unexpected unknown core method result ok=%v err=%v", ok, err)
+	}
+
+	for _, tc := range []struct {
+		id     string
+		method string
+		params map[string]any
+	}{
+		{id: "prov-default", method: "providers.default", params: map[string]any{"provider_ref": "provider-1"}},
+		{id: "prov-test", method: "providers.test", params: map[string]any{"provider": map[string]any{"id": "provider-1", "provider": "compatible", "base_url": providerSrv.URL, "api_key": "secret", "enabled": true}}},
+		{id: "binding-update", method: "agent-bindings.update", params: map[string]any{"binding": map[string]any{"agent": "helper", "provider_ref": "provider-1", "model": "gpt-test"}}},
+	} {
+		handled, err = conn.handleMutationWSRequest(ctx, openClawWSFrame{ID: tc.id, Params: tc.params}, tc.method)
+		if err != nil || !handled {
+			t.Fatalf("mutation method %s handled=%v err=%v", tc.method, handled, err)
+		}
+		if frame := readWSFrame(t, clientConn); !frame.OK {
+			t.Fatalf("mutation method %s response not ok: %+v", tc.method, frame)
+		}
+	}
+
+	if _, err := marshalWSParam(nil, "provider", "required", "invalid"); err == nil {
+		t.Fatal("expected marshalWSParam to reject nil params")
+	}
+	if ok, err := conn.handleMutationWSRequest(ctx, openClawWSFrame{}, "unknown.mutation"); err != nil || ok {
+		t.Fatalf("unexpected unknown mutation result ok=%v err=%v", ok, err)
+	}
+
+	handled, err = conn.handleDeviceWSRequest(ctx, openClawWSFrame{ID: "gen-1", Params: map[string]any{"device_name": "cli", "device_type": "desktop"}}, "device.pairing.generate")
+	if err != nil || !handled {
+		t.Fatalf("generate pairing handled=%v err=%v", handled, err)
+	}
+	frame := readWSFrame(t, clientConn)
+	if !frame.OK {
+		t.Fatalf("pairing generate response not ok: %+v", frame)
+	}
+	data, _ := frame.Data.(map[string]any)
+	code, _ := data["code"].(string)
+
+	for _, tc := range []struct {
+		id     string
+		method string
+		params map[string]any
+	}{
+		{id: "validate-1", method: "device.pairing.validate", params: map[string]any{"code": code}},
+		{id: "pair-1", method: "device.pairing.pair", params: map[string]any{"code": code, "device_id": "dev-1", "device_name": "cli"}},
+		{id: "list-1", method: "device.pairing.list"},
+		{id: "status-2", method: "device.pairing.status"},
+		{id: "renew-1", method: "device.pairing.renew", params: map[string]any{"device_id": "dev-1"}},
+		{id: "unpair-1", method: "device.pairing.unpair", params: map[string]any{"device_id": "dev-1"}},
+	} {
+		handled, err = conn.handleDeviceWSRequest(ctx, openClawWSFrame{ID: tc.id, Params: tc.params}, tc.method)
+		if err != nil || !handled {
+			t.Fatalf("device method %s handled=%v err=%v", tc.method, handled, err)
+		}
+		if frame := readWSFrame(t, clientConn); !frame.OK {
+			t.Fatalf("device method %s response not ok: %+v", tc.method, frame)
+		}
+	}
+
+	if ok, err := conn.handleDeviceWSRequest(ctx, openClawWSFrame{}, "unknown.device"); err != nil || ok {
+		t.Fatalf("unexpected unknown device result ok=%v err=%v", ok, err)
+	}
+}

--- a/pkg/gateway/gateway_ws_server.go
+++ b/pkg/gateway/gateway_ws_server.go
@@ -1,0 +1,32 @@
+package gateway
+
+import (
+	"net/http"
+
+	gatewaysurface "github.com/1024XEngineer/anyclaw/pkg/gateway/surface"
+	"github.com/gorilla/websocket"
+)
+
+var openClawWSUpgrader = websocket.Upgrader{
+	ReadBufferSize:  4096,
+	WriteBufferSize: 4096,
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+}
+
+func (s *Server) handleOpenClawWS(w http.ResponseWriter, r *http.Request) {
+	conn, err := openClawWSUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	client := &openClawWSConn{
+		server:    s,
+		conn:      conn,
+		user:      UserFromContext(r.Context()),
+		challenge: uniqueID("ws"),
+		transport: gatewaysurface.HTTPTransport(r, ""),
+		closed:    make(chan struct{}),
+	}
+	client.run(r.Context())
+}

--- a/pkg/gateway/gateway_ws_types.go
+++ b/pkg/gateway/gateway_ws_types.go
@@ -1,0 +1,36 @@
+package gateway
+
+import (
+	"sync"
+	"time"
+
+	gatewaysurface "github.com/1024XEngineer/anyclaw/pkg/gateway/surface"
+	"github.com/1024XEngineer/anyclaw/pkg/state"
+	"github.com/gorilla/websocket"
+)
+
+type openClawWSFrame struct {
+	Type   string         `json:"type"`
+	ID     string         `json:"id,omitempty"`
+	Method string         `json:"method,omitempty"`
+	Event  string         `json:"event,omitempty"`
+	Params map[string]any `json:"params,omitempty"`
+	Data   any            `json:"data,omitempty"`
+	OK     bool           `json:"ok,omitempty"`
+	Error  string         `json:"error,omitempty"`
+}
+
+type openClawWSConn struct {
+	server      *Server
+	conn        *websocket.Conn
+	user        *AuthUser
+	writeMu     sync.Mutex
+	connected   bool
+	connMu      sync.RWMutex
+	challenge   string
+	transport   gatewaysurface.TransportRef
+	eventStream chan *state.Event
+	closed      chan struct{}
+	closeOnce   sync.Once
+	connectedAt time.Time
+}

--- a/pkg/gateway/transport/client/client.go
+++ b/pkg/gateway/transport/client/client.go
@@ -1,0 +1,304 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+type GatewayClient struct {
+	addr       string
+	wsConn     *websocket.Conn
+	httpClient *http.Client
+	mu         sync.RWMutex
+
+	onMessage  func(msg IncomingMessage)
+	onToolCall func(call ToolCall)
+	onPresence func(presence Presence)
+	onTyping   func(indicator TypingIndicator)
+
+	pendingRequests map[string]chan json.RawMessage
+}
+
+type GatewayOption func(*GatewayClient)
+
+func WithGatewayAddr(addr string) GatewayOption {
+	return func(c *GatewayClient) {
+		c.addr = addr
+	}
+}
+
+func WithHTTPClient(client *http.Client) GatewayOption {
+	return func(c *GatewayClient) {
+		c.httpClient = client
+	}
+}
+
+func NewGateway(opts ...GatewayOption) (*GatewayClient, error) {
+	c := &GatewayClient{
+		addr:            "127.0.0.1:18789",
+		httpClient:      &http.Client{Timeout: 30 * time.Second},
+		pendingRequests: make(map[string]chan json.RawMessage),
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c, nil
+}
+
+func (g *GatewayClient) Connect(ctx context.Context) error {
+	url := fmt.Sprintf("ws://%s/gateway", g.addr)
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to connect to gateway: %w", err)
+	}
+	g.wsConn = conn
+
+	go g.readLoop()
+
+	return nil
+}
+
+func (g *GatewayClient) Disconnect() error {
+	if g.wsConn != nil {
+		return g.wsConn.Close()
+	}
+	return nil
+}
+
+func (g *GatewayClient) readLoop() {
+	for {
+		_, data, err := g.wsConn.ReadMessage()
+		if err != nil {
+			return
+		}
+
+		var msg map[string]json.RawMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			continue
+		}
+
+		if msgType, ok := msg["type"]; ok {
+			switch string(msgType) {
+			case "message":
+				var incoming IncomingMessage
+				if rawData, ok := msg["data"]; ok {
+					json.Unmarshal(rawData, &incoming)
+				}
+				if g.onMessage != nil {
+					g.onMessage(incoming)
+				}
+			case "tool_call":
+				var call ToolCall
+				if rawData, ok := msg["data"]; ok {
+					json.Unmarshal(rawData, &call)
+				}
+				if g.onToolCall != nil {
+					g.onToolCall(call)
+				}
+			case "presence":
+				var presence Presence
+				if rawData, ok := msg["data"]; ok {
+					json.Unmarshal(rawData, &presence)
+				}
+				if g.onPresence != nil {
+					g.onPresence(presence)
+				}
+			case "typing":
+				var indicator TypingIndicator
+				if rawData, ok := msg["data"]; ok {
+					json.Unmarshal(rawData, &indicator)
+				}
+				if g.onTyping != nil {
+					g.onTyping(indicator)
+				}
+			}
+		}
+	}
+}
+
+func (g *GatewayClient) SendMessage(ctx context.Context, channelID ChannelID, msg OutgoingMessage) error {
+	data, _ := json.Marshal(map[string]any{
+		"type":       "message_send",
+		"channel_id": channelID,
+		"message":    msg,
+	})
+	return g.wsConn.WriteMessage(websocket.TextMessage, data)
+}
+
+func (g *GatewayClient) CreateSession(ctx context.Context, agentID AgentID, channelID ChannelID) (SessionID, error) {
+	req := map[string]any{
+		"agent_id":   agentID,
+		"channel_id": channelID,
+	}
+
+	resp, err := g.request(ctx, "sessions_create", req)
+	if err != nil {
+		return "", err
+	}
+
+	var result struct {
+		SessionID SessionID `json:"session_id"`
+	}
+	json.Unmarshal(resp, &result)
+	return result.SessionID, nil
+}
+
+func (g *GatewayClient) SendToSession(ctx context.Context, sessionID SessionID, content string) error {
+	req := map[string]any{
+		"session_id": sessionID,
+		"content":    content,
+	}
+	_, err := g.request(ctx, "agent_send", req)
+	return err
+}
+
+func (g *GatewayClient) ListSessions(ctx context.Context) ([]Session, error) {
+	resp, err := g.request(ctx, "sessions_list", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var sessions []Session
+	json.Unmarshal(resp, &sessions)
+	return sessions, nil
+}
+
+func (g *GatewayClient) GetSessionHistory(ctx context.Context, sessionID SessionID) ([]IncomingMessage, error) {
+	req := map[string]any{"session_id": sessionID}
+	resp, err := g.request(ctx, "sessions_history", req)
+	if err != nil {
+		return nil, err
+	}
+
+	var messages []IncomingMessage
+	json.Unmarshal(resp, &messages)
+	return messages, nil
+}
+
+func (g *GatewayClient) InvokeTool(ctx context.Context, name string, input json.RawMessage) (json.RawMessage, error) {
+	req := map[string]any{
+		"name":  name,
+		"input": input,
+	}
+	return g.request(ctx, "tools_invoke", req)
+}
+
+func (g *GatewayClient) ListTools(ctx context.Context) ([]ToolDefinition, error) {
+	resp, err := g.request(ctx, "tools_list", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var tools []ToolDefinition
+	json.Unmarshal(resp, &tools)
+	return tools, nil
+}
+
+func (g *GatewayClient) ListAgents(ctx context.Context) ([]Agent, error) {
+	resp, err := g.request(ctx, "agents_list", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var agents []Agent
+	json.Unmarshal(resp, &agents)
+	return agents, nil
+}
+
+func (g *GatewayClient) ListChannels(ctx context.Context) ([]ChannelInfo, error) {
+	resp, err := g.request(ctx, "channels_list", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var channels []ChannelInfo
+	json.Unmarshal(resp, &channels)
+	return channels, nil
+}
+
+func (g *GatewayClient) ListNodes(ctx context.Context) ([]NodeInfo, error) {
+	resp, err := g.request(ctx, "nodes_list", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var nodes []NodeInfo
+	json.Unmarshal(resp, &nodes)
+	return nodes, nil
+}
+
+func (g *GatewayClient) NodeInvoke(ctx context.Context, nodeID NodeID, action string, input json.RawMessage) (json.RawMessage, error) {
+	req := map[string]any{
+		"node_id": nodeID,
+		"action":  action,
+		"input":   input,
+	}
+	return g.request(ctx, "node_invoke", req)
+}
+
+func (g *GatewayClient) request(ctx context.Context, method string, params map[string]any) (json.RawMessage, error) {
+	reqID := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	req := map[string]any{
+		"id":     reqID,
+		"method": method,
+		"params": params,
+	}
+
+	data, _ := json.Marshal(req)
+	err := g.wsConn.WriteMessage(websocket.TextMessage, data)
+	if err != nil {
+		return nil, err
+	}
+
+	ch := make(chan json.RawMessage, 1)
+	g.mu.Lock()
+	g.pendingRequests[reqID] = ch
+	g.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		g.mu.Lock()
+		delete(g.pendingRequests, reqID)
+		g.mu.Unlock()
+		return nil, ctx.Err()
+	case resp := <-ch:
+		g.mu.Lock()
+		delete(g.pendingRequests, reqID)
+		g.mu.Unlock()
+
+		var result struct {
+			Error  string          `json:"error,omitempty"`
+			Result json.RawMessage `json:"result,omitempty"`
+		}
+		json.Unmarshal(resp, &result)
+		if result.Error != "" {
+			return nil, fmt.Errorf("gateway error: %s", result.Error)
+		}
+		return result.Result, nil
+	}
+}
+
+func (g *GatewayClient) OnMessage(handler func(msg IncomingMessage)) {
+	g.onMessage = handler
+}
+
+func (g *GatewayClient) OnToolCall(handler func(call ToolCall)) {
+	g.onToolCall = handler
+}
+
+func (g *GatewayClient) OnPresence(handler func(presence Presence)) {
+	g.onPresence = handler
+}
+
+func (g *GatewayClient) OnTyping(handler func(indicator TypingIndicator)) {
+	g.onTyping = handler
+}

--- a/pkg/gateway/transport/client/client_test.go
+++ b/pkg/gateway/transport/client/client_test.go
@@ -1,0 +1,65 @@
+package sdk
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+func TestNewGatewayAppliesOptions(t *testing.T) {
+	httpClient := &http.Client{Timeout: time.Second}
+	client, err := NewGateway(WithGatewayAddr("127.0.0.1:19999"), WithHTTPClient(httpClient))
+	if err != nil {
+		t.Fatalf("NewGateway: %v", err)
+	}
+	if client.addr != "127.0.0.1:19999" {
+		t.Fatalf("addr = %q", client.addr)
+	}
+	if client.httpClient != httpClient {
+		t.Fatal("expected custom http client")
+	}
+	if err := client.Disconnect(); err != nil {
+		t.Fatalf("Disconnect: %v", err)
+	}
+
+	client.OnMessage(func(IncomingMessage) {})
+	client.OnToolCall(func(ToolCall) {})
+	client.OnPresence(func(Presence) {})
+	client.OnTyping(func(TypingIndicator) {})
+	if client.onMessage == nil || client.onToolCall == nil || client.onPresence == nil || client.onTyping == nil {
+		t.Fatal("expected callbacks to be registered")
+	}
+}
+
+func TestWSClientHelpers(t *testing.T) {
+	client := NewWSClient("ws://127.0.0.1:18789/ws", "token")
+	if client == nil || client.Connected() {
+		t.Fatal("expected disconnected client")
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !client.isClosed() {
+		t.Fatal("expected closed client")
+	}
+
+	url := GatewayURLFromConfig(&config.Config{})
+	if url != "ws://127.0.0.1:18789/ws" {
+		t.Fatalf("GatewayURLFromConfig = %q", url)
+	}
+	if got := mapString(map[string]any{" name ": "ignored", "name": " value "}, "name"); got != "value" {
+		t.Fatalf("mapString = %q", got)
+	}
+	if id1, id2 := uniqueID("req"), uniqueID("req"); id1 == id2 {
+		t.Fatal("expected unique ids")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := client.ensureConnected(ctx); err == nil {
+		t.Fatal("expected ensureConnected to fail on closed client")
+	}
+}

--- a/pkg/gateway/transport/client/gateway_status.go
+++ b/pkg/gateway/transport/client/gateway_status.go
@@ -1,0 +1,19 @@
+package sdk
+
+type Status struct {
+	OK         bool   `json:"ok"`
+	Status     string `json:"status"`
+	Version    string `json:"version"`
+	Provider   string `json:"provider"`
+	Model      string `json:"model"`
+	Address    string `json:"address"`
+	StartedAt  string `json:"started_at,omitempty"`
+	WorkingDir string `json:"working_dir"`
+	WorkDir    string `json:"work_dir"`
+	Sessions   int    `json:"sessions"`
+	Events     int    `json:"events"`
+	Skills     int    `json:"skills"`
+	Tools      int    `json:"tools"`
+	Secured    bool   `json:"secured"`
+	Users      int    `json:"users"`
+}

--- a/pkg/gateway/transport/client/gateway_ws_client.go
+++ b/pkg/gateway/transport/client/gateway_ws_client.go
@@ -1,0 +1,1042 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+	"github.com/gorilla/websocket"
+)
+
+type openClawWSFrame struct {
+	Type   string         `json:"type"`
+	ID     string         `json:"id,omitempty"`
+	Method string         `json:"method,omitempty"`
+	Event  string         `json:"event,omitempty"`
+	Params map[string]any `json:"params,omitempty"`
+	Data   any            `json:"data,omitempty"`
+	OK     bool           `json:"ok,omitempty"`
+	Error  string         `json:"error,omitempty"`
+}
+
+type pendingRequest struct {
+	ch   chan openClawWSFrame
+	conn *websocket.Conn
+}
+
+type WSClient struct {
+	url               string
+	token             string
+	conn              *websocket.Conn
+	connected         bool
+	mu                sync.RWMutex
+	connectMu         sync.Mutex
+	nonce             string
+	onEvent           func(event *Event)
+	pending           map[string]*pendingRequest
+	pendingMu         sync.Mutex
+	closed            chan struct{}
+	closeOnce         sync.Once
+	writeMu           sync.Mutex
+	keepAliveInterval time.Duration
+	keepAliveStarted  bool
+}
+
+func NewWSClient(url, token string) *WSClient {
+	return &WSClient{
+		url:               url,
+		token:             token,
+		pending:           make(map[string]*pendingRequest),
+		closed:            make(chan struct{}),
+		keepAliveInterval: 30 * time.Second,
+	}
+}
+
+func (c *WSClient) Connect(ctx context.Context) error {
+	if c.isClosed() {
+		return fmt.Errorf("gateway client is closed")
+	}
+
+	c.connectMu.Lock()
+	defer c.connectMu.Unlock()
+
+	c.mu.RLock()
+	if c.connected && c.conn != nil {
+		c.mu.RUnlock()
+		return nil
+	}
+	c.mu.RUnlock()
+
+	header := http.Header{}
+	if c.token != "" {
+		header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	dialer := websocket.DefaultDialer
+	dialer.Proxy = func(req *http.Request) (*url.URL, error) {
+		return nil, nil
+	}
+	conn, _, err := dialer.DialContext(ctx, c.url, header)
+	if err != nil {
+		return fmt.Errorf("failed to connect to gateway: %w", err)
+	}
+
+	if err := c.sendConnect(ctx, conn); err != nil {
+		conn.Close()
+		return err
+	}
+
+	c.mu.Lock()
+	c.conn = conn
+	c.nonce = uniqueID("client")
+	c.connected = true
+	startKeepAlive := !c.keepAliveStarted
+	if startKeepAlive {
+		c.keepAliveStarted = true
+	}
+	c.mu.Unlock()
+
+	if startKeepAlive {
+		go c.keepAliveLoop()
+	}
+	go c.readLoop(conn)
+
+	return nil
+}
+
+func (c *WSClient) sendConnect(ctx context.Context, conn *websocket.Conn) error {
+	conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+
+	var challengeFrame openClawWSFrame
+	if err := conn.ReadJSON(&challengeFrame); err != nil {
+		return fmt.Errorf("failed to read challenge: %w", err)
+	}
+
+	if challengeFrame.Type != "event" || challengeFrame.Event != "connect.challenge" {
+		return fmt.Errorf("unexpected frame type: expected connect.challenge event")
+	}
+
+	data, ok := challengeFrame.Data.(map[string]any)
+	if !ok {
+		return fmt.Errorf("invalid challenge data format")
+	}
+
+	gatewayNonce, _ := data["nonce"].(string)
+	if gatewayNonce == "" {
+		return fmt.Errorf("nonce not provided in challenge")
+	}
+
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "connect",
+		Params: map[string]any{
+			"challenge": gatewayNonce,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	err := conn.WriteJSON(frame)
+	if err != nil {
+		return err
+	}
+
+	conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+	var resp openClawWSFrame
+	if err := conn.ReadJSON(&resp); err != nil {
+		return err
+	}
+
+	if !resp.OK {
+		return fmt.Errorf("connect failed: %s", resp.Error)
+	}
+
+	return nil
+}
+
+func (c *WSClient) readLoop(conn *websocket.Conn) {
+	defer c.handleDisconnect(conn)
+
+	conn.SetReadDeadline(time.Now().Add(90 * time.Second))
+	conn.SetPongHandler(func(string) error {
+		conn.SetReadDeadline(time.Now().Add(90 * time.Second))
+		return nil
+	})
+
+	for {
+		var frame openClawWSFrame
+		err := conn.ReadJSON(&frame)
+		if err != nil {
+			return
+		}
+
+		conn.SetReadDeadline(time.Now().Add(90 * time.Second))
+
+		if frame.Type == "res" && frame.ID != "" {
+			c.pendingMu.Lock()
+			if p, ok := c.pending[frame.ID]; ok && p.conn == conn {
+				p.ch <- frame
+				close(p.ch)
+				delete(c.pending, frame.ID)
+			}
+			c.pendingMu.Unlock()
+			continue
+		}
+
+		if frame.Type == "event" && frame.Event != "" {
+			c.mu.RLock()
+			handler := c.onEvent
+			c.mu.RUnlock()
+			if handler != nil {
+				var payload map[string]any
+				if frame.Data != nil {
+					if p, ok := frame.Data.(map[string]any); ok {
+						payload = p
+					}
+				}
+				event := &Event{
+					Type:      frame.Event,
+					SessionID: "",
+					Payload:   payload,
+				}
+				handler(event)
+			}
+		}
+	}
+}
+
+func (c *WSClient) call(ctx context.Context, frame openClawWSFrame) (openClawWSFrame, error) {
+	conn, err := c.ensureConnected(ctx)
+	if err != nil {
+		return openClawWSFrame{}, err
+	}
+
+	ch := make(chan openClawWSFrame, 1)
+
+	c.pendingMu.Lock()
+	c.pending[frame.ID] = &pendingRequest{ch: ch, conn: conn}
+	c.pendingMu.Unlock()
+
+	c.writeMu.Lock()
+	err = conn.WriteJSON(frame)
+	c.writeMu.Unlock()
+	if err != nil {
+		c.pendingMu.Lock()
+		delete(c.pending, frame.ID)
+		c.pendingMu.Unlock()
+		c.handleDisconnect(conn)
+		return openClawWSFrame{}, err
+	}
+
+	select {
+	case resp, ok := <-ch:
+		if !ok {
+			return openClawWSFrame{}, fmt.Errorf("connection closed")
+		}
+		return resp, nil
+	case <-ctx.Done():
+		c.pendingMu.Lock()
+		delete(c.pending, frame.ID)
+		c.pendingMu.Unlock()
+		return openClawWSFrame{}, ctx.Err()
+	}
+}
+
+func (c *WSClient) Connected() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.connected
+}
+
+func (c *WSClient) Close() error {
+	c.closeOnce.Do(func() {
+		close(c.closed)
+	})
+
+	c.mu.Lock()
+	conn := c.conn
+	c.conn = nil
+	c.connected = false
+	c.mu.Unlock()
+
+	c.cleanupPending(nil)
+
+	if conn != nil {
+		return conn.Close()
+	}
+	return nil
+}
+
+func (c *WSClient) ensureConnected(ctx context.Context) (*websocket.Conn, error) {
+	c.mu.RLock()
+	conn := c.conn
+	connected := c.connected
+	c.mu.RUnlock()
+	if connected && conn != nil {
+		return conn, nil
+	}
+
+	if err := c.Connect(ctx); err != nil {
+		return nil, err
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if !c.connected || c.conn == nil {
+		return nil, fmt.Errorf("not connected to gateway")
+	}
+	return c.conn, nil
+}
+
+func (c *WSClient) keepAliveLoop() {
+	interval := c.keepAliveInterval
+	if interval <= 0 {
+		return
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.closed:
+			return
+		case <-ticker.C:
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			_ = c.Ping(ctx)
+			cancel()
+		}
+	}
+}
+
+func (c *WSClient) handleDisconnect(conn *websocket.Conn) {
+	if conn == nil {
+		return
+	}
+
+	c.mu.Lock()
+	if c.conn == conn {
+		c.conn = nil
+		c.connected = false
+	}
+	c.mu.Unlock()
+
+	c.cleanupPending(conn)
+	_ = conn.Close()
+}
+
+func (c *WSClient) cleanupPending(conn *websocket.Conn) {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+
+	for id, p := range c.pending {
+		if conn != nil && p.conn != conn {
+			continue
+		}
+		close(p.ch)
+		delete(c.pending, id)
+	}
+}
+
+func (c *WSClient) isClosed() bool {
+	select {
+	case <-c.closed:
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *WSClient) SendMessage(ctx context.Context, message string) (string, error) {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "chat.send",
+		Params: map[string]any{
+			"message": message,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	resp, err := c.call(ctx, frame)
+	if err != nil {
+		return "", err
+	}
+
+	if !resp.OK {
+		return "", fmt.Errorf("%s", resp.Error)
+	}
+
+	data, ok := resp.Data.(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("invalid response format")
+	}
+
+	response, _ := data["response"].(string)
+	if response == "" {
+		response, _ = data["message"].(string)
+	}
+	return response, nil
+}
+
+func (c *WSClient) GetStatus(ctx context.Context) (Status, error) {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "status.get",
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	resp, err := c.call(ctx, frame)
+	if err != nil {
+		return Status{}, err
+	}
+
+	if !resp.OK {
+		return Status{}, fmt.Errorf("%s", resp.Error)
+	}
+
+	data, ok := resp.Data.(map[string]any)
+	if !ok {
+		return Status{}, fmt.Errorf("invalid response format")
+	}
+
+	jsonData, _ := json.Marshal(data)
+	var status Status
+	json.Unmarshal(jsonData, &status)
+	return status, nil
+}
+
+func (c *WSClient) ListSessions(ctx context.Context) ([]Session, error) {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "sessions.list",
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	resp, err := c.call(ctx, frame)
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("%s", resp.Error)
+	}
+
+	var sessions []Session
+	if data, ok := resp.Data.(map[string]any); ok {
+		if sessionsData, ok := data["sessions"].([]any); ok {
+			for _, s := range sessionsData {
+				if sessionMap, ok := s.(map[string]any); ok {
+					session := Session{}
+					if id, ok := sessionMap["id"].(string); ok {
+						session.ID = SessionID(id)
+					}
+					if title, ok := sessionMap["title"].(string); ok {
+						session.Title = title
+					}
+					sessions = append(sessions, session)
+				}
+			}
+		}
+	}
+
+	return sessions, nil
+}
+
+func (c *WSClient) SubscribeEvents(ctx context.Context, eventType string, handler func(*Event)) error {
+	c.mu.Lock()
+	c.onEvent = handler
+	c.mu.Unlock()
+
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "events.subscribe",
+		Params: map[string]any{
+			"event": eventType,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	_, err := c.call(ctx, frame)
+	return err
+}
+
+func (c *WSClient) InvokeTool(ctx context.Context, toolName string, args map[string]any) (any, error) {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "tools.invoke",
+		Params: map[string]any{
+			"tool": toolName,
+			"args": args,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	resp, err := c.call(ctx, frame)
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("%s", resp.Error)
+	}
+
+	return resp.Data, nil
+}
+
+func (c *WSClient) SendChatMessage(ctx context.Context, sessionID, message string) (string, error) {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "sessions.send",
+		Params: map[string]any{
+			"session_id": sessionID,
+			"message":    message,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	resp, err := c.call(ctx, frame)
+	if err != nil {
+		return "", err
+	}
+
+	if !resp.OK {
+		return "", fmt.Errorf("%s", resp.Error)
+	}
+
+	data, ok := resp.Data.(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("invalid response format")
+	}
+
+	response, _ := data["response"].(string)
+	return response, nil
+}
+
+func (c *WSClient) GetConfig(ctx context.Context) (map[string]any, error) {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "config.get",
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	resp, err := c.call(ctx, frame)
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("%s", resp.Error)
+	}
+
+	data, ok := resp.Data.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("invalid response format")
+	}
+
+	return data, nil
+}
+
+func (c *WSClient) SetConfig(ctx context.Context, key string, value any) error {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "config.set",
+		Params: map[string]any{
+			"key":   key,
+			"value": value,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	_, err := c.call(ctx, frame)
+	return err
+}
+
+func (c *WSClient) ListAgents(ctx context.Context) ([]string, error) {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "agents.list",
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	resp, err := c.call(ctx, frame)
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("%s", resp.Error)
+	}
+
+	var agents []string
+	if data, ok := resp.Data.(map[string]any); ok {
+		if agentsData, ok := data["agents"].([]any); ok {
+			for _, a := range agentsData {
+				if name, ok := a.(string); ok {
+					agents = append(agents, name)
+				} else if agentMap, ok := a.(map[string]any); ok {
+					if name, ok := agentMap["name"].(string); ok {
+						agents = append(agents, name)
+					}
+				}
+			}
+		}
+	}
+
+	return agents, nil
+}
+
+func (c *WSClient) ListChannels(ctx context.Context) ([]string, error) {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "channels.list",
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	resp, err := c.call(ctx, frame)
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("%s", resp.Error)
+	}
+
+	var channels []string
+	if data, ok := resp.Data.(map[string]any); ok {
+		if channelsData, ok := data["channels"].([]any); ok {
+			for _, ch := range channelsData {
+				if name, ok := ch.(string); ok {
+					channels = append(channels, name)
+				} else if chMap, ok := ch.(map[string]any); ok {
+					if name, ok := chMap["name"].(string); ok {
+						channels = append(channels, name)
+					}
+				}
+			}
+		}
+	}
+
+	return channels, nil
+}
+
+func (c *WSClient) ListTools(ctx context.Context) ([]string, error) {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "tools.list",
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	resp, err := c.call(ctx, frame)
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("%s", resp.Error)
+	}
+
+	var tools []string
+	if data, ok := resp.Data.(map[string]any); ok {
+		if toolsData, ok := data["tools"].([]any); ok {
+			for _, t := range toolsData {
+				if name, ok := t.(string); ok {
+					tools = append(tools, name)
+				} else if toolMap, ok := t.(map[string]any); ok {
+					if name, ok := toolMap["name"].(string); ok {
+						tools = append(tools, name)
+					}
+				}
+			}
+		}
+	}
+
+	return tools, nil
+}
+
+func (c *WSClient) AbortChat(ctx context.Context) error {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "chat.abort",
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	_, err := c.call(ctx, frame)
+	return err
+}
+
+func (c *WSClient) GetChatHistory(ctx context.Context, sessionID string) ([]map[string]any, error) {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "chat.history",
+		Params: map[string]any{
+			"session_id": sessionID,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	resp, err := c.call(ctx, frame)
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("%s", resp.Error)
+	}
+
+	var history []map[string]any
+	if data, ok := resp.Data.(map[string]any); ok {
+		if historyData, ok := data["history"].([]any); ok {
+			for _, h := range historyData {
+				if item, ok := h.(map[string]any); ok {
+					history = append(history, item)
+				}
+			}
+		}
+	}
+
+	return history, nil
+}
+
+func (c *WSClient) Ping(ctx context.Context) error {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "ping",
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	_, err := c.call(ctx, frame)
+	return err
+}
+
+func (c *WSClient) ListMethods(ctx context.Context) ([]string, error) {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "methods.list",
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	resp, err := c.call(ctx, frame)
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("%s", resp.Error)
+	}
+
+	var methods []string
+	if data, ok := resp.Data.(map[string]any); ok {
+		if methodsData, ok := data["methods"].([]any); ok {
+			for _, m := range methodsData {
+				if method, ok := m.(string); ok {
+					methods = append(methods, method)
+				}
+			}
+		}
+	}
+
+	return methods, nil
+}
+
+func GatewayURLFromConfig(cfg *config.Config) string {
+	host := strings.TrimSpace(cfg.Gateway.Host)
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	port := cfg.Gateway.Port
+	if port == 0 {
+		port = 18789
+	}
+	return fmt.Sprintf("ws://%s:%d/ws", host, port)
+}
+
+type PairingCodeResult struct {
+	Code    string `json:"code"`
+	Expires string `json:"expires"`
+	Device  string `json:"device"`
+	Type    string `json:"type"`
+}
+
+func (c *WSClient) GeneratePairingCode(ctx context.Context, deviceName, deviceType string) (*PairingCodeResult, error) {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "device.pairing.generate",
+		Params: map[string]any{
+			"device_name": deviceName,
+			"device_type": deviceType,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	resp, err := c.call(ctx, frame)
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("%s", resp.Error)
+	}
+
+	data, ok := resp.Data.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("invalid response format")
+	}
+
+	result := &PairingCodeResult{}
+	if code, ok := data["code"].(string); ok {
+		result.Code = code
+	}
+	if expires, ok := data["expires"].(string); ok {
+		result.Expires = expires
+	}
+	if device, ok := data["device"].(string); ok {
+		result.Device = device
+	}
+	if deviceType, ok := data["type"].(string); ok {
+		result.Type = deviceType
+	}
+
+	return result, nil
+}
+
+func (c *WSClient) ValidatePairingCode(ctx context.Context, code string) (bool, error) {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "device.pairing.validate",
+		Params: map[string]any{
+			"code": code,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	resp, err := c.call(ctx, frame)
+	if err != nil {
+		return false, err
+	}
+
+	if !resp.OK {
+		return false, fmt.Errorf("%s", resp.Error)
+	}
+
+	data, ok := resp.Data.(map[string]any)
+	if !ok {
+		return false, fmt.Errorf("invalid response format")
+	}
+
+	valid, _ := data["valid"].(bool)
+	return valid, nil
+}
+
+func (c *WSClient) CompletePairing(ctx context.Context, code, deviceID, deviceName string) (map[string]any, error) {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "device.pairing.pair",
+		Params: map[string]any{
+			"code":        code,
+			"device_id":   deviceID,
+			"device_name": deviceName,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	resp, err := c.call(ctx, frame)
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("%s", resp.Error)
+	}
+
+	data, ok := resp.Data.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("invalid response format")
+	}
+
+	return data, nil
+}
+
+func (c *WSClient) ListPairedDevices(ctx context.Context) ([]map[string]any, error) {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "device.pairing.list",
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	resp, err := c.call(ctx, frame)
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("%s", resp.Error)
+	}
+
+	var devices []map[string]any
+	if data, ok := resp.Data.(map[string]any); ok {
+		if devicesData, ok := data["devices"].([]any); ok {
+			for _, d := range devicesData {
+				if device, ok := d.(map[string]any); ok {
+					devices = append(devices, device)
+				}
+			}
+		}
+	}
+
+	return devices, nil
+}
+
+func (c *WSClient) UnpairDevice(ctx context.Context, deviceID string) error {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "device.pairing.unpair",
+		Params: map[string]any{
+			"device_id": deviceID,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	_, err := c.call(ctx, frame)
+	return err
+}
+
+func (c *WSClient) GetPairingStatus(ctx context.Context) (map[string]any, error) {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "device.pairing.status",
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	resp, err := c.call(ctx, frame)
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("%s", resp.Error)
+	}
+
+	data, ok := resp.Data.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("invalid response format")
+	}
+
+	return data, nil
+}
+
+func (c *WSClient) RenewPairing(ctx context.Context, deviceID string) (map[string]any, error) {
+	frame := openClawWSFrame{
+		Type:   "req",
+		ID:     uniqueID("req"),
+		Method: "device.pairing.renew",
+		Params: map[string]any{
+			"device_id": deviceID,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	resp, err := c.call(ctx, frame)
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("%s", resp.Error)
+	}
+
+	data, ok := resp.Data.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("invalid response format")
+	}
+
+	return data, nil
+}
+
+var wsClientIDCounter uint64
+
+func uniqueID(prefix string) string {
+	seq := atomic.AddUint64(&wsClientIDCounter, 1)
+	return fmt.Sprintf("%s_%d_%d", prefix, time.Now().UnixNano(), seq)
+}
+
+func mapString(values map[string]any, key string) string {
+	if values == nil {
+		return ""
+	}
+	value, _ := values[key].(string)
+	return strings.TrimSpace(value)
+}

--- a/pkg/gateway/transport/client/gateway_ws_client_test.go
+++ b/pkg/gateway/transport/client/gateway_ws_client_test.go
@@ -1,0 +1,224 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func newMockWSGateway(t *testing.T) string {
+	t.Helper()
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		_ = conn.WriteJSON(openClawWSFrame{Type: "event", Event: "connect.challenge", Data: map[string]any{"nonce": "challenge-token"}})
+		var connectReq openClawWSFrame
+		if err := conn.ReadJSON(&connectReq); err != nil {
+			return
+		}
+		_ = conn.WriteJSON(openClawWSFrame{Type: "res", ID: connectReq.ID, OK: true, Data: map[string]any{"connected": true}})
+
+		for {
+			var frame openClawWSFrame
+			if err := conn.ReadJSON(&frame); err != nil {
+				return
+			}
+			resp := openClawWSFrame{Type: "res", ID: frame.ID, OK: true, Data: map[string]any{}}
+			switch frame.Method {
+			case "chat.send":
+				resp.Data = map[string]any{"response": "chat-response"}
+			case "status.get":
+				resp.Data = map[string]any{"ok": true, "status": "ok", "version": "1", "provider": "openai", "model": "gpt", "address": "127.0.0.1", "working_dir": ".", "work_dir": "."}
+			case "sessions.list":
+				resp.Data = map[string]any{"sessions": []map[string]any{{"id": "s1", "title": "Session 1"}}}
+			case "events.subscribe":
+				resp.Data = map[string]any{"subscribed": true}
+				_ = conn.WriteJSON(openClawWSFrame{Type: "event", Event: "runtime.updated", Data: map[string]any{"value": "ok"}})
+			case "tools.invoke":
+				resp.Data = map[string]any{"tool": "done"}
+			case "sessions.send":
+				resp.Data = map[string]any{"response": "session-response"}
+			case "config.get":
+				resp.Data = map[string]any{"theme": "light"}
+			case "config.set", "chat.abort", "ping", "device.pairing.unpair":
+				resp.Data = map[string]any{"ok": true}
+			case "agents.list":
+				resp.Data = map[string]any{"agents": []any{"alpha", map[string]any{"name": "beta"}}}
+			case "channels.list":
+				resp.Data = map[string]any{"channels": []any{"general", map[string]any{"name": "random"}}}
+			case "tools.list":
+				resp.Data = map[string]any{"tools": []any{"grep", map[string]any{"name": "read"}}}
+			case "chat.history":
+				resp.Data = map[string]any{"history": []any{map[string]any{"role": "assistant"}}}
+			case "methods.list":
+				resp.Data = map[string]any{"methods": []any{"ping", "status.get"}}
+			case "device.pairing.generate":
+				resp.Data = map[string]any{"code": "abcd1234", "expires": "soon", "device": "cli", "type": "desktop"}
+			case "device.pairing.validate":
+				resp.Data = map[string]any{"valid": true}
+			case "device.pairing.pair", "device.pairing.status", "device.pairing.renew":
+				resp.Data = map[string]any{"device_id": "dev-1", "status": "paired"}
+			case "device.pairing.list":
+				resp.Data = map[string]any{"devices": []any{map[string]any{"device_id": "dev-1"}}}
+			default:
+				resp.OK = false
+				resp.Error = "unknown method"
+			}
+			_ = conn.WriteJSON(resp)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return "ws" + strings.TrimPrefix(server.URL, "http")
+}
+
+func TestWSClientEndToEnd(t *testing.T) {
+	client := NewWSClient(newMockWSGateway(t), "token")
+	client.keepAliveInterval = 0
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer client.Close()
+	if !client.Connected() {
+		t.Fatal("expected client to be connected")
+	}
+
+	var eventMu sync.Mutex
+	var events []string
+	if err := client.SubscribeEvents(ctx, "runtime.updated", func(event *Event) {
+		eventMu.Lock()
+		defer eventMu.Unlock()
+		events = append(events, event.Type)
+	}); err != nil {
+		t.Fatalf("SubscribeEvents: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	if resp, err := client.SendMessage(ctx, "hello"); err != nil || resp != "chat-response" {
+		t.Fatalf("SendMessage = %q, %v", resp, err)
+	}
+	if _, err := client.GetStatus(ctx); err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if sessions, err := client.ListSessions(ctx); err != nil || len(sessions) != 1 {
+		t.Fatalf("ListSessions = %v, %v", sessions, err)
+	}
+	if out, err := client.InvokeTool(ctx, "grep", map[string]any{"q": "x"}); err != nil || out == nil {
+		t.Fatalf("InvokeTool = %v, %v", out, err)
+	}
+	if resp, err := client.SendChatMessage(ctx, "s1", "hi"); err != nil || resp != "session-response" {
+		t.Fatalf("SendChatMessage = %q, %v", resp, err)
+	}
+	if cfg, err := client.GetConfig(ctx); err != nil || cfg["theme"] != "light" {
+		t.Fatalf("GetConfig = %v, %v", cfg, err)
+	}
+	if err := client.SetConfig(ctx, "theme", "dark"); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	if agents, err := client.ListAgents(ctx); err != nil || len(agents) != 2 {
+		t.Fatalf("ListAgents = %v, %v", agents, err)
+	}
+	if channels, err := client.ListChannels(ctx); err != nil || len(channels) != 2 {
+		t.Fatalf("ListChannels = %v, %v", channels, err)
+	}
+	if tools, err := client.ListTools(ctx); err != nil || len(tools) != 2 {
+		t.Fatalf("ListTools = %v, %v", tools, err)
+	}
+	if err := client.AbortChat(ctx); err != nil {
+		t.Fatalf("AbortChat: %v", err)
+	}
+	if history, err := client.GetChatHistory(ctx, "s1"); err != nil || len(history) != 1 {
+		t.Fatalf("GetChatHistory = %v, %v", history, err)
+	}
+	if err := client.Ping(ctx); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if methods, err := client.ListMethods(ctx); err != nil || len(methods) != 2 {
+		t.Fatalf("ListMethods = %v, %v", methods, err)
+	}
+
+	if pairing, err := client.GeneratePairingCode(ctx, "cli", "desktop"); err != nil || pairing.Code == "" {
+		t.Fatalf("GeneratePairingCode = %v, %v", pairing, err)
+	}
+	if valid, err := client.ValidatePairingCode(ctx, "abcd1234"); err != nil || !valid {
+		t.Fatalf("ValidatePairingCode = %v, %v", valid, err)
+	}
+	if result, err := client.CompletePairing(ctx, "abcd1234", "dev-1", "cli"); err != nil || result["status"] != "paired" {
+		t.Fatalf("CompletePairing = %v, %v", result, err)
+	}
+	if devices, err := client.ListPairedDevices(ctx); err != nil || len(devices) != 1 {
+		t.Fatalf("ListPairedDevices = %v, %v", devices, err)
+	}
+	if status, err := client.GetPairingStatus(ctx); err != nil || status["status"] != "paired" {
+		t.Fatalf("GetPairingStatus = %v, %v", status, err)
+	}
+	if renewed, err := client.RenewPairing(ctx, "dev-1"); err != nil || renewed["status"] != "paired" {
+		t.Fatalf("RenewPairing = %v, %v", renewed, err)
+	}
+	if err := client.UnpairDevice(ctx, "dev-1"); err != nil {
+		t.Fatalf("UnpairDevice: %v", err)
+	}
+
+	eventMu.Lock()
+	defer eventMu.Unlock()
+	if len(events) == 0 || events[0] != "runtime.updated" {
+		t.Fatalf("expected subscription event, got %v", events)
+	}
+}
+
+func TestGatewayClientReadLoopCallbacks(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		frames := []map[string]any{
+			{"type": "message", "data": map[string]any{"content": "hello"}},
+			{"type": "tool_call", "data": map[string]any{"name": "grep"}},
+			{"type": "presence", "data": map[string]any{"status": "online"}},
+			{"type": "typing", "data": map[string]any{"typing": true}},
+		}
+		for _, frame := range frames {
+			data, _ := json.Marshal(frame)
+			_ = conn.WriteMessage(websocket.TextMessage, data)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	addr := strings.TrimPrefix(server.URL, "http://")
+	client, err := NewGateway(WithGatewayAddr(addr))
+	if err != nil {
+		t.Fatalf("NewGateway: %v", err)
+	}
+
+	client.OnMessage(func(IncomingMessage) {})
+	client.OnToolCall(func(ToolCall) {})
+	client.OnPresence(func(Presence) {})
+	client.OnTyping(func(TypingIndicator) {})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer client.Disconnect()
+	time.Sleep(100 * time.Millisecond)
+}

--- a/pkg/gateway/transport/client/types.go
+++ b/pkg/gateway/transport/client/types.go
@@ -1,0 +1,173 @@
+package sdk
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type (
+	MessageID  string
+	ChannelID  string
+	SessionID  string
+	AgentID    string
+	ToolCallID string
+	NodeID     string
+	UserID     string
+)
+
+type MessageType string
+
+const (
+	MessageTypeText    MessageType = "text"
+	MessageTypeImage   MessageType = "image"
+	MessageTypeAudio   MessageType = "audio"
+	MessageTypeVideo   MessageType = "video"
+	MessageTypeFile    MessageType = "file"
+	MessageTypeCommand MessageType = "command"
+)
+
+type SenderType string
+
+const (
+	SenderTypeUser    SenderType = "user"
+	SenderTypeAgent   SenderType = "agent"
+	SenderTypeChannel SenderType = "channel"
+	SenderTypeSystem  SenderType = "system"
+)
+
+type OutgoingMessage struct {
+	To          string          `json:"to"`
+	Content     string          `json:"content"`
+	ContentType MessageType     `json:"content_type,omitempty"`
+	Metadata    json.RawMessage `json:"metadata,omitempty"`
+	ReplyTo     MessageID       `json:"reply_to,omitempty"`
+}
+
+type IncomingMessage struct {
+	ID          MessageID       `json:"id"`
+	ChannelID   ChannelID       `json:"channel_id"`
+	SessionID   SessionID       `json:"session_id"`
+	Sender      Sender          `json:"sender"`
+	Content     string          `json:"content"`
+	ContentType MessageType     `json:"content_type"`
+	Timestamp   time.Time       `json:"timestamp"`
+	Metadata    json.RawMessage `json:"metadata,omitempty"`
+}
+
+type Sender struct {
+	ID       UserID          `json:"id"`
+	Name     string          `json:"name"`
+	Type     SenderType      `json:"type"`
+	Metadata json.RawMessage `json:"metadata,omitempty"`
+}
+
+type ToolCall struct {
+	ID       ToolCallID      `json:"id"`
+	Name     string          `json:"name"`
+	Input    json.RawMessage `json:"input"`
+	Progress float64         `json:"progress,omitempty"`
+	Output   json.RawMessage `json:"output,omitempty"`
+	Error    string          `json:"error,omitempty"`
+}
+
+type ToolDefinition struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+type ToolResult struct {
+	ToolCallID ToolCallID      `json:"tool_call_id"`
+	Output     json.RawMessage `json:"output,omitempty"`
+	Error      string          `json:"error,omitempty"`
+	IsError    bool            `json:"is_error"`
+}
+
+type Session struct {
+	ID        SessionID    `json:"id"`
+	Title     string       `json:"title,omitempty"`
+	AgentID   AgentID      `json:"agent_id"`
+	ChannelID ChannelID    `json:"channel_id"`
+	State     SessionState `json:"state"`
+	CreatedAt time.Time    `json:"created_at"`
+	UpdatedAt time.Time    `json:"updated_at"`
+}
+
+type SessionState string
+
+const (
+	SessionStateActive  SessionState = "active"
+	SessionStateIdle    SessionState = "idle"
+	SessionStateWaiting SessionState = "waiting"
+	SessionStateError   SessionState = "error"
+)
+
+type Agent struct {
+	ID           AgentID  `json:"id"`
+	Name         string   `json:"name"`
+	Description  string   `json:"description"`
+	Model        string   `json:"model"`
+	Provider     string   `json:"provider"`
+	Tools        []string `json:"tools,omitempty"`
+	Skills       []string `json:"skills,omitempty"`
+	SystemPrompt string   `json:"system_prompt,omitempty"`
+}
+
+type NodeInfo struct {
+	ID           NodeID     `json:"id"`
+	Name         string     `json:"name"`
+	Platform     string     `json:"platform"`
+	Status       NodeStatus `json:"status"`
+	Capabilities []string   `json:"capabilities"`
+	LastSeen     time.Time  `json:"last_seen"`
+}
+
+type NodeStatus string
+
+const (
+	NodeStatusOnline  NodeStatus = "online"
+	NodeStatusOffline NodeStatus = "offline"
+	NodeStatusBusy    NodeStatus = "busy"
+)
+
+type NodeAction struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema,omitempty"`
+}
+
+type NodeActionResult struct {
+	Action  string          `json:"action"`
+	Output  json.RawMessage `json:"output,omitempty"`
+	Error   string          `json:"error,omitempty"`
+	IsError bool            `json:"is_error"`
+}
+
+type ChannelInfo struct {
+	ID           ChannelID `json:"id"`
+	Name         string    `json:"name"`
+	Type         string    `json:"type"`
+	Status       string    `json:"status"`
+	Connected    bool      `json:"connected"`
+	MessageCount int64     `json:"message_count"`
+}
+
+type Presence struct {
+	UserID    UserID    `json:"user_id"`
+	Status    string    `json:"status"`
+	ChannelID ChannelID `json:"channel_id"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type TypingIndicator struct {
+	UserID    UserID    `json:"user_id"`
+	ChannelID ChannelID `json:"channel_id"`
+	Typing    bool      `json:"typing"`
+}
+
+type Event struct {
+	Type      string         `json:"type"`
+	SessionID string         `json:"session_id,omitempty"`
+	Payload   map[string]any `json:"payload,omitempty"`
+	Source    string         `json:"source,omitempty"`
+}

--- a/pkg/gateway/transport/controlui/routes.go
+++ b/pkg/gateway/transport/controlui/routes.go
@@ -1,0 +1,148 @@
+package controlui
+
+import (
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+type Options struct {
+	BasePath string
+	Root     string
+}
+
+func normalizeBasePath(basePath string) string {
+	basePath = strings.TrimSpace(basePath)
+	if basePath == "" {
+		return "/dashboard"
+	}
+	return basePath
+}
+
+func RegisterRoutes(mux *http.ServeMux, opts Options) {
+	if mux == nil {
+		return
+	}
+
+	handler := routeHandler{opts: opts}
+
+	basePath := normalizeBasePath(opts.BasePath)
+
+	controlPaths := []string{basePath, "/dashboard", "/control"}
+	seen := map[string]bool{}
+	for _, route := range controlPaths {
+		route = strings.TrimSpace(route)
+		if route == "" || seen[route] {
+			continue
+		}
+		seen[route] = true
+		mux.HandleFunc(route, handler.handleControlUI)
+		mux.HandleFunc(route+"/", handler.handleControlUI)
+	}
+
+	mux.HandleFunc("/market", handler.handleMarketUI)
+	mux.HandleFunc("/market/", handler.handleMarketUI)
+	mux.HandleFunc("/discovery", handler.handleDiscoveryUI)
+	mux.HandleFunc("/discovery/", handler.handleDiscoveryUI)
+}
+
+type routeHandler struct {
+	opts Options
+}
+
+func (h routeHandler) controlUIBasePath() string {
+	return normalizeBasePath(h.opts.BasePath)
+}
+
+func (h routeHandler) controlUIRoot() string {
+	candidates := []string{
+		strings.TrimSpace(os.Getenv("ANYCLAW_CONTROL_UI_ROOT")),
+		strings.TrimSpace(h.opts.Root),
+		"dist/control-ui",
+	}
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		info, err := os.Stat(candidate)
+		if err == nil && info.IsDir() {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func (h routeHandler) handleControlUI(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if root := h.controlUIRoot(); root != "" {
+		if h.tryServeControlUIAsset(w, r, root) {
+			return
+		}
+		indexPath := filepath.Join(root, "index.html")
+		if _, err := os.Stat(indexPath); err == nil {
+			http.ServeFile(w, r, indexPath)
+			return
+		}
+	}
+	http.Error(w, "control UI not found", http.StatusNotFound)
+}
+
+func (h routeHandler) tryServeControlUIAsset(w http.ResponseWriter, r *http.Request, root string) bool {
+	controlPaths := []string{
+		strings.TrimSpace(h.opts.BasePath),
+		"/dashboard",
+		"/control",
+	}
+
+	requestPath := path.Clean(r.URL.Path)
+	for _, base := range controlPaths {
+		base = strings.TrimSpace(base)
+		if base == "" {
+			continue
+		}
+		base = path.Clean(base)
+		if requestPath == base || requestPath == base+"/" {
+			return false
+		}
+		prefix := base + "/"
+		if !strings.HasPrefix(requestPath, prefix) {
+			continue
+		}
+		rel := strings.TrimPrefix(requestPath, prefix)
+		if rel == "" || rel == "." {
+			return false
+		}
+		target := filepath.Join(root, filepath.FromSlash(rel))
+		info, err := os.Stat(target)
+		if err != nil || info.IsDir() {
+			return false
+		}
+		http.ServeFile(w, r, target)
+		return true
+	}
+	return false
+}
+
+func (h routeHandler) handleMarketUI(w http.ResponseWriter, r *http.Request) {
+	h.redirectLegacyUI(w, r, "market")
+}
+
+func (h routeHandler) handleDiscoveryUI(w http.ResponseWriter, r *http.Request) {
+	h.redirectLegacyUI(w, r, "discovery")
+}
+
+func (h routeHandler) redirectLegacyUI(w http.ResponseWriter, r *http.Request, section string) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	target := h.controlUIBasePath() + "#/" + strings.TrimPrefix(section, "/")
+	http.Redirect(w, r, target, http.StatusTemporaryRedirect)
+}

--- a/pkg/gateway/transport/controlui/routes_test.go
+++ b/pkg/gateway/transport/controlui/routes_test.go
@@ -1,0 +1,60 @@
+package controlui
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRegisterRoutesServesAssetsAndRedirects(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "index.html"), []byte("index"), 0o644); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "app.js"), []byte("console.log('ok')"), 0o644); err != nil {
+		t.Fatalf("write asset: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, Options{BasePath: "/console", Root: root})
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/console", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /console = %d", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/console/app.js", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /console/app.js = %d", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/market", nil))
+	if rec.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("GET /market = %d", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodHead, "/discovery", nil))
+	if rec.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("HEAD /discovery = %d", rec.Code)
+	}
+	if got := rec.Header().Get("Location"); got == "" {
+		t.Fatal("expected redirect location")
+	}
+
+	h := routeHandler{opts: Options{BasePath: " ", Root: root}}
+	if got := h.controlUIBasePath(); got != "/dashboard" {
+		t.Fatalf("controlUIBasePath = %q", got)
+	}
+	if got := normalizeBasePath(" "); got != "/dashboard" {
+		t.Fatalf("normalizeBasePath = %q", got)
+	}
+	if got := h.controlUIRoot(); got != root {
+		t.Fatalf("controlUIRoot = %q", got)
+	}
+}

--- a/pkg/gateway/transport/scheduleui/ui.go
+++ b/pkg/gateway/transport/scheduleui/ui.go
@@ -1,0 +1,204 @@
+package scheduleui
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	runtimeschedule "github.com/1024XEngineer/anyclaw/pkg/runtime/execution/schedule"
+)
+
+// RegisterUIHandler registers the cron web UI and API handlers on the given mux.
+func RegisterUIHandler(mux *http.ServeMux, scheduler *runtimeschedule.Scheduler, prefix string) {
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+
+	mux.HandleFunc(prefix, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if r.URL.Query().Get("json") == "1" {
+				serveCronJSON(w, scheduler)
+			} else {
+				serveCronUI(w, scheduler)
+			}
+		case http.MethodPost:
+			handleCreateTask(w, r, scheduler)
+		default:
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	mux.HandleFunc(prefix+"stats", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(scheduler.Stats())
+	})
+
+	mux.HandleFunc(prefix+"validate", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		expr := r.URL.Query().Get("expr")
+		desc, err := runtimeschedule.ValidateCronExpression(expr)
+		resp := map[string]any{"valid": err == nil}
+		if err != nil {
+			resp["error"] = err.Error()
+		} else {
+			resp["description"] = desc
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	mux.HandleFunc(prefix+"next", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		expr := r.URL.Query().Get("expr")
+		count := 5
+		times, err := runtimeschedule.NextRunTimes(expr, time.Now(), count)
+		resp := map[string]any{}
+		if err != nil {
+			resp["error"] = err.Error()
+		} else {
+			resp["next_runs"] = times
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+}
+
+func serveCronUI(w http.ResponseWriter, s *runtimeschedule.Scheduler) {
+	tasks := s.ListTasks()
+	stats := s.Stats()
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+
+	fmt.Fprintf(w, `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Cron Task Manager</title>
+<style>
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f5f5f5; color: #333; }
+.container { max-width: 1200px; margin: 0 auto; padding: 20px; }
+h1 { margin-bottom: 20px; color: #1a1a2e; }
+.stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 15px; margin-bottom: 30px; }
+.stat-card { background: white; border-radius: 8px; padding: 20px; text-align: center; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+.stat-card .value { font-size: 2em; font-weight: bold; color: #4A90D9; }
+.stat-card .label { color: #666; margin-top: 5px; }
+.task-list { background: white; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); overflow: hidden; }
+.task-header { display: grid; grid-template-columns: 2fr 1.5fr 1fr 1fr 1fr 1fr 120px; padding: 12px 20px; background: #f8f9fa; font-weight: bold; border-bottom: 1px solid #eee; }
+.task-row { display: grid; grid-template-columns: 2fr 1.5fr 1fr 1fr 1fr 1fr 120px; padding: 12px 20px; border-bottom: 1px solid #f0f0f0; align-items: center; }
+.task-row:hover { background: #f8f9fa; }
+.task-row:last-child { border-bottom: none; }
+.badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.85em; }
+.badge-enabled { background: #d4edda; color: #155724; }
+.badge-disabled { background: #f8d7da; color: #721c24; }
+.badge-success { background: #d4edda; color: #155724; }
+.badge-failed { background: #f8d7da; color: #721c24; }
+.btn { padding: 4px 12px; border: none; border-radius: 4px; cursor: pointer; font-size: 0.85em; margin-right: 4px; }
+.btn-primary { background: #4A90D9; color: white; }
+.btn-danger { background: #dc3545; color: white; }
+.btn-success { background: #28a745; color: white; }
+.btn-sm { padding: 2px 8px; font-size: 0.8em; }
+.empty { padding: 40px; text-align: center; color: #999; }
+</style>
+</head>
+<body>
+<div class="container">
+<h1>⏰ Cron Task Manager</h1>
+
+<div class="stats">
+<div class="stat-card"><div class="value">%d</div><div class="label">Total Tasks</div></div>
+<div class="stat-card"><div class="value">%d</div><div class="label">Enabled</div></div>
+<div class="stat-card"><div class="value">%d</div><div class="label">Total Runs</div></div>
+<div class="stat-card"><div class="value">%d</div><div class="label">Success</div></div>
+<div class="stat-card"><div class="value">%d</div><div class="label">Failed</div></div>
+</div>
+
+<div class="task-list">
+<div class="task-header">
+<span>Name</span><span>Schedule</span><span>Agent</span><span>Status</span><span>Last Run</span><span>Next Run</span><span>Actions</span>
+</div>
+`, stats["total_tasks"], stats["enabled_tasks"], stats["total_runs"], stats["success_runs"], stats["failed_runs"])
+
+	if len(tasks) == 0 {
+		fmt.Fprintf(w, `<div class="empty">No cron tasks configured. Use the API to add tasks.</div>`)
+	} else {
+		for _, t := range tasks {
+			statusClass := "badge-enabled"
+			statusText := "Enabled"
+			if !t.Enabled {
+				statusClass = "badge-disabled"
+				statusText = "Disabled"
+			}
+			lastRun := "-"
+			if t.LastRun != nil {
+				lastRun = t.LastRun.Format("2006-01-02 15:04")
+			}
+			nextRun := "-"
+			if t.NextRun != nil {
+				nextRun = t.NextRun.Format("2006-01-02 15:04")
+			}
+			agent := t.Agent
+			if agent == "" {
+				agent = "-"
+			}
+			fmt.Fprintf(w, `<div class="task-row">
+<span><strong>%s</strong><br><small style="color:#999">%s</small></span>
+<span><code>%s</code></span>
+<span>%s</span>
+<span><span class="badge %s">%s</span></span>
+<span>%s</span>
+<span>%s</span>
+<span>
+<button class="btn btn-primary btn-sm" onclick="runTask('%s')">Run</button>
+<button class="btn btn-sm" style="background:#6c757d;color:white" onclick="toggleTask('%s', %t)">Toggle</button>
+</span>
+</div>`, t.Name, t.Command, t.Schedule, agent, statusClass, statusText, lastRun, nextRun, t.ID, t.ID, t.Enabled)
+		}
+	}
+
+	fmt.Fprintf(w, `</div>
+</div>
+<script>
+function runTask(id) { fetch('/cron/'+id+'/run', {method:'POST'}).then(r=>r.json()).then(d=>alert(d.message||JSON.stringify(d))); }
+function toggleTask(id, enabled) { fetch('/cron/'+id+(enabled?'/disable':'/enable'), {method:'POST'}).then(r=>r.json()).then(d=>location.reload()); }
+</script>
+</body>
+</html>`)
+}
+
+func serveCronJSON(w http.ResponseWriter, s *runtimeschedule.Scheduler) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"tasks": s.ListTasks(),
+		"stats": s.Stats(),
+	})
+}
+
+func handleCreateTask(w http.ResponseWriter, r *http.Request, s *runtimeschedule.Scheduler) {
+	var task runtimeschedule.Task
+	if err := json.NewDecoder(r.Body).Decode(&task); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	id, err := s.AddTask(&task)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(map[string]any{"id": id, "message": "Task created"})
+}

--- a/pkg/gateway/transport/scheduleui/ui_test.go
+++ b/pkg/gateway/transport/scheduleui/ui_test.go
@@ -1,0 +1,53 @@
+package scheduleui
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	runtimeschedule "github.com/1024XEngineer/anyclaw/pkg/runtime/execution/schedule"
+)
+
+func TestRegisterUIHandlerServesCronViews(t *testing.T) {
+	scheduler := runtimeschedule.New()
+	mux := http.NewServeMux()
+	RegisterUIHandler(mux, scheduler, "/cron")
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/cron/?json=1", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /cron/?json=1 = %d", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/cron/stats", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /cron/stats = %d", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/cron/validate?expr=*+*+*+*+*", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /cron/validate = %d", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/cron/next?expr=*+*+*+*+*", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /cron/next = %d", rec.Code)
+	}
+
+	body := bytes.NewBufferString(`{"name":"sample","schedule":"invalid","command":"echo hi","enabled":true}`)
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/cron/", body))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("POST /cron/ = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/cron/", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /cron/ = %d", rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- add channel bootstrap/runtime activation
- add speech, MCP, market, discovery, daemon, and worker runtime startup wiring
- switch the gateway run path back to the full activated flow after the earlier stack pieces land

## Testing
- go test ./pkg/gateway/... ./pkg/speech/...

## Stack
- base branch: `gateway-wiring-gateway-speech5`